### PR TITLE
feat: scaffold blog admin gate

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -1,12 +1,24 @@
 # FIX.md — Requests & Resolutions Log
 
-> Track **what the user wanted** and **how you fixed it** (technical detail).  
+> Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-10-31 — "Need in-browser blog editor"
+
+- **User ask / Bug:** Wanted ability to create and edit blog posts via browser instead of manual files.
+- **Fix:**
+  - Added `/admin/blog` routes with session-gated access and a placeholder editor page.
+  - Implemented `middleware.ts` to protect admin paths and API.
+  - Created `/api/admin/blog/login` to validate access code `cake2025` and set session cookie.
+  - Added "+ New post" button linking to admin editor.
+- **Files:** `apps/www/middleware.ts`, `apps/www/app/api/admin/blog/login/route.ts`, `apps/www/app/admin/blog/**`, `apps/www/app/blog/page.tsx`.
+- **Follow-ups:** Flesh out full editor with saving, publishing, and file operations.
+
 ## 2025-10-30 — “Reset emails not sending”
+
 - **User ask / Bug:** Password reset emails never arrive.
 - **Root cause:** `SMTP_*` env vars not mapped in `next.config.js`; missing `await` in `sendPasswordResetEmail()`.
-- **Fix:** 
+- **Fix:**
   - Mapped env vars in `next.config.js` and `.env.example`.
   - Added `await transporter.sendMail(...)` and error handling + retry with exponential backoff.
   - Logged `messageId` for observability.
@@ -14,6 +26,7 @@
 - **Follow-ups:** Add integration test using local SMTP stub.
 
 ## 2025-10-26 — “Gradient heading inconsistent in Safari”
+
 - **User ask / Bug:** Gradient text renders dull in Safari.
 - **Fix:** Switched to `background-clip:text` + `text-fill-color:transparent` fallback and ensured tokens use `--feature-9` / `--feature-11`.
 - **Files:** `apps/www/components/SectionTitle.tsx`, `apps/www/styles/globals.css`

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,12 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-10-31
+
+- Added initial in-browser blog admin skeleton with code gate and placeholder editor.
+- Introduced middleware and API login route for simple session handling.
+- Surfaced "+ New post" button on blog index.
+
 ## 2025-10-30
 
 - Added password reset flow with email tokens.

--- a/apps/www/app/admin/blog/new/login-gate.tsx
+++ b/apps/www/app/admin/blog/new/login-gate.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function LoginGate() {
+  const [code, setCode] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const res = await fetch("/api/admin/blog/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+    if (res.ok) {
+      window.location.reload();
+    } else {
+      setError("Incorrect code");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-sm mx-auto mt-24 space-y-4">
+      <label htmlFor="code" className="text-sm font-medium">
+        Enter editor code
+      </label>
+      <Input
+        id="code"
+        type="password"
+        required
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+      />
+      {error ? <p className="text-sm text-red-500">{error}</p> : null}
+      <Button type="submit" className="w-full">
+        Enter
+      </Button>
+    </form>
+  );
+}

--- a/apps/www/app/admin/blog/new/page.tsx
+++ b/apps/www/app/admin/blog/new/page.tsx
@@ -1,0 +1,15 @@
+import { cookies } from "next/headers";
+import { LoginGate } from "./login-gate";
+
+export default function NewPostPage() {
+  const session = cookies().get("editor_token");
+  if (session?.value === "granted") {
+    return (
+      <div className="container mx-auto mt-24 space-y-2">
+        <h1 className="text-2xl font-bold">Blog editor</h1>
+        <p className="text-muted-foreground">Editor interface coming soon.</p>
+      </div>
+    );
+  }
+  return <LoginGate />;
+}

