### PR TITLE
Reposition code example CTAs and refresh localized copy

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,15 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-09-25 — “Move code template CTAs and refresh platform copy”
+
+- **User ask / Bug:** Relocate the “Get Started” and “Visit the docs” buttons so they sit beneath the code template selector, update their English and Dutch labels, refresh the AI assistant and platform section copy, and rename the analytics “Show API code” control.
+- **Fix:**
+  - Rebuilt the code example CTA layout to place the buttons below the language tabs and sourced their labels from a shared CTA translation namespace.
+  - Localized the assistant headline, platform messaging, and analytics toggle with the new English/Dutch copy while updating the docs CTA text site-wide.
+- **Files:** `apps/www/app/code-examples.tsx`, `apps/www/app/[locale]/(site)/page.tsx`, `apps/www/components/analytics/analytics-bento.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `UPDATE.md`.
+- **Follow-ups:** None.
+
 ## 2025-09-24 — “Refresh partner heading and code examples messaging”
 
 - **User ask / Bug:** Replace the "Powering" label on the homepage with "Partners" and update the duplicated "Any language, any framework, always secure" copy in the code examples section with the new English and Dutch messaging.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,10 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-09-25
+
+- Repositioned the code example CTA buttons beneath the language templates, refreshed their English and Dutch labels, updated the analytics request access control, and introduced localized platform section messaging for both locales.
+
 ## 2025-09-24
 
 - Updated the homepage logo cloud heading and code examples copy with the new TransformAI messaging, adding localized English and Dutch strings for the contact CTA and project explorer descriptions.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -71,6 +71,11 @@ export async function generateMetadata({
 }
 
 export default async function Landing() {
+  const [cta, platform] = await Promise.all([
+    getTranslations("CTA"),
+    getTranslations("Platform"),
+  ]);
+
   return (
     <>
       <TopRightShiningLight />
@@ -102,8 +107,8 @@ export default async function Landing() {
           <Section className="mt-16 md:mt-20">
             <SectionTitle
               className="mt-8 md:mt-16 lg:mt-32"
-              title="Everything you need for your API"
-              text="Build, monetize, analyze, and protect your APIs; our platform makes it easy, providing everything you need."
+              title={platform("title")}
+              text={platform("text")}
               align="center"
             />
             <AnalyticsBento />
@@ -124,10 +129,18 @@ export default async function Landing() {
             >
               <div className="flex mt-10 mb-10 space-x-6">
                 <Link href="https://app.unkey.com" className="group">
-                  <PrimaryButton shiny IconLeft={LogIn} label="Get Started" className="h-10" />
+                  <PrimaryButton
+                    shiny
+                    IconLeft={LogIn}
+                    label={cta("getStarted")}
+                    className="h-10"
+                  />
                 </Link>
                 <Link href="/docs">
-                  <SecondaryButton label="Visit the Docs" IconRight={ChevronRight} />
+                  <SecondaryButton
+                    label={cta("exploreProjects")}
+                    IconRight={ChevronRight}
+                  />
                 </Link>
               </div>
             </SectionTitle>
@@ -163,11 +176,19 @@ export default async function Landing() {
               >
                 <div className="flex mt-10 mb-10 space-x-6">
                   <Link href="https://app.unkey.com" className="group">
-                    <PrimaryButton shiny IconLeft={LogIn} label="Get Started" className="h-10" />
+                    <PrimaryButton
+                      shiny
+                      IconLeft={LogIn}
+                      label={cta("getStarted")}
+                      className="h-10"
+                    />
                   </Link>
 
                   <Link href="/docs">
-                    <SecondaryButton label="Visit the Docs" IconRight={ChevronRight} />
+                    <SecondaryButton
+                      label={cta("exploreProjects")}
+                      IconRight={ChevronRight}
+                    />
                   </Link>
                 </div>
               </SectionTitle>

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -554,6 +554,7 @@ LanguageTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 export const CodeExamples: React.FC<Props> = ({ className }) => {
   const t = useTranslations("CodeExamples");
+  const cta = useTranslations("CTA");
   const [language, setLanguage] = useState<Language>("Typescript");
   const [framework, setFramework] = useState<FrameworkName>("Typescript");
   const [languageHover, setLanguageHover] = useState("Typescript");
@@ -602,16 +603,6 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
           <MeteorLines className="ml-2 fade-in-0" delay={4} number={1} />
           <MeteorLines className="ml-10 fade-in-40" delay={0} number={1} />
           <MeteorLines className="ml-16 fade-in-100" delay={2} number={1} />
-        </div>
-        <div className="mt-10">
-          <div className="flex gap-6 pb-14">
-            <Link key="get-started" href="https://app.unkey.com">
-              <PrimaryButton shiny label="Get Started" IconRight={ChevronRight} />
-            </Link>
-            <Link key="docs" href="/docs">
-              <SecondaryButton label="Visit the docs" IconRight={ChevronRight} />
-            </Link>
-          </div>
         </div>
       </SectionTitle>
       <SectionTitle
@@ -662,6 +653,21 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
             />
           </div>
         </div>
+      </div>
+      <div className="flex flex-wrap items-center justify-center gap-4 mt-12">
+        <Link key="get-started" href="https://app.unkey.com">
+          <PrimaryButton
+            shiny
+            label={cta("getStarted")}
+            IconRight={ChevronRight}
+          />
+        </Link>
+        <Link key="explore-projects" href="/docs">
+          <SecondaryButton
+            label={cta("exploreProjects")}
+            IconRight={ChevronRight}
+          />
+        </Link>
       </div>
     </section>
   );

--- a/apps/www/components/analytics/analytics-bento.tsx
+++ b/apps/www/components/analytics/analytics-bento.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { motion } from "framer-motion";
 import { Wand2 } from "lucide-react";
 import type { PrismTheme } from "prism-react-renderer";
+import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { PrimaryButton } from "../button";
 import { AnalyticsStars } from "../svg/analytics-stars";
@@ -59,12 +60,17 @@ const theme = {
 
 export function AnalyticsBento() {
   const [showApi, toggleShowApi] = useState(false);
+  const t = useTranslations("Analytics");
 
   return (
     <div className="relative flex justify-center w-full">
       <div className="absolute z-50 top-14">
-        <button type="button" aria-label="Show API code" onClick={() => toggleShowApi(!showApi)}>
-          <PrimaryButton shiny label="Show API code" IconLeft={Wand2} />
+        <button
+          type="button"
+          aria-label={t("requestAccess")}
+          onClick={() => toggleShowApi(!showApi)}
+        >
+          <PrimaryButton shiny label={t("requestAccess")} IconLeft={Wand2} />
         </button>
       </div>
       <div

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -39,13 +39,24 @@
   },
   "CodeExamples": {
     "top": {
-      "title": "Your AI Assistant for all things TransformAI",
+      "title": "Ask anything about TransformAI to our AI Assistant",
       "text": "Ask questions, schedule a call, or learn more about our solutions and services."
     },
     "bottom": {
       "title": "Explore the projects we’ve been part of",
       "text": "Click through the interface below to explore sample projects."
     }
+  },
+  "CTA": {
+    "getStarted": "Get Started",
+    "exploreProjects": "Explore All projects"
+  },
+  "Analytics": {
+    "requestAccess": "Request Access"
+  },
+  "Platform": {
+    "title": "Our Platform (Beta)",
+    "text": "We’re building the best platform to help businesses seamlessly integrate AI into their operations."
   },
   "Footer": {
     "tagline": "Build better APIs faster.",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -39,13 +39,24 @@
   },
   "CodeExamples": {
     "top": {
-      "title": "Jouw AI-assistent voor alles rond TransformAI",
+      "title": "Vraag alles over TransformAI aan onze AI-assistent",
       "text": "Stel je vragen, plan een afspraak of ontdek meer over onze oplossingen en diensten."
     },
     "bottom": {
       "title": "Ontdek de projecten waar wij aan hebben meegewerkt",
       "text": "Klik door de interface hieronder om enkele projecten te ontdekken."
     }
+  },
+  "CTA": {
+    "getStarted": "Begin Nu",
+    "exploreProjects": "Ontdek Alle projecten"
+  },
+  "Analytics": {
+    "requestAccess": "Vraag Toegang"
+  },
+  "Platform": {
+    "title": "Ons platform (Beta)",
+    "text": "Wij bouwen aan het beste platform waarmee bedrijven AI moeiteloos in hun organisatie kunnen inzetten."
   },
   "Footer": {
     "tagline": "Bouw betere API's sneller.",


### PR DESCRIPTION
## Plan
- Move the code example primary/secondary CTAs beneath the language template grid and hook their labels into shared translations.
- Refresh the assistant and platform section copy for both English and Dutch by updating the message catalogs and server render logic.
- Rename the analytics toggle button via next-intl and ensure related UI references reflect the new "Request Access" copy.
- Update project logs and validate typecheck/lint, noting any pre-existing lint exceptions.

## Summary
- Repositioned the code example CTA buttons under the template tabs and wired them to shared CTA translations for localized labels.
- Localized the analytics "Request Access" control and introduced translated platform section messaging in both English and Dutch catalogs.
- Logged the change in UPDATE.md and FIX.md for continuity.

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: existing repo lint violations outside touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9676cbac832a97543c43c528eb38