### PR TITLE
Temporarily hide homepage hashed keys, audit logs, and open-source sections

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,13 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-09-28 — “Prompt for coding agent — Hide but don’t delete specific sections (including all text)”
+
+- **User ask / Bug:** Temporarily remove the One-way hashed Keys, Audit Logs, and Open-source homepage sections without deleting their code so they can be restored later.
+- **Fix:** Wrapped each section’s JSX in a `{false && (...)}` guard with inline comments to suppress rendering while keeping the original components and imports intact.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `UPDATE.md`.
+- **Follow-ups:** Re-enable the guards when the sections should return.
+
 ## 2025-09-27 — “Prompt for coding agent — AI Activity Feed (production formatting, full i18n)”
 
 - **User ask / Bug:** Replace the billing-focused usage bento with an AI activity feed that highlights task actors, descriptions, meta details, and precise durations while localizing all copy in English and Dutch.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,10 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-09-28
+
+- Temporarily hid the homepage hashed keys, audit logs, and open-source sections behind disabled wrappers so they can be re-enabled later without code loss.
+
 ## 2025-09-27
 
 - Reimagined the usage bento as an AI activity feed with localized actor, description, and meta copy alongside duration-based timestamps and refreshed task-specific icons.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -100,9 +100,12 @@ export default async function Landing() {
           <Section className="mt-16 md:mt-18">
             <CodeExamples />
           </Section>
-          <Section className="mt-16 md:mt-18">
-            <OpenSource />
-          </Section>
+          {/* Temporarily hidden: Open-source / GitHub block (including text + button) */}
+          {false && (
+            <Section className="mt-16 md:mt-18">
+              <OpenSource />
+            </Section>
+          )}
 
           <Section className="mt-16 md:mt-20">
             <SectionTitle
@@ -144,10 +147,14 @@ export default async function Landing() {
                 </Link>
               </div>
             </SectionTitle>
-            <div className="grid xl:grid-cols-[2fr_3fr] gap-6">
-              <HashedKeysBento />
-              <AuditLogsBento />
-            </div>
+            {/* Temporarily hidden: One-way hashed Keys section (including heading/paragraph) */}
+            {/* Temporarily hidden: Audit Logs section (including heading, description, table headers) */}
+            {false && (
+              <div className="grid xl:grid-cols-[2fr_3fr] gap-6">
+                <HashedKeysBento />
+                <AuditLogsBento />
+              </div>
+            )}
 
             <div className="relative grid md:grid-cols-[1fr_1fr] xl:grid-cols-[3fr_2fr] gap-6 z-50">
               {/* TODO: optimize to avoid fetching svg on mobile */}


### PR DESCRIPTION
## Summary
- wrap the homepage Open-source, hashed keys, and audit logs sections in disabled JSX guards while preserving their code for later reactivation
- annotate each hidden block with comments explaining the temporary removal and document the change in UPDATE.md and FIX.md

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: numerous existing lint issues in untouched files such as app/[locale]/(site)/about/page.tsx)*

## Plan
- locate the landing page sections covering Open-source, hashed keys, and audit logs
- hide those sections by wrapping their JSX in `{false && (...)}` guards and add the required explanatory comments
- update project logs and run the documented typecheck/lint commands

------
https://chatgpt.com/codex/tasks/task_e_68cbbcff4490832ab7461347ff5cae95