### PR TITLE
Refresh security and budgets cards with localized AI messaging

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,15 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-09-29 — “Prompt for coding agent — Replace “IP Whitelisting / Rate Limits” cards”
+
+- **User ask / Bug:** Refresh the paired homepage cards so they communicate AI data and IP protection plus team budget controls, with localized copy and updated visuals that drop the raw IP and API key references.
+- **Fix:**
+  - Converted both card components to client-side translations, swapped the IP-focused badges for policy/compliance chips with new shield, lock, and residency glyphs, and added a credits usage meter with wallet iconography.
+  - Updated the JSON code sample, project pill, and inline stats to reflect credits and fair-use rate limits while wiring English and Dutch strings under the `Security` and `Budgets` namespaces.
+- **Files:** `apps/www/components/ip-whitelisting-bento.tsx`, `apps/www/components/rate-limits-bento.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `UPDATE.md`.
+- **Follow-ups:** None.
+
 ## 2025-09-28 — “Prompt for coding agent — Hide but don’t delete specific sections (including all text)”
 
 - **User ask / Bug:** Temporarily remove the One-way hashed Keys, Audit Logs, and Open-source homepage sections without deleting their code so they can be restored later.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,10 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-09-29
+
+- Reimagined the homepage security and rate limit cards as AI data protection and team budgeting experiences, refreshed their visuals, and localized all copy in English and Dutch.
+
 ## 2025-09-28
 
 - Temporarily hid the homepage hashed keys, audit logs, and open-source sections behind disabled wrappers so they can be re-enabled later without code loss.

--- a/apps/www/components/ip-whitelisting-bento.tsx
+++ b/apps/www/components/ip-whitelisting-bento.tsx
@@ -1,40 +1,151 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useTranslations } from "next-intl";
+
+import { cn } from "@/lib/utils";
+
 import ip from "../images/ip.svg";
 import { ImageWithBlur } from "./image-with-blur";
 
 export function IpWhitelistingBento() {
+  const t = useTranslations("Security");
+
+  const policies: PolicyBadgeProps[] = [
+    {
+      label: t("badges.confidential"),
+      caption: t("captions.pii"),
+      icon: <ConfidentialPolicyIcon />,
+      className: "top-[16%] left-[12%]",
+    },
+    {
+      label: t("badges.internal"),
+      caption: t("captions.access"),
+      icon: <AccessPolicyIcon />,
+      className: "top-1/2 right-[14%] -translate-y-1/2",
+    },
+    {
+      label: t("badges.public"),
+      caption: t("captions.residency"),
+      icon: <ResidencyPolicyIcon />,
+      className: "bottom-[18%] left-[28%]",
+    },
+  ];
+
   return (
     <div className="w-full mt-5 ip-blur-gradient relative ip-whitelisting-bg-gradient border-[.75px] h-[520px] rounded-[32px] border-[#ffffff]/10 flex overflow-x-hidden">
       <ImageWithBlur src={ip} alt="animated map" className="w-full" />
+      <div className="absolute inset-0 pointer-events-none">
+        <div className="absolute inset-0 bg-gradient-to-br from-black/60 via-black/30 to-black/10" />
+        <div className="relative z-10 h-full w-full">
+          {policies.map((policy) => (
+            <PolicyBadge key={policy.caption} {...policy} />
+          ))}
+        </div>
+      </div>
       <IpWhitelistingText />
     </div>
   );
 }
 
 export function IpWhitelistingText() {
+  const t = useTranslations("Security");
+
   return (
-    <div className="flex flex-col text-white absolute left-[20px] sm:left-[40px] xl:left-[40px] bottom-[40px] max-w-[350px]">
+    <div className="flex flex-col text-white absolute left-[20px] sm:left-[40px] xl:left-[40px] bottom-[40px] max-w-[350px] z-20">
       <div className="flex items-center w-full">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-        >
-          <path
-            fillRule="evenodd"
-            clipRule="evenodd"
-            d="M19.3732 7.83136L23.3732 3.33136L22.6258 2.66699L18.9781 6.77066L16.8531 4.64562L16.146 5.35273L18.646 7.85273L19.0209 8.22769L19.3732 7.83136ZM3.5 6.0003H3V6.5003V16.5003V17.0003H3.5H6V19.5003V20.0003H6.5H15.5H16V19.5003V17.0003H18.5H19V16.5003V11.0003H18V16.0003H15.5H15V16.5003V19.0003H7V16.5003V16.0003H6.5H4V7.0003H6V12.0003H7V7.0003H9V12.0003H10V7.0003H12V12.0003H13V6.5003V6.0003H12.5H9.5H6.5H3.5ZM15 8.0003V12.0003H16V8.0003H15Z"
-            fill="white"
-            fillOpacity="0.4"
-          />
-        </svg>
-        <h3 className="ml-4 text-lg font-medium text-white">IP Whitelisting</h3>
+        <ShieldCheckIcon className="h-6 w-6 text-white/70" />
+        <h3 className="ml-4 text-lg font-medium text-white">{t("title")}</h3>
       </div>
       <p className="mt-4 leading-6 text-white/60">
-        Ensure secure access control by allowing only designated IP addresses to interact with your
-        system, adding an extra layer of protection.
+        {t("body")}
       </p>
     </div>
+  );
+}
+
+type PolicyBadgeProps = {
+  icon: ReactNode;
+  label: string;
+  caption: string;
+  className?: string;
+};
+
+function PolicyBadge({ icon, label, caption, className }: PolicyBadgeProps) {
+  return (
+    <div className={cn("absolute flex flex-col gap-2 text-white", className)}>
+      <div className="inline-flex items-center gap-2 rounded-full border-[0.75px] border-white/20 bg-white/5 px-4 py-2 backdrop-blur-sm">
+        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-white/10 text-white/80">
+          {icon}
+        </span>
+        <span className="text-xs font-medium tracking-tight text-white">{label}</span>
+      </div>
+      <span className="text-[10px] font-medium uppercase tracking-[0.16em] text-white/60">{caption}</span>
+    </div>
+  );
+}
+
+function ShieldCheckIcon({ className }: { className?: string }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" className={className}>
+      <path
+        d="M12 3L5 6V11C5 15.97 8.86 20.44 12 21C15.14 20.44 19 15.97 19 11V6L12 3Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      <path d="M9.5 11.5L11 13L14.5 9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function ConfidentialPolicyIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <path
+        d="M8 2L3.5 4V7.75C3.5 10.61 5.71 13.31 8 13.75C10.29 13.31 12.5 10.61 12.5 7.75V4L8 2Z"
+        stroke="white"
+        strokeOpacity="0.8"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+      <path d="M6.5 7.5L7.75 8.75L10 6.5" stroke="white" strokeOpacity="0.8" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function AccessPolicyIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <rect
+        x="3"
+        y="7"
+        width="10"
+        height="6"
+        rx="1.5"
+        stroke="white"
+        strokeOpacity="0.8"
+        strokeWidth="1.2"
+      />
+      <path
+        d="M5.5 7V5.5C5.5 4.11929 6.61929 3 8 3C9.38071 3 10.5 4.11929 10.5 5.5V7"
+        stroke="white"
+        strokeOpacity="0.8"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+      <path d="M8 9.5V11.5" stroke="white" strokeOpacity="0.8" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function ResidencyPolicyIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <circle cx="8" cy="8" r="5" stroke="white" strokeOpacity="0.8" strokeWidth="1.2" />
+      <path d="M8 3C9.65685 3 11 5.23858 11 8C11 10.7614 9.65685 13 8 13" stroke="white" strokeOpacity="0.8" strokeWidth="1.2" />
+      <path d="M5 6H11" stroke="white" strokeOpacity="0.8" strokeWidth="1.2" strokeLinecap="round" />
+      <path d="M5 10H11" stroke="white" strokeOpacity="0.8" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
   );
 }

--- a/apps/www/components/rate-limits-bento.tsx
+++ b/apps/www/components/rate-limits-bento.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
 export function RateLimitsBento() {
   return (
     <div className="w-full md:mt-5 relative border-[.75px] h-[520px] rounded-[32px] border-[#ffffff]/10 flex overflow-x-hidden rate-limits-background-gradient bg-gradient-to-t backdrop-blur-[1px] from-black/20 via-black/20 via-20% to-transparent">
@@ -8,29 +12,53 @@ export function RateLimitsBento() {
 }
 
 export function RateLimits() {
+  const t = useTranslations("Budgets");
+
+  const config = {
+    credits: {
+      total: 10000,
+      teamAllocation: {
+        Sales: 2500,
+        Support: 2500,
+        Ops: 2500,
+        "R&D": 2500,
+      },
+    },
+    rateLimit: {
+      limit: 100,
+      intervalMs: 1000,
+    },
+  };
+
+  const configString = JSON.stringify(config, null, 2);
+  const configLines = configString.split("\n");
+
   return (
     <div className="relative mx-[40px] flex w-full flex-col">
       <div className="flex h-[200px] w-full ratelimits-editor-bg-gradient rounded-b-xl ">
-        <div className="flex flex-col font-mono text-sm text-white px-[24px] space-y-3 mt-1 border-r-[.75px] border-[#ffffff]/20">
-          <p>1</p>
-          <p>2</p>
-          <p>3</p>
-          <p>4</p>
-          <p>5</p>
-          <p>6</p>
+        <div className="flex flex-col font-mono text-sm text-white/40 px-[24px] mt-1 border-r-[.75px] border-[#ffffff]/20">
+          {configLines.map((_, index) => (
+            <p key={index} className="leading-8">
+              {index + 1}
+            </p>
+          ))}
         </div>
         <div className="flex w-full pl-8 font-mono text-xs leading-8 text-white whitespace-pre ratelimits-editor-bg-gradient-2 rounded-br-xl">
-          {JSON.stringify({ rateLimit: { limit: 10, interval: 1000 } }, null, 2)}
+          {configString}
         </div>
       </div>
       <div className="flex flex-col mt-8 ratelimits-fade-gradient">
-        <div className="flex items-center">
-          <div className="font-mono text-xs text-white sm:font-sm whitespace-nowrap">
-            <span className="text-[#ffffff]/40">Rate limiting</span>
-            <span className="text-[#ffffff]/40 tracking-[-5px]">...</span>
-            <span className="inline-flex w-[4px] h-[12px] bg-white ratelimits-bar-shadow ml-3 relative top-[1px] flicker" />
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+          <div className="flex items-center gap-4 font-mono text-xs text-white">
+            <BudgetMeterIcon className="h-9 w-9 text-white/70" />
+            <div className="flex flex-col gap-2">
+              <span>{t("creditsLabel")}</span>
+              <div className="relative h-[6px] w-[180px] overflow-hidden rounded-full bg-white/10">
+                <span className="absolute inset-y-0 left-0 w-[32.4%] rounded-full bg-[#3CEEAE] ratelimits-bar-shadow" />
+              </div>
+            </div>
           </div>
-          <div className="inline-flex items-center overflow-hidden ml-4 h-[36px] text-white font-mono text-sm ratelimits-key-gradient border-[.75px] border-[#ffffff]/20 rounded-xl">
+          <div className="inline-flex items-center overflow-hidden ml-0 sm:ml-4 h-[36px] text-white font-mono text-sm ratelimits-key-gradient border-[.75px] border-[#ffffff]/20 rounded-xl">
             <div className="w-[62px] h-[36px]">
               <svg
                 className="ratelimits-key-icon "
@@ -115,7 +143,7 @@ export function RateLimits() {
                 </defs>
               </svg>
             </div>
-            <p className="relative text-xs right-4">sk_TEwCE9AY9BFTq1XJdIO</p>
+            <p className="relative text-xs right-4">{t("projectPill")}</p>
           </div>
         </div>
         <div className="inline-flex w-[205px] opacity-70 items-center ml-[150px] mt-[30px] h-[36px] text-white font-mono text-sm ratelimits-link ratelimits-key-gradient border-[.75px] border-[#ffffff]/20 rounded-xl [mask-image:linear-gradient(to_bottom_left,black_30%,transparent)]">
@@ -204,7 +232,7 @@ export function RateLimits() {
               </filter>
             </defs>
           </svg>
-          <p className="relative text-xs right-4">dom@keyauth.dev</p>
+          <p className="relative text-xs right-4">{t("rateLimitPill")}</p>
         </div>
       </div>
     </div>
@@ -212,6 +240,8 @@ export function RateLimits() {
 }
 
 export function RateLimitsText() {
+  const t = useTranslations("Budgets");
+
   return (
     <div className="flex flex-col text-white absolute left-[20px] sm:left-[40px] xl:left-[40px] bottom-[40px] max-w-[350px]">
       <div className="flex items-center w-full">
@@ -230,12 +260,30 @@ export function RateLimitsText() {
             fillOpacity="0.4"
           />
         </svg>
-        <h3 className="ml-4 text-lg font-medium text-white">Rate Limits</h3>
+        <h3 className="ml-4 text-lg font-medium text-white">{t("title")}</h3>
       </div>
       <p className="mt-4 leading-6 text-white/60">
-        Per IP, per user, per API key, or any identifier that matters to you. Enforced on the edge,
-        as close to your users as possible, delivering fast and reliable rate limiting.
+        {t("body")}
       </p>
     </div>
+  );
+}
+
+function BudgetMeterIcon({ className }: { className?: string }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" fill="none" className={className}>
+      <rect
+        x="6"
+        y="11"
+        width="24"
+        height="16"
+        rx="4"
+        stroke="currentColor"
+        strokeWidth="1.4"
+      />
+      <path d="M10 15H22" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+      <circle cx="25.5" cy="19" r="2.5" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M6 16H4V22H6" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
   );
 }

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -197,6 +197,27 @@
       "privacy": "Privacy Policy"
     }
   },
+  "Security": {
+    "title": "AI Data & IP Protection",
+    "body": "Protect your company’s intellectual property and sensitive data as you adopt AI. Enforce policies, redact confidential content, and control where data flows—without slowing teams down.",
+    "badges": {
+      "confidential": "Policy: Confidential",
+      "internal": "Policy: Internal",
+      "public": "Policy: Public"
+    },
+    "captions": {
+      "pii": "PII Redaction",
+      "access": "Model Access Control",
+      "residency": "Data Residency"
+    }
+  },
+  "Budgets": {
+    "title": "Rate Limits & Team Budgets",
+    "body": "Assign budgets to teams and projects, set fair-use rates, and prevent overruns. Keep AI costs predictable while giving teams the headroom they need.",
+    "creditsLabel": "Credits: 3,240 / 10,000",
+    "projectPill": "projectTransform",
+    "rateLimitPill": "Limit: 100 req / s"
+  },
   "Language": {
     "selectTitle": "Select language",
     "english": "English",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -197,6 +197,27 @@
       "privacy": "Privacybeleid"
     }
   },
+  "Security": {
+    "title": "Bescherming van AI-data en intellectueel eigendom",
+    "body": "Bescherm het intellectuele eigendom en de gevoelige data van je organisatie bij het inzetten van AI. Handhaaf policies, redacteer vertrouwelijke inhoud en beheer datastromen—zonder teams te vertragen.",
+    "badges": {
+      "confidential": "Beleid: Vertrouwelijk",
+      "internal": "Beleid: Intern",
+      "public": "Beleid: Publiek"
+    },
+    "captions": {
+      "pii": "PII-redactie",
+      "access": "Modeltoegangsbeheer",
+      "residency": "Data-residentie"
+    }
+  },
+  "Budgets": {
+    "title": "Rate limits & teambudgetten",
+    "body": "Wijs budgetten toe aan teams en projecten, stel fair-use-limieten in en voorkom overschrijdingen. Houd AI-kosten voorspelbaar met voldoende ruimte voor teams.",
+    "creditsLabel": "Credits: 3.240 / 10.000",
+    "projectPill": "projectTransform",
+    "rateLimitPill": "Limiet: 100 req / s"
+  },
   "Language": {
     "selectTitle": "Selecteer taal",
     "english": "Engels",


### PR DESCRIPTION
## Summary
- Replaced the IP-focused security card with AI data and intellectual property protection messaging, policy badges, and shield iconography wired to the `Security` namespace.
- Reframed the rate limits card around team budgets with a credits meter, project pill, and JSON config that now surfaces credits plus fair-use rate limits through the `Budgets` namespace.
- Added the associated English/Dutch strings and documented the refresh in `UPDATE.md` and `FIX.md`.

## Plan
- Update `IpWhitelistingBento` to present AI data and IP protection storytelling with policy/compliance badges.
- Rework `RateLimitsBento` to emphasize team budgets, credits usage, and rate limit controls while preserving the layout.
- Extend the `Security` and `Budgets` translation namespaces in `messages/en.json` and `messages/nl.json` and refresh project docs.
- Run the www dev server to verify the UI and capture an updated screenshot.

## Testing
- pnpm --filter www dev

## Checklist
- [x] Reused existing primitives and styling tokens.
- [x] Strings routed through next-intl with EN/NL coverage.
- [x] Verified the refreshed cards in both light and dark themes during manual review.
- [x] Captured UI screenshot for the updated cards.


------
https://chatgpt.com/codex/tasks/task_e_68cbc22f0b34832a8ef736ee6c18edc8