### PR TITLE
feat: add basic i18n support

### DIFF
--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -1,8 +1,11 @@
 import { Footer } from "@/components/footer/footer";
 import { Navigation } from "@/components/navbar/navigation";
+import { LanguageSwitcherModal } from "@/components/language-switcher";
 import { env } from "@/lib/env";
 import { GeistMono } from "geist/font/mono";
 import { GeistSans } from "geist/font/sans";
+import { NextIntlClientProvider } from "next-intl";
+import { getMessages, getLocale } from "next-intl/server";
 import type { Metadata } from "next";
 import "./globals.css";
 
@@ -37,14 +40,16 @@ export const metadata: Metadata = {
     shortcut: "/unkey.png",
   },
 };
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const locale = await getLocale();
+  const messages = await getMessages();
   return (
     <html
-      lang="en"
+      lang={locale}
       className={`[color-scheme:dark] scroll-smooth ${GeistSans.variable} ${GeistMono.variable}`}
     >
       <body className="min-h-screen overflow-x-hidden antialiased bg-black text-pretty">
@@ -59,23 +64,25 @@ export default function RootLayout({
           }}
         >
           <ConsentBanner />
-
-          <div className="relative overflow-x-clip">
-            <Navigation />
-            {children}
-            <Tracking />
-            {process.env.NODE_ENV !== "production" ? (
-              <div className="fixed bottom-0 right-0 flex items-center justify-center w-6 h-6 p-3 m-8 font-mono text-xs text-black bg-white rounded-lg pointer-events-none ">
-                <div className="block sm:hidden md:hidden lg:hidden xl:hidden 2xl:hidden">al</div>
-                <div className="hidden sm:block md:hidden lg:hidden xl:hidden 2xl:hidden">sm</div>
-                <div className="hidden sm:hidden md:block lg:hidden xl:hidden 2xl:hidden">md</div>
-                <div className="hidden sm:hidden md:hidden lg:block xl:hidden 2xl:hidden">lg</div>
-                <div className="hidden sm:hidden md:hidden lg:hidden xl:block 2xl:hidden">xl</div>
-                <div className="hidden sm:hidden md:hidden lg:hidden xl:hidden 2xl:block">2xl</div>
-              </div>
-            ) : null}
-          </div>
-          <Footer />
+          <NextIntlClientProvider locale={locale} messages={messages}>
+            <LanguageSwitcherModal />
+            <div className="relative overflow-x-clip">
+              <Navigation />
+              {children}
+              <Tracking />
+              {process.env.NODE_ENV !== "production" ? (
+                <div className="fixed bottom-0 right-0 flex items-center justify-center w-6 h-6 p-3 m-8 font-mono text-xs text-black bg-white rounded-lg pointer-events-none ">
+                  <div className="block sm:hidden md:hidden lg:hidden xl:hidden 2xl:hidden">al</div>
+                  <div className="hidden sm:block md:hidden lg:hidden xl:hidden 2xl:hidden">sm</div>
+                  <div className="hidden sm:hidden md:block lg:hidden xl:hidden 2xl:hidden">md</div>
+                  <div className="hidden sm:hidden md:hidden lg:block xl:hidden 2xl:hidden">lg</div>
+                  <div className="hidden sm:hidden md:hidden lg:hidden xl:block 2xl:hidden">xl</div>
+                  <div className="hidden sm:hidden md:hidden lg:hidden xl:hidden 2xl:block">2xl</div>
+                </div>
+              ) : null}
+            </div>
+            <Footer />
+          </NextIntlClientProvider>
         </ConsentManagerProvider>
       </body>
     </html>

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -21,6 +21,7 @@ import Link from "next/link";
 import mainboard from "../images/mainboard.svg";
 import { DesktopLogoCloud, MobileLogoCloud } from "./(components)/logo-cloud-content";
 import { CodeExamples } from "./code-examples";
+import { useTranslations } from "next-intl";
 
 export const metadata = {
   title: "Unkey",
@@ -49,6 +50,7 @@ export const metadata = {
 };
 
 export default async function Landing() {
+  const t = useTranslations("Index");
   return (
     <>
       <TopRightShiningLight />
@@ -80,8 +82,8 @@ export default async function Landing() {
           <Section className="mt-16 md:mt-20">
             <SectionTitle
               className="mt-8 md:mt-16 lg:mt-32"
-              title="Everything you need for your API"
-              text="Build, monetize, analyze, and protect your APIs; our platform makes it easy, providing everything you need."
+              title={t("heroTitle")}
+              text={t("heroText")}
               align="center"
             />
             <AnalyticsBento />

--- a/apps/www/components/language-switcher.tsx
+++ b/apps/www/components/language-switcher.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {useEffect, useState} from 'react';
+import {usePathname, useRouter} from 'next/navigation';
+import {useTranslations} from 'next-intl';
+
+export function LanguageSwitcherModal() {
+  const t = useTranslations('LanguageModal');
+  const router = useRouter();
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('locale');
+      if (!stored) {
+        setOpen(true);
+      }
+    }
+  }, []);
+
+  function selectLocale(locale: string) {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('locale', locale);
+      document.cookie = `NEXT_LOCALE=${locale};path=/;max-age=31536000`;
+    }
+    setOpen(false);
+    const newPath =
+      locale === 'en'
+        ? pathname.replace(/^\/nl/, '')
+        : pathname.startsWith('/nl')
+        ? pathname
+        : `/nl${pathname}`;
+    router.replace(newPath);
+  }
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="rounded bg-white p-4 text-black">
+        <p className="mb-2">{t('title')}</p>
+        <div className="flex space-x-2">
+          <button onClick={() => selectLocale('en')} className="border px-2 py-1">
+            {t('english')}
+          </button>
+          <button onClick={() => selectLocale('nl')} className="border px-2 py-1">
+            {t('dutch')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/www/content/en/README.md
+++ b/apps/www/content/en/README.md
@@ -1,0 +1,1 @@
+Localized English content

--- a/apps/www/content/nl/README.md
+++ b/apps/www/content/nl/README.md
@@ -1,0 +1,1 @@
+Gelokaliseerde Nederlandse inhoud

--- a/apps/www/i18n.ts
+++ b/apps/www/i18n.ts
@@ -1,0 +1,8 @@
+import {getRequestConfig} from 'next-intl/server';
+
+export const locales = ['en', 'nl'] as const;
+export const defaultLocale = 'en';
+
+export default getRequestConfig(async ({locale}) => ({
+  messages: (await import(`./messages/${locale}.json`)).default
+}));

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -1,0 +1,11 @@
+{
+  "Index": {
+    "heroTitle": "Everything you need for your API",
+    "heroText": "Build, monetize, analyze, and protect your APIs; our platform makes it easy, providing everything you need."
+  },
+  "LanguageModal": {
+    "title": "Select your language",
+    "english": "English",
+    "dutch": "Dutch"
+  }
+}

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -1,0 +1,11 @@
+{
+  "Index": {
+    "heroTitle": "Alles wat je nodig hebt voor je API",
+    "heroText": "Bouw, monetiseer, analyseer en bescherm je API's; ons platform maakt het eenvoudig en biedt alles wat je nodig hebt."
+  },
+  "LanguageModal": {
+    "title": "Selecteer uw taal",
+    "english": "Engels",
+    "dutch": "Nederlands"
+  }
+}

--- a/apps/www/middleware.ts
+++ b/apps/www/middleware.ts
@@ -1,0 +1,12 @@
+import createMiddleware from 'next-intl/middleware';
+import {locales, defaultLocale} from './i18n';
+
+export default createMiddleware({
+  locales,
+  defaultLocale,
+  localePrefix: 'as-needed'
+});
+
+export const config = {
+  matcher: ['/((?!api|_next|.*\\..*).*)']
+};

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -15,6 +15,10 @@ const nextConfig = {
   pageExtensions: ["tsx", "mdx", "ts", "js"],
   reactStrictMode: true,
   swcMinify: true,
+  i18n: {
+    locales: ["en", "nl"],
+    defaultLocale: "en",
+  },
   async headers() {
     return [
       {

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -47,6 +47,7 @@
     "mermaid": "^11.6.0",
     "nanoid": "^5.0.9",
     "next": "14.2.26",
+    "next-intl": "^3.17.0",
     "next-mdx-remote": "^4.4.1",
     "prism-react-renderer": "^2.3.1",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,9 @@ importers:
       next:
         specifier: 14.2.26
         version: 14.2.26(@opentelemetry/api@1.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-intl:
+        specifier: ^3.17.0
+        version: 3.26.5(next@14.2.26(@opentelemetry/api@1.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       next-mdx-remote:
         specifier: ^4.4.1
         version: 4.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1271,8 +1274,23 @@ packages:
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
+  '@formatjs/ecma402-abstract@2.3.4':
+    resolution: {integrity: sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==}
+
+  '@formatjs/fast-memoize@2.2.7':
+    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
+
+  '@formatjs/icu-messageformat-parser@2.11.2':
+    resolution: {integrity: sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==}
+
+  '@formatjs/icu-skeleton-parser@1.8.14':
+    resolution: {integrity: sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==}
+
   '@formatjs/intl-localematcher@0.5.10':
     resolution: {integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==}
+
+  '@formatjs/intl-localematcher@0.6.1':
+    resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
 
   '@google-cloud/precise-date@4.0.0':
     resolution: {integrity: sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA==}
@@ -3922,6 +3940,9 @@ packages:
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decode-formdata@0.9.0:
     resolution: {integrity: sha512-q5uwOjR3Um5YD+ZWPOF/1sGHVW9A5rCrRwITQChRXlmPkxDFBqCm4jNTIVdGHNH9OnR+V9MoZVgRhsFb+ARbUw==}
 
@@ -4726,6 +4747,9 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  intl-messageformat@10.7.16:
+    resolution: {integrity: sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==}
+
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
 
@@ -5494,6 +5518,12 @@ packages:
   neverthrow@8.2.0:
     resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
     engines: {node: '>=18'}
+
+  next-intl@3.26.5:
+    resolution: {integrity: sha512-EQlCIfY0jOhRldiFxwSXG+ImwkQtDEfQeSOEQp6ieAGSLWGlgjdb/Ck/O7wMfC430ZHGeUKVKax8KGusTPKCgg==}
+    peerDependencies:
+      next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
   next-mdx-remote@4.4.1:
     resolution: {integrity: sha512-1BvyXaIou6xy3XoNF4yaMZUCb6vD2GTAa5ciOa6WoO+gAUTYsb1K4rI/HSC2ogAWLrb/7VSV52skz07vOzmqIQ==}
@@ -6630,6 +6660,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-intl@3.26.5:
+    resolution: {integrity: sha512-OdsJnC/znPvHCHLQH/duvQNXnP1w0hPfS+tkSi3mAbfjYBGh4JnyfdwkQBfIVf7t8gs9eSX/CntxUMvtKdG2MQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
   use-sidecar@1.1.3:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
@@ -7881,7 +7916,33 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
+  '@formatjs/ecma402-abstract@2.3.4':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/intl-localematcher': 0.6.1
+      decimal.js: 10.6.0
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@2.2.7':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/icu-messageformat-parser@2.11.2':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/icu-skeleton-parser': 1.8.14
+      tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@1.8.14':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      tslib: 2.8.1
+
   '@formatjs/intl-localematcher@0.5.10':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.6.1':
     dependencies:
       tslib: 2.8.1
 
@@ -10926,6 +10987,8 @@ snapshots:
 
   decimal.js-light@2.5.1: {}
 
+  decimal.js@10.6.0: {}
+
   decode-formdata@0.9.0: {}
 
   decode-named-character-reference@1.1.0:
@@ -11758,6 +11821,13 @@ snapshots:
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
+
+  intl-messageformat@10.7.16:
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/icu-messageformat-parser': 2.11.2
+      tslib: 2.8.1
 
   is-alphabetical@1.0.4: {}
 
@@ -13007,6 +13077,14 @@ snapshots:
   neverthrow@8.2.0:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.44.2
+
+  next-intl@3.26.5(next@14.2.26(@opentelemetry/api@1.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@formatjs/intl-localematcher': 0.5.10
+      negotiator: 1.0.0
+      next: 14.2.26(@opentelemetry/api@1.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      use-intl: 3.26.5(react@18.3.1)
 
   next-mdx-remote@4.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -14426,6 +14504,12 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.8
+
+  use-intl@3.26.5(react@18.3.1):
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      intl-messageformat: 10.7.16
+      react: 18.3.1
 
   use-sidecar@1.1.3(@types/react@18.3.20)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary
- configure Next.js i18n with English and Dutch locales
- add translation infrastructure and language selection modal
- translate hero section using `next-intl`
- use server helpers for locale and messages to avoid runtime crash

## Testing
- `pnpm --filter landing lint` *(fails: next lint requires configuration)*
- `pnpm --filter landing build` *(fails: Failed to collect page data for /oss-friends; ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68c403625d34832aa09470316c1597fe