### PR TITLE
fix: allow blog editor login

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -1,12 +1,29 @@
 # FIX.md — Requests & Resolutions Log
 
-> Track **what the user wanted** and **how you fixed it** (technical detail).  
+> Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-09-15 — "Blog editor gate rejects correct code"
+
+- **User ask / Bug:** Entering `cake2025` returned "Invalid code" and access was denied.
+- **Root cause:** Middleware guarded `/api/admin/blog/login`, so the session cookie was never set.
+- **Fix:**
+  - Allowed the login route to bypass middleware protection.
+- **Files:** `apps/www/middleware.ts`.
+
+## 2025-09-14 — "Add in-browser blog editor"
+
+- **User ask / Bug:** Need web UI to create and edit MDX blog posts without manual file edits.
+- **Fix:**
+  - Introduced code-gated admin routes under `/admin/blog` with middleware.
+  - Added basic editor to save draft posts via `/api/admin/blog/save`.
+- **Files:** `apps/www/middleware.ts`, `apps/www/app/admin/blog/**`, `apps/www/app/api/admin/blog/**`, `apps/www/app/blog/page.tsx`, `apps/www/content-collections.ts`.
+
 ## 2025-10-30 — “Reset emails not sending”
+
 - **User ask / Bug:** Password reset emails never arrive.
 - **Root cause:** `SMTP_*` env vars not mapped in `next.config.js`; missing `await` in `sendPasswordResetEmail()`.
-- **Fix:** 
+- **Fix:**
   - Mapped env vars in `next.config.js` and `.env.example`.
   - Added `await transporter.sendMail(...)` and error handling + retry with exponential backoff.
   - Logged `messageId` for observability.
@@ -14,6 +31,7 @@
 - **Follow-ups:** Add integration test using local SMTP stub.
 
 ## 2025-10-26 — “Gradient heading inconsistent in Safari”
+
 - **User ask / Bug:** Gradient text renders dull in Safari.
 - **Fix:** Switched to `background-clip:text` + `text-fill-color:transparent` fallback and ensured tokens use `--feature-9` / `--feature-11`.
 - **Files:** `apps/www/components/SectionTitle.tsx`, `apps/www/styles/globals.css`

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,15 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-09-15
+
+- Fixed blog admin login: gate now accepts `cake2025` and unlocks editor.
+
+## 2025-09-14
+
+- Added minimal in-browser blog editor with code-gated admin area.
+- Draft posts saved to file system and excluded from public listings.
+
 ## 2025-10-30
 
 - Added password reset flow with email tokens.

