### PR TITLE
Localize hero messaging

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,15 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-09-23 — “Refresh hero messaging for TransformAI”
+
+- **User ask / Bug:** Replace the homepage hero headline and supporting paragraph with the new TransformAI positioning in English and Dutch.
+- **Fix:**
+  - Added a `Hero` namespace to the locale message catalogs and passed the translated strings into the hero component via `next-intl`.
+  - Swapped the static landing metadata for a locale-aware generator so open graph and SEO descriptions follow the updated copy.
+- **Files:** `apps/www/components/hero/hero.tsx`, `apps/www/components/hero/hero-main-section.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `apps/www/app/[locale]/(site)/page.tsx`
+- **Follow-ups:** None.
+
 ## 2025-09-22 — “Language picker crashes after submit”
 
 - **User ask / Bug:** Selecting a language triggered a runtime error about a missing `next-intl` config file and kept the visitor on `/select-language`.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,11 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-09-23
+
+- Localized the homepage hero heading and description with the new TransformAI messaging for English and Dutch visitors.
+- Connected the landing page metadata to next-intl so SEO descriptions mirror the updated hero copy across locales.
+
 ## 2025-09-22
 
 - Wrapped the Next.js config with the `next-intl` plugin and centralized message loading so runtime translations inherit English fallbacks without throwing.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -15,38 +15,60 @@ import { FeatureGridChip } from "@/components/svg/feature-grid-chip";
 import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/hero";
 import { OssLight } from "@/components/svg/oss-light";
 import { UsageBento } from "@/components/usage-bento";
+import { isLocale } from "@/i18n/routing";
 import { ChevronRight, LogIn } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
 import mainboard from "@/images/mainboard.svg";
 import { DesktopLogoCloud, MobileLogoCloud } from "./(components)/logo-cloud-content";
 import { CodeExamples } from "../../code-examples";
 
-export const metadata = {
-  title: "Unkey",
-  description: "The Developer Platform for Modern APIs",
-  keywords: ["Unkey", "API", "API development", "API security", "API development platform"],
-  openGraph: {
-    title: "Unkey",
-    description: "The Developer Platform for Modern APIs",
-    url: "https://unkey.com/",
-    siteName: "unkey.com",
-    images: [
-      {
-        url: "https://unkey.com/og.png",
-        width: 1200,
-        height: 675,
-      },
-    ],
-  },
-  twitter: {
-    title: "Unkey",
-    card: "summary_large_image",
-  },
-  icons: {
-    shortcut: "/unkey.png",
-  },
+type LandingPageMetadataProps = {
+  params: {
+    locale: string;
+  };
 };
+
+export async function generateMetadata({
+  params,
+}: LandingPageMetadataProps): Promise<Metadata> {
+  const { locale } = params;
+
+  if (!isLocale(locale)) {
+    notFound();
+  }
+
+  const t = await getTranslations({ locale, namespace: "Metadata" });
+
+  return {
+    title: t("title"),
+    description: t("description"),
+    keywords: ["Unkey", "API", "API development", "API security", "API development platform"],
+    openGraph: {
+      title: t("openGraph.title"),
+      description: t("openGraph.description"),
+      url: "https://unkey.com/",
+      siteName: t("openGraph.siteName"),
+      images: [
+        {
+          url: "https://unkey.com/og.png",
+          width: 1200,
+          height: 675,
+        },
+      ],
+    },
+    twitter: {
+      title: t("twitter.title"),
+      card: "summary_large_image",
+    },
+    icons: {
+      shortcut: "/unkey.png",
+    },
+  };
+}
 
 export default async function Landing() {
   return (

--- a/apps/www/components/hero/hero-main-section.tsx
+++ b/apps/www/components/hero/hero-main-section.tsx
@@ -3,16 +3,20 @@ import Link from "next/link";
 import { PrimaryButton, SecondaryButton } from "@/components/button";
 import { BookOpen, ChevronRight, LogIn } from "lucide-react";
 
-export function HeroMainSection() {
+type HeroMainSectionProps = {
+  title: string;
+  description: string;
+};
+
+export function HeroMainSection({ title, description }: HeroMainSectionProps) {
   return (
     <div className="relative flex flex-col items-center text-center ">
       <h1 className="bg-gradient-to-br text-balance text-transparent bg-gradient-stop bg-clip-text from-white via-white via-30% to-white/30  font-medium text-6xl leading-none xl:text-[82px] tracking-tighter">
-        The Developer Platform for Modern APIs
+        {title}
       </h1>
 
       <p className="mt-6 sm:mt-8 bg-gradient-to-br text-transparent text-balance bg-gradient-stop bg-clip-text max-w-sm sm:max-w-lg xl:max-w-4xl from-white/70 via-white/70 via-40% to-white/30 text-base md:text-lg">
-        Easily integrate necessary API features like API keys, rate limiting, and usage analytics,
-        ensuring your API is ready to scale.
+        {description}
       </p>
 
       <div className="flex items-center gap-6 mt-16">

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -1,11 +1,14 @@
 "use client";
 import { motion } from "framer-motion";
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 import { HeroMainSection } from "./hero-main-section";
 
 import mainboard from "@/images/mainboard.svg";
 import { SubHeroMainboard } from "./hero-sub-mainboard";
 export const Hero: React.FC = () => {
+  const t = useTranslations("Hero");
+
   const containerVariants = {
     hidden: {},
     visible: {
@@ -32,7 +35,10 @@ export const Hero: React.FC = () => {
       animate="visible"
     >
       <motion.div variants={childVariants}>
-        <HeroMainSection />
+        <HeroMainSection
+          title={t("title")}
+          description={t("description")}
+        />
       </motion.div>
 
       <div>

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -2,10 +2,10 @@
   "Metadata": {
     "title": "Unkey",
     "titleTemplate": "%s | Unkey",
-    "description": "Build better APIs faster",
+    "description": "Your Transformation Partner for the Age of AI",
     "openGraph": {
       "title": "Unkey",
-      "description": "Build better APIs faster",
+      "description": "Your Transformation Partner for the Age of AI",
       "siteName": "unkey.com"
     },
     "twitter": {
@@ -29,6 +29,10 @@
       "docs": "Docs",
       "discord": "Discord"
     }
+  },
+  "Hero": {
+    "title": "Your Transformation Partner for the Age of AI",
+    "description": "We help companies adapt successfully and sustainably to the challenges and opportunities that Artificial Intelligence brings."
   },
   "Footer": {
     "tagline": "Build better APIs faster.",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -2,10 +2,10 @@
   "Metadata": {
     "title": "Unkey",
     "titleTemplate": "%s | Unkey",
-    "description": "Bouw betere API's sneller",
+    "description": "Jouw transformatiepartner voor het AI-tijdperk",
     "openGraph": {
       "title": "Unkey",
-      "description": "Bouw betere API's sneller",
+      "description": "Jouw transformatiepartner voor het AI-tijdperk",
       "siteName": "unkey.com"
     },
     "twitter": {
@@ -29,6 +29,10 @@
       "docs": "Documentatie",
       "discord": "Discord"
     }
+  },
+  "Hero": {
+    "title": "Jouw transformatiepartner voor het AI-tijdperk",
+    "description": "Wij helpen bedrijven zich succesvol en duurzaam aan te passen aan de kansen en uitdagingen die Kunstmatige Intelligentie met zich meebrengt."
   },
   "Footer": {
     "tagline": "Bouw betere API's sneller.",


### PR DESCRIPTION
## Plan
- Replace the hard-coded hero headline and paragraph with localized strings for English and Dutch visitors.
- Extend the locale message catalogs and hero component to read the new copy via next-intl.
- Update the landing page metadata so SEO descriptions follow the refreshed messaging.
- Validate the changes across languages and run the usual typecheck/lint/build commands.

## Summary
- Added a Hero translation namespace and wired the hero component to render locale-specific title and description copy.
- Swapped the landing page metadata constant for a locale-aware generator so OpenGraph/twitter descriptions reuse the translated messaging.
- Logged the change in UPDATE.md and FIX.md for project continuity.

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint`
- `pnpm -w turbo run build --filter=www`


------
https://chatgpt.com/codex/tasks/task_e_68ca700ebddc832a83bc83af439ac802