--- a/apps/www/app/admin/blog/page.tsx
+++ b/apps/www/app/admin/blog/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { allPosts } from "content-collections";
+import { Button } from "@/components/ui/button";
+
+export default function AdminBlog() {
+  const session = cookies().get("editor_token");
+  if (session?.value !== "granted") {
+    redirect("/admin/blog/new");
+  }
+  return (
+    <div className="container mx-auto mt-24">
+      <div className="flex items-center justify-between mb-8">
+        <h1 className="text-2xl font-bold">Blog Admin</h1>
+        <Link href="/admin/blog/new">
+          <Button variant="outline" size="sm">
+            + New post
+          </Button>
+        </Link>
+      </div>
+      <ul className="space-y-2">
+        {allPosts.map((post) => (
+          <li key={post.slug}>
+            <Link href={`/admin/blog/${post.slug}`} className="underline">
+              {post.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/www/app/api/admin/blog/login/route.ts
+++ b/apps/www/app/api/admin/blog/login/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const { code } = await req.json().catch(() => ({ code: "" }));
+  if (code === "cake2025") {
+    const res = NextResponse.json({ ok: true });
+    res.cookies.set("editor_token", "granted", {
+      httpOnly: true,
+      sameSite: "lax",
+      maxAge: 60 * 60,
+      path: "/",
+    });
+    return res;
+  }
+  return NextResponse.json({ ok: false }, { status: 401 });
+}

--- a/apps/www/app/blog/page.tsx
+++ b/apps/www/app/blog/page.tsx
@@ -1,8 +1,12 @@
 import { BlogHero } from "@/components/blog/blog-hero";
 import { ClientBlogGrid } from "@/components/blog/client-blog-grid";
 import { CTA } from "@/components/cta";
-import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/background-shiny";
+import {
+  TopLeftShiningLight,
+  TopRightShiningLight,
+} from "@/components/svg/background-shiny";
 import { MeteorLinesAngular } from "@/components/ui/meteorLines";
+import { Button } from "@/components/ui/button";
 import { authors } from "@/content/blog/authors";
 import { type Post, allPosts } from "content-collections";
 import Link from "next/link";
@@ -109,12 +113,22 @@ export default async function Blog() {
           <TopRightShiningLight />
         </div>
 
+        <div className="flex justify-end mb-6">
+          <Link href="/admin/blog/new">
+            <Button variant="outline" size="sm">
+              + New post
+            </Button>
+          </Link>
+        </div>
+
         {featuredPost ? (
           <div className="w-full px-0 mx-0 rounded-3xl">
             <Link href={`${featuredPost.url}`} key={featuredPost.url}>
               <BlogHero
                 tags={featuredPost.tags}
-                imageUrl={featuredPost.image ?? "/images/blog-images/defaultBlog.png"}
+                imageUrl={
+                  featuredPost.image ?? "/images/blog-images/defaultBlog.png"
+                }
                 title={featuredPost.title}
                 subTitle={featuredPost.description}
                 author={authors[featuredPost.author]}

--- a/apps/www/middleware.ts
+++ b/apps/www/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const ADMIN_PREFIX = "/admin/blog";
+
+export function middleware(req: NextRequest) {
+  const isAdminRoute = req.nextUrl.pathname.startsWith(ADMIN_PREFIX);
+  const isApiRoute = req.nextUrl.pathname.startsWith("/api/admin/blog");
+  if (isAdminRoute || isApiRoute) {
+    const token = req.cookies.get("editor_token");
+    if (
+      token?.value !== "granted" &&
+      req.nextUrl.pathname !== "/admin/blog/new"
+    ) {
+      const url = req.nextUrl.clone();
+      url.pathname = "/admin/blog/new";
+      return NextResponse.redirect(url);
+    }
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/admin/blog/:path*", "/api/admin/blog/:path*"],
+};


### PR DESCRIPTION
## Summary
- add basic middleware + login API to guard `/admin/blog`
- expose `+ New post` button on blog index
- scaffold placeholder admin pages after passing gate

## Testing
- `pnpm -w run format`
- `pnpm --filter ./apps/www lint` *(fails: ESLint not configured)*
- `pnpm -w run check-types` *(no tasks)*
- `pnpm -w run build` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68c5528baa1c832aabdb27c17af1fb49