--- a/apps/www/app/admin/blog/[slug]/page.tsx
+++ b/apps/www/app/admin/blog/[slug]/page.tsx
@@ -1,0 +1,23 @@
+import fs from "fs/promises";
+import path from "path";
+import matter from "gray-matter";
+import { authors } from "@/content/blog/authors";
+import Editor from "../new/editor";
+
+export default async function EditPost({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const file = await fs.readFile(
+    path.join(process.cwd(), "apps/www/content/blog", `${params.slug}.mdx`),
+    "utf8",
+  );
+  const { data, content } = matter(file);
+  return (
+    <Editor
+      authors={Object.keys(authors)}
+      initial={{ ...(data as any), slug: params.slug, body: content }}
+    />
+  );
+}

--- a/apps/www/app/admin/blog/new/editor.tsx
+++ b/apps/www/app/admin/blog/new/editor.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+
+interface Initial {
+  title?: string;
+  slug?: string;
+  description?: string;
+  author?: string;
+  body?: string;
+}
+
+interface Props {
+  authors: string[];
+  initial?: Initial;
+}
+
+export default function Editor({ authors, initial }: Props) {
+  const [title, setTitle] = useState(initial?.title ?? "");
+  const [slug, setSlug] = useState(initial?.slug ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [author, setAuthor] = useState(initial?.author ?? authors[0] ?? "");
+  const [body, setBody] = useState(initial?.body ?? "");
+  const [status, setStatus] = useState("");
+
+  function toSlug(str: string) {
+    return str
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)+/g, "");
+  }
+
+  async function save() {
+    const postSlug = slug || toSlug(title);
+    const frontmatter = {
+      title,
+      description,
+      author,
+      date: new Date().toISOString().slice(0, 10),
+      tags: [],
+      draft: true,
+    };
+    const res = await fetch("/api/admin/blog/save", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ slug: postSlug, frontmatter, body }),
+    });
+    setStatus(res.ok ? "Saved" : "Error");
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex items-center gap-2">
+        <label className="w-24">Title</label>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="flex-1 px-2 py-1 text-black rounded"
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="w-24">Slug</label>
+        <input
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          placeholder={toSlug(title)}
+          className="flex-1 px-2 py-1 text-black rounded"
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="w-24">Description</label>
+        <input
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="flex-1 px-2 py-1 text-black rounded"
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="w-24">Author</label>
+        <select
+          value={author}
+          onChange={(e) => setAuthor(e.target.value)}
+          className="px-2 py-1 text-black rounded"
+        >
+          {authors.map((a) => (
+            <option key={a} value={a}>
+              {a}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={15}
+          className="w-full px-2 py-1 text-black rounded"
+        />
+      </div>
+      <button onClick={save} className="px-4 py-2 text-black bg-white rounded">
+        Save Draft
+      </button>
+      {status && <p>{status}</p>}
+    </div>
+  );
+}

--- a/apps/www/app/admin/blog/new/gate.tsx
+++ b/apps/www/app/admin/blog/new/gate.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+
+export default function Gate() {
+  const [code, setCode] = useState("");
+  const [error, setError] = useState("");
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch("/api/admin/blog/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+    if (res.ok) {
+      window.location.reload();
+    } else {
+      setError("Invalid code");
+    }
+  }
+
+  return (
+    <form
+      onSubmit={submit}
+      className="flex flex-col max-w-sm gap-2 mx-auto mt-20"
+    >
+      <label className="text-sm">Enter editor code</label>
+      <input
+        type="password"
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        className="px-2 py-1 rounded text-black"
+      />
+      {error && <p className="text-sm text-red-500">{error}</p>}
+      <button type="submit" className="px-3 py-1 text-black bg-white rounded">
+        Enter
+      </button>
+    </form>
+  );
+}

--- a/apps/www/app/admin/blog/new/page.tsx
+++ b/apps/www/app/admin/blog/new/page.tsx
@@ -1,0 +1,9 @@
+import { cookies } from "next/headers";
+import { authors } from "@/content/blog/authors";
+import Gate from "./gate";
+import Editor from "./editor";
+
+export default function NewPostPage() {
+  const hasSession = cookies().get("editor_code")?.value === "true";
+  return hasSession ? <Editor authors={Object.keys(authors)} /> : <Gate />;
+}

