### PR TITLE
Update logo cloud and code examples messaging

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,15 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-09-24 — “Refresh partner heading and code examples messaging”
+
+- **User ask / Bug:** Replace the "Powering" label on the homepage with "Partners" and update the duplicated "Any language, any framework, always secure" copy in the code examples section with the new English and Dutch messaging.
+- **Fix:**
+  - Fetched the logo cloud heading via next-intl so both desktop and mobile variants render the localized "Partners" label.
+  - Added a `CodeExamples` namespace to the locale catalogs and rendered two localized `SectionTitle` blocks that reflect the requested TransformAI assistant and project explorer descriptions.
+- **Files:** `apps/www/app/[locale]/(site)/(components)/logo-cloud-content.tsx`, `apps/www/app/code-examples.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`
+- **Follow-ups:** None.
+
 ## 2025-09-23 — “Refresh hero messaging for TransformAI”
 
 - **User ask / Bug:** Replace the homepage hero headline and supporting paragraph with the new TransformAI positioning in English and Dutch.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,10 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-09-24
+
+- Updated the homepage logo cloud heading and code examples copy with the new TransformAI messaging, adding localized English and Dutch strings for the contact CTA and project explorer descriptions.
+
 ## 2025-09-23
 
 - Localized the homepage hero heading and description with the new TransformAI messaging for English and Dutch visitors.

--- a/apps/www/app/[locale]/(site)/(components)/logo-cloud-content.tsx
+++ b/apps/www/app/[locale]/(site)/(components)/logo-cloud-content.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from "react";
 
 import { cn } from "@/lib/utils";
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
 
 const logos = [
   {
@@ -22,7 +23,10 @@ const logos = [
   },
 ];
 
-export function DesktopLogoCloud() {
+export async function DesktopLogoCloud() {
+  const t = await getTranslations("LogoCloud");
+  const heading = t("label");
+
   return (
     <div className="hidden md:flex w-full flex-col items-center">
       <span
@@ -30,7 +34,7 @@ export function DesktopLogoCloud() {
           "font-mono text-sm md:text-md text-white/50 text-center opacity-0 animate-fade-in-up [animation-delay:1s]",
         )}
       >
-        Powering
+        {heading}
       </span>
 
       <div className="flex w-full flex-col items-center justify-center px-4 md:px-8">
@@ -59,10 +63,13 @@ export function DesktopLogoCloud() {
   );
 }
 
-export const MobileLogoCloud = () => {
+export async function MobileLogoCloud() {
+  const t = await getTranslations("LogoCloud");
+  const heading = t("label");
+
   return (
     <div className="md:hidden w-full flex flex-col items-center">
-      <span className={cn("font-mono text-sm md:text-md text-white/50 text-center")}>Powering</span>
+      <span className={cn("font-mono text-sm md:text-md text-white/50 text-center")}>{heading}</span>
 
       <div className="w-full px-4 md:px-8">
         <div
@@ -93,4 +100,4 @@ export const MobileLogoCloud = () => {
       </div>
     </div>
   );
-};
+}

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -18,6 +18,7 @@ import { cn } from "@/lib/utils";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { ChevronRight } from "lucide-react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import type { PrismTheme } from "prism-react-renderer";
 import React, { useEffect } from "react";
 import { useState } from "react";
@@ -552,6 +553,7 @@ const LanguageTrigger = React.forwardRef<
 LanguageTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 export const CodeExamples: React.FC<Props> = ({ className }) => {
+  const t = useTranslations("CodeExamples");
   const [language, setLanguage] = useState<Language>("Typescript");
   const [framework, setFramework] = useState<FrameworkName>("Typescript");
   const [languageHover, setLanguageHover] = useState("Typescript");
@@ -586,8 +588,8 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
   return (
     <section className={className}>
       <SectionTitle
-        title="Any language, any framework, always secure"
-        text="Simplify API security and access control with Unkey's developer-friendly platform. Our SDKs, intuitive REST API, and public OpenAPI spec make it easy to secure your APIs without complex configurations."
+        title={t("top.title")}
+        text={t("top.text")}
         align="center"
         className="relative"
       >
@@ -612,7 +614,13 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
           </div>
         </div>
       </SectionTitle>
-      <div className="relative w-full rounded-4xl border-[.75px] border-white/10 bg-gradient-to-b from-[#111111] to-black border-t-[.75px] border-t-white/20">
+      <SectionTitle
+        title={t("bottom.title")}
+        text={t("bottom.text")}
+        align="center"
+        className="relative mt-12"
+      />
+      <div className="relative w-full mt-10 rounded-4xl border-[.75px] border-white/10 bg-gradient-to-b from-[#111111] to-black border-t-[.75px] border-t-white/20">
         <div
           aria-hidden
           className="absolute pointer-events-none inset-x-16 h-[432px] bottom-[calc(100%-2rem)] bg-[radial-gradient(94.69%_94.69%_at_50%_100%,rgba(255,255,255,0.20)_0%,rgba(255,255,255,0)_55.45%)]"

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -34,6 +34,19 @@
     "title": "Your Transformation Partner for the Age of AI",
     "description": "We help companies adapt successfully and sustainably to the challenges and opportunities that Artificial Intelligence brings."
   },
+  "LogoCloud": {
+    "label": "Partners"
+  },
+  "CodeExamples": {
+    "top": {
+      "title": "Your AI Assistant for all things TransformAI",
+      "text": "Ask questions, schedule a call, or learn more about our solutions and services."
+    },
+    "bottom": {
+      "title": "Explore the projects we’ve been part of",
+      "text": "Click through the interface below to explore sample projects."
+    }
+  },
   "Footer": {
     "tagline": "Build better APIs faster.",
     "copyright": "Unkeyed, Inc. {year}",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -34,6 +34,19 @@
     "title": "Jouw transformatiepartner voor het AI-tijdperk",
     "description": "Wij helpen bedrijven zich succesvol en duurzaam aan te passen aan de kansen en uitdagingen die Kunstmatige Intelligentie met zich meebrengt."
   },
+  "LogoCloud": {
+    "label": "Partners"
+  },
+  "CodeExamples": {
+    "top": {
+      "title": "Jouw AI-assistent voor alles rond TransformAI",
+      "text": "Stel je vragen, plan een afspraak of ontdek meer over onze oplossingen en diensten."
+    },
+    "bottom": {
+      "title": "Ontdek de projecten waar wij aan hebben meegewerkt",
+      "text": "Klik door de interface hieronder om enkele projecten te ontdekken."
+    }
+  },
   "Footer": {
     "tagline": "Bouw betere API's sneller.",
     "copyright": "Unkeyed, Inc. {year}",


### PR DESCRIPTION
## Summary
- localize the homepage logo cloud heading so desktop and mobile variants show the "Partners" label
- add CodeExamples namespace translations for English and Dutch and render two section titles with the requested TransformAI messaging
- document the change in UPDATE.md and FIX.md for future agents

## Plan
- audit the homepage components and message catalogs that surface the existing strings
- route the logo cloud label through next-intl with the new copy and wire up fresh translations for the code examples section
- verify layout spacing after duplicating the code examples heading and update project logs

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: pre-existing repo lint violations surfaced in about/careers/pricing/startups templates)*
- `pnpm -w turbo run build --filter=www` *(fails: same lint violations stop the Next.js build phase)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7805c5e0832a850b457768c48f40