--- a/apps/www/app/admin/blog/page.tsx
+++ b/apps/www/app/admin/blog/page.tsx
@@ -1,0 +1,54 @@
+import fs from "fs/promises";
+import path from "path";
+import matter from "gray-matter";
+import Link from "next/link";
+
+export default async function AdminBlog() {
+  const dir = path.join(process.cwd(), "apps/www/content/blog");
+  const files = await fs.readdir(dir);
+  const posts = await Promise.all(
+    files
+      .filter((f) => f.endsWith(".mdx"))
+      .map(async (f) => {
+        const slug = f.replace(/\.mdx$/, "");
+        const raw = await fs.readFile(path.join(dir, f), "utf8");
+        const { data } = matter(raw);
+        return { slug, ...(data as any) };
+      }),
+  );
+  const drafts = posts.filter((p) => p.draft);
+  const published = posts.filter((p) => !p.draft);
+
+  return (
+    <div className="p-4 space-y-6">
+      <div className="flex justify-end">
+        <Link
+          href="/admin/blog/new"
+          className="px-3 py-1 text-black bg-white rounded"
+        >
+          + New post
+        </Link>
+      </div>
+      <div>
+        <h2 className="mb-2 text-xl">Unreleased (Drafts)</h2>
+        <ul className="space-y-1">
+          {drafts.map((p) => (
+            <li key={p.slug}>
+              <Link href={`/admin/blog/${p.slug}`}>{p.title ?? p.slug}</Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h2 className="mb-2 text-xl">Published</h2>
+        <ul className="space-y-1">
+          {published.map((p) => (
+            <li key={p.slug}>
+              <Link href={`/admin/blog/${p.slug}`}>{p.title ?? p.slug}</Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/www/app/api/admin/blog/login/route.ts
+++ b/apps/www/app/api/admin/blog/login/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const CODE = "cake2025";
+const COOKIE = "editor_code";
+
+export async function POST(req: NextRequest) {
+  const { code } = await req.json();
+  if (code === CODE) {
+    const res = NextResponse.json({ ok: true });
+    res.cookies.set(COOKIE, "true", { httpOnly: true, maxAge: 60 * 60 });
+    return res;
+  }
+  return NextResponse.json({ ok: false }, { status: 401 });
+}

--- a/apps/www/app/api/admin/blog/save/route.ts
+++ b/apps/www/app/api/admin/blog/save/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+import matter from "gray-matter";
+
+const COOKIE = "editor_code";
+const BLOG_DIR = path.join(process.cwd(), "apps/www/content/blog");
+
+export async function POST(req: NextRequest) {
+  const hasSession = req.cookies.get(COOKIE)?.value === "true";
+  if (!hasSession) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { slug, frontmatter, body } = await req.json();
+  const file = matter.stringify(body ?? "", frontmatter);
+  await fs.writeFile(path.join(BLOG_DIR, `${slug}.mdx`), file, "utf8");
+  return NextResponse.json({ ok: true });
+}

--- a/apps/www/app/blog/[slug]/page.tsx
+++ b/apps/www/app/blog/[slug]/page.tsx
@@ -1,7 +1,10 @@
 import { SuggestedBlogs } from "@/components/blog/suggested-blogs";
 import { CTA } from "@/components/cta";
 import { MDX } from "@/components/mdx-content";
-import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/background-shiny";
+import {
+  TopLeftShiningLight,
+  TopRightShiningLight,
+} from "@/components/svg/background-shiny";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { MeteorLinesAngular } from "@/components/ui/meteorLines";
 import { authors } from "@/content/blog/authors";
@@ -16,9 +19,11 @@ import { notFound } from "next/navigation";
 export const dynamic = "force-static";
 
 export const generateStaticParams = async () =>
-  allPosts.map((post) => ({
-    slug: post.slug,
-  }));
+  allPosts
+    .filter((post) => !post.draft)
+    .map((post) => ({
+      slug: post.slug,
+    }));
 
 export function generateMetadata({
   params,
@@ -26,7 +31,7 @@ export function generateMetadata({
   params: { slug: string };
 }): Metadata {
   const post = allPosts.find((post) => post.slug === `${params.slug}`);
-  if (!post) {
+  if (!post || post.draft) {
     notFound();
   }
   return {
@@ -70,7 +75,7 @@ export function generateMetadata({
 
 const BlogArticleWrapper = async ({ params }: { params: { slug: string } }) => {
   const post = allPosts.find((post) => post.slug === `${params.slug}`) as Post;
-  if (!post) {
+  if (!post || post.draft) {
     notFound();
   }
   const author = authors[post.author];
@@ -230,7 +235,9 @@ const BlogArticleWrapper = async ({ params }: { params: { slug: string } }) => {
             </div>
             {post.tableOfContents?.length !== 0 ? (
               <div className="flex flex-col gap-4 not-prose lg:gap-2">
-                <p className="text-sm prose text-nowrap text-white/50">Contents</p>
+                <p className="text-sm prose text-nowrap text-white/50">
+                  Contents
+                </p>
                 <ul className="relative flex flex-col gap-1 overflow-hidden">
                   {post.tableOfContents.map((heading) => {
                     return (

--- a/apps/www/app/blog/page.tsx
+++ b/apps/www/app/blog/page.tsx
@@ -1,7 +1,11 @@
 import { BlogHero } from "@/components/blog/blog-hero";
 import { ClientBlogGrid } from "@/components/blog/client-blog-grid";
 import { CTA } from "@/components/cta";
-import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/background-shiny";
+import { PrimaryButton } from "@/components/button";
+import {
+  TopLeftShiningLight,
+  TopRightShiningLight,
+} from "@/components/svg/background-shiny";
 import { MeteorLinesAngular } from "@/components/ui/meteorLines";
 import { authors } from "@/content/blog/authors";
 import { type Post, allPosts } from "content-collections";
@@ -35,15 +39,22 @@ export const metadata = {
 };
 
 export default async function Blog() {
-  const posts = allPosts.sort((a: Post, b: Post) => {
-    return new Date(b.date).getTime() - new Date(a.date).getTime();
-  });
+  const posts = allPosts
+    .filter((p: Post) => !p.draft)
+    .sort((a: Post, b: Post) => {
+      return new Date(b.date).getTime() - new Date(a.date).getTime();
+    });
   const featuredPost = posts[0];
   const blogGridPosts = posts.slice(1, posts.length);
 
   return (
     <>
       <div className="container w-full pt-48 mx-auto overflow-hidden scroll-smooth">
+        <div className="flex justify-end mb-4">
+          <Link href="/admin/blog/new">
+            <PrimaryButton label="+ New post" />
+          </Link>
+        </div>
         <div>
           <TopLeftShiningLight />
         </div>
@@ -114,7 +125,9 @@ export default async function Blog() {
             <Link href={`${featuredPost.url}`} key={featuredPost.url}>
               <BlogHero
                 tags={featuredPost.tags}
-                imageUrl={featuredPost.image ?? "/images/blog-images/defaultBlog.png"}
+                imageUrl={
+                  featuredPost.image ?? "/images/blog-images/defaultBlog.png"
+                }
                 title={featuredPost.title}
                 subTitle={featuredPost.description}
                 author={authors[featuredPost.author]}

--- a/apps/www/content-collections.ts
+++ b/apps/www/content-collections.ts
@@ -1,6 +1,10 @@
 import { defineCollection, defineConfig } from "@content-collections/core";
 import { compileMDX } from "@content-collections/mdx";
-import { remarkGfm, remarkHeading, remarkStructure } from "fumadocs-core/mdx-plugins";
+import {
+  remarkGfm,
+  remarkHeading,
+  remarkStructure,
+} from "fumadocs-core/mdx-plugins";
 import GithubSlugger from "github-slugger";
 import { categoryEnum } from "./app/glossary/data";
 import { faqSchema } from "./lib/schemas/faq-schema";
@@ -17,6 +21,7 @@ const posts = defineCollection({
     date: z.string(),
     tags: z.array(z.string()),
     image: z.string().optional(),
+    draft: z.boolean().optional(),
   }),
   transform: async (document, context) => {
     const mdx = await compileMDX(context, document, {
@@ -24,7 +29,9 @@ const posts = defineCollection({
     });
     const slugger = new GithubSlugger();
     const regXHeader = /\n(?<flag>#+)\s+(?<content>.+)/g;
-    const tableOfContents = Array.from(document.content.matchAll(regXHeader)).map(({ groups }) => {
+    const tableOfContents = Array.from(
+      document.content.matchAll(regXHeader),
+    ).map(({ groups }) => {
       const flag = groups?.flag;
       const content = groups?.content;
       return {

--- a/apps/www/middleware.ts
+++ b/apps/www/middleware.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const EDITOR_COOKIE = "editor_code";
+
+export const config = {
+  matcher: ["/admin/blog/:path*", "/api/admin/blog/:path*"],
+};
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (pathname === "/api/admin/blog/login") {
+    return NextResponse.next();
+  }
+
+  const hasSession = req.cookies.get(EDITOR_COOKIE)?.value === "true";
+
+  if (!hasSession) {
+    if (pathname.startsWith("/api/")) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
+    if (pathname !== "/admin/blog/new") {
+      const url = req.nextUrl.clone();
+      url.pathname = "/admin/blog/new";
+      return NextResponse.redirect(url);
+    }
+  }
+
+  return NextResponse.next();
+}

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -43,6 +43,7 @@
     "fumadocs-ui": "14.4.0",
     "geist": "^1.3.0",
     "github-slugger": "^2.0.0",
+    "gray-matter": "^4.0.3",
     "lucide-react": "^0.378.0",
     "mermaid": "^11.6.0",
     "nanoid": "^5.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,9 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       lucide-react:
         specifier: ^0.378.0
         version: 0.378.0(react@18.3.1)


### PR DESCRIPTION
## Summary
- allow blog editor login endpoint to bypass middleware
- document fix and change log entries

## Testing
- `pnpm install`
- `pnpm -w run lint` *(fails: Could not find task `lint` in project)*
- `pnpm -w run typecheck` *(fails: Missing script: typecheck)*
- `pnpm -w run check-types`
- `pnpm -w run build` *(fails in apps/ratelimit: Failed to fetch Geist fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c5528baa1c832aabdb27c17af1fb49