### PR TITLE
Polish AI protection and budgets cards

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,34 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-10-31 — “Follow-up prompt for the coding agent — polish the two cards”
+
+- **User ask / Bug:** Deliver production-ready layouts for the AI protection and team budgets cards so copy never collides with floating chips or the JSON panel across breakpoints.
+- **Root cause:** The first refresh left policy badges large enough to drift into the text safe area and the rate limit code viewer flexible, allowing the project pill and credits meter to crowd the heading zone on smaller screens.
+- **Fix:**
+  - Anchored the policy badges to the radar rings with smaller, lower-opacity chips and deepened the text-side gradients to preserve a clear reading zone.
+  - Locked the JSON preview to seven lines with hidden overflow, tightened the bottom fade, and rebuilt the credits row so the usage meter and “#22” project pill align cleanly with added padding.
+- **Files:** `apps/www/components/ip-whitelisting-bento.tsx`, `apps/www/components/rate-limits-bento.tsx`, `UPDATE.md`.
+- **Follow-ups:** None.
+
+## 2025-09-30 — “Follow-up prompt for the coding agent — polish the two cards”
+
+- **User ask / Bug:** Resolve layout collisions on the refreshed AI protection and budget cards by tightening chip placement, cleaning the overlays, and keeping the text and code blocks readable on every breakpoint.
+- **Fix:**
+  - Established bottom-left safe zones with subtle gradients, repositioned the compliance chips along the radar rings, and softened their scale so they stay clear of the heading copy.
+  - Rebuilt the budget preview into a fixed seven-line code pane with highlighted keys, reorganized the credits meter row so the project pill (now “#22”) sits flush right, and widened pill padding to prevent truncation.
+- **Files:** `apps/www/components/ip-whitelisting-bento.tsx`, `apps/www/components/rate-limits-bento.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `UPDATE.md`.
+- **Follow-ups:** None.
+
+## 2025-09-29 — “Prompt for coding agent — Replace “IP Whitelisting / Rate Limits” cards”
+
+- **User ask / Bug:** Refresh the paired homepage cards so they communicate AI data and IP protection plus team budget controls, with localized copy and updated visuals that drop the raw IP and API key references.
+- **Fix:**
+  - Converted both card components to client-side translations, swapped the IP-focused badges for policy/compliance chips with new shield, lock, and residency glyphs, and added a credits usage meter with wallet iconography.
+  - Updated the JSON code sample, project pill, and inline stats to reflect credits and fair-use rate limits while wiring English and Dutch strings under the `Security` and `Budgets` namespaces.
+- **Files:** `apps/www/components/ip-whitelisting-bento.tsx`, `apps/www/components/rate-limits-bento.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `UPDATE.md`.
+- **Follow-ups:** None.
+
 ## 2025-09-28 — “Prompt for coding agent — Hide but don’t delete specific sections (including all text)”
 
 - **User ask / Bug:** Temporarily remove the One-way hashed Keys, Audit Logs, and Open-source homepage sections without deleting their code so they can be restored later.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,18 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-10-31
+
+- Rebalanced the AI protection and team budgets cards by anchoring policy chips outside the text safe area, deepening the supporting gradients, fixing the JSON viewer height, and aligning the credits row with its project pill so nothing collides across breakpoints.
+
+## 2025-09-30
+
+- Polished the AI data protection and budget control cards by defining safe text zones, rebalancing policy chips, tightening overlays, and rebuilding the code preview so the layout stays collision-free across breakpoints.
+
+## 2025-09-29
+
+- Reimagined the homepage security and rate limit cards as AI data protection and team budgeting experiences, refreshed their visuals, and localized all copy in English and Dutch.
+
 ## 2025-09-28
 
 - Temporarily hid the homepage hashed keys, audit logs, and open-source sections behind disabled wrappers so they can be re-enabled later without code loss.

--- a/apps/www/components/ip-whitelisting-bento.tsx
+++ b/apps/www/components/ip-whitelisting-bento.tsx
@@ -1,40 +1,162 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useTranslations } from "next-intl";
+
+import { cn } from "@/lib/utils";
+
 import ip from "../images/ip.svg";
 import { ImageWithBlur } from "./image-with-blur";
 
 export function IpWhitelistingBento() {
+  const t = useTranslations("Security");
+
+  const policies: PolicyBadgeProps[] = [
+    {
+      label: t("badges.confidential"),
+      caption: t("captions.pii"),
+      icon: <ConfidentialPolicyIcon />,
+      className:
+        "top-[14%] left-[22%] -translate-x-1/2 -translate-y-1/2 sm:top-[16%] sm:left-[26%] lg:top-[18%] lg:left-[30%]",
+    },
+    {
+      label: t("badges.internal"),
+      caption: t("captions.access"),
+      icon: <AccessPolicyIcon />,
+      className:
+        "top-[46%] right-[12%] -translate-y-1/2 sm:right-[16%] lg:right-[18%]",
+    },
+    {
+      label: t("badges.public"),
+      caption: t("captions.residency"),
+      icon: <ResidencyPolicyIcon />,
+      className:
+        "bottom-[20%] right-[14%] sm:bottom-[18%] sm:right-[20%] lg:bottom-[16%] lg:right-[24%]",
+    },
+  ];
+
   return (
-    <div className="w-full mt-5 ip-blur-gradient relative ip-whitelisting-bg-gradient border-[.75px] h-[520px] rounded-[32px] border-[#ffffff]/10 flex overflow-x-hidden">
-      <ImageWithBlur src={ip} alt="animated map" className="w-full" />
+    <div className="relative mt-5 flex h-[520px] w-full overflow-hidden rounded-[32px] border-[0.75px] border-[#ffffff]/10 ip-blur-gradient ip-whitelisting-bg-gradient">
+      <ImageWithBlur src={ip} alt="animated map" className="h-full w-full object-cover" />
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute inset-0 bg-gradient-to-br from-black/65 via-black/35 to-black/10" />
+        <div className="absolute bottom-0 left-0 right-[28%] top-[52%] sm:right-[32%] sm:top-[50%] lg:right-[38%]">
+          <div className="absolute inset-0 rounded-br-[32px] rounded-tl-[32px] bg-gradient-to-t from-black/85 via-black/40 to-transparent" />
+        </div>
+        <div className="relative z-10 h-full w-full">
+          {policies.map((policy) => (
+            <PolicyBadge key={policy.caption} {...policy} />
+          ))}
+        </div>
+      </div>
       <IpWhitelistingText />
     </div>
   );
 }
 
 export function IpWhitelistingText() {
+  const t = useTranslations("Security");
+
   return (
-    <div className="flex flex-col text-white absolute left-[20px] sm:left-[40px] xl:left-[40px] bottom-[40px] max-w-[350px]">
-      <div className="flex items-center w-full">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-        >
-          <path
-            fillRule="evenodd"
-            clipRule="evenodd"
-            d="M19.3732 7.83136L23.3732 3.33136L22.6258 2.66699L18.9781 6.77066L16.8531 4.64562L16.146 5.35273L18.646 7.85273L19.0209 8.22769L19.3732 7.83136ZM3.5 6.0003H3V6.5003V16.5003V17.0003H3.5H6V19.5003V20.0003H6.5H15.5H16V19.5003V17.0003H18.5H19V16.5003V11.0003H18V16.0003H15.5H15V16.5003V19.0003H7V16.5003V16.0003H6.5H4V7.0003H6V12.0003H7V7.0003H9V12.0003H10V7.0003H12V12.0003H13V6.5003V6.0003H12.5H9.5H6.5H3.5ZM15 8.0003V12.0003H16V8.0003H15Z"
-            fill="white"
-            fillOpacity="0.4"
-          />
-        </svg>
-        <h3 className="ml-4 text-lg font-medium text-white">IP Whitelisting</h3>
+    <div className="absolute bottom-10 left-6 z-30 max-w-[320px] text-white sm:bottom-12 sm:left-10 sm:max-w-[360px]">
+      <div className="relative">
+        <div className="pointer-events-none absolute -inset-x-6 -inset-y-8 rounded-[30px] bg-gradient-to-t from-black/85 via-black/40 to-transparent" />
+        <div className="relative flex flex-col">
+          <div className="flex items-center">
+            <ShieldCheckIcon className="h-6 w-6 text-white/70" />
+            <h3 className="ml-3 text-lg font-medium text-white">{t("title")}</h3>
+          </div>
+          <p className="mt-4 text-sm leading-6 text-white/70">
+            {t("body")}
+          </p>
+        </div>
       </div>
-      <p className="mt-4 leading-6 text-white/60">
-        Ensure secure access control by allowing only designated IP addresses to interact with your
-        system, adding an extra layer of protection.
-      </p>
     </div>
+  );
+}
+
+type PolicyBadgeProps = {
+  icon: ReactNode;
+  label: string;
+  caption: string;
+  className?: string;
+};
+
+function PolicyBadge({ icon, label, caption, className }: PolicyBadgeProps) {
+  return (
+    <div className={cn("absolute z-20 flex w-max flex-col gap-1 text-white/80", className)}>
+      <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 backdrop-blur-sm">
+        <span className="flex h-4 w-4 items-center justify-center rounded-full bg-white/10 text-white/65">
+          {icon}
+        </span>
+        <span className="text-[10px] font-medium tracking-tight text-white/85">{label}</span>
+      </div>
+      <span className="pl-1 text-[9px] font-medium uppercase tracking-[0.18em] text-white/45">{caption}</span>
+    </div>
+  );
+}
+
+function ShieldCheckIcon({ className }: { className?: string }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" className={className}>
+      <path
+        d="M12 3L5 6V11C5 15.97 8.86 20.44 12 21C15.14 20.44 19 15.97 19 11V6L12 3Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      <path d="M9.5 11.5L11 13L14.5 9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function ConfidentialPolicyIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <path
+        d="M8 2L3.5 4V7.75C3.5 10.61 5.71 13.31 8 13.75C10.29 13.31 12.5 10.61 12.5 7.75V4L8 2Z"
+        stroke="white"
+        strokeOpacity="0.8"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+      <path d="M6.5 7.5L7.75 8.75L10 6.5" stroke="white" strokeOpacity="0.8" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function AccessPolicyIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <rect
+        x="3"
+        y="7"
+        width="10"
+        height="6"
+        rx="1.5"
+        stroke="white"
+        strokeOpacity="0.8"
+        strokeWidth="1.2"
+      />
+      <path
+        d="M5.5 7V5.5C5.5 4.11929 6.61929 3 8 3C9.38071 3 10.5 4.11929 10.5 5.5V7"
+        stroke="white"
+        strokeOpacity="0.8"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+      <path d="M8 9.5V11.5" stroke="white" strokeOpacity="0.8" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function ResidencyPolicyIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <circle cx="8" cy="8" r="5" stroke="white" strokeOpacity="0.8" strokeWidth="1.2" />
+      <path d="M8 3C9.65685 3 11 5.23858 11 8C11 10.7614 9.65685 13 8 13" stroke="white" strokeOpacity="0.8" strokeWidth="1.2" />
+      <path d="M5 6H11" stroke="white" strokeOpacity="0.8" strokeWidth="1.2" strokeLinecap="round" />
+      <path d="M5 10H11" stroke="white" strokeOpacity="0.8" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
   );
 }

--- a/apps/www/components/rate-limits-bento.tsx
+++ b/apps/www/components/rate-limits-bento.tsx
@@ -1,3 +1,8 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useTranslations } from "next-intl";
+
 export function RateLimitsBento() {
   return (
     <div className="w-full md:mt-5 relative border-[.75px] h-[520px] rounded-[32px] border-[#ffffff]/10 flex overflow-x-hidden rate-limits-background-gradient bg-gradient-to-t backdrop-blur-[1px] from-black/20 via-black/20 via-20% to-transparent">
@@ -8,117 +13,80 @@ export function RateLimitsBento() {
 }
 
 export function RateLimits() {
+  const t = useTranslations("Budgets");
+
+  const configLines = [
+    "{",
+    '  "credits": { "total": 10000,',
+    '    "teamAllocation": { "Sales": 2500,',
+    '      "Support": 2500, "Ops": 2500,',
+    '      "R&D": 2500 } },',
+    '  "rateLimit": { "limit": 100, "intervalMs": 1000 }',
+    "}",
+  ];
+
+  const highlightRegex = /"(?:credits|total|teamAllocation|rateLimit)"/g;
+
   return (
-    <div className="relative mx-[40px] flex w-full flex-col">
-      <div className="flex h-[200px] w-full ratelimits-editor-bg-gradient rounded-b-xl ">
-        <div className="flex flex-col font-mono text-sm text-white px-[24px] space-y-3 mt-1 border-r-[.75px] border-[#ffffff]/20">
-          <p>1</p>
-          <p>2</p>
-          <p>3</p>
-          <p>4</p>
-          <p>5</p>
-          <p>6</p>
-        </div>
-        <div className="flex w-full pl-8 font-mono text-xs leading-8 text-white whitespace-pre ratelimits-editor-bg-gradient-2 rounded-br-xl">
-          {JSON.stringify({ rateLimit: { limit: 10, interval: 1000 } }, null, 2)}
+    <div className="relative z-10 mx-[32px] flex h-full w-full flex-col px-1 pt-8 pb-36 sm:mx-[40px] sm:px-0 sm:pt-10">
+      <div className="relative overflow-hidden rounded-[24px] border-[0.75px] border-white/15 bg-white/[0.04]">
+        <div className="flex">
+          <div className="flex h-[228px] flex-col overflow-hidden border-r-[0.75px] border-white/10 px-6 py-4 font-mono text-xs leading-7 text-white/30">
+            {configLines.map((_, index) => (
+              <span key={`line-${index}`}>{index + 1}</span>
+            ))}
+          </div>
+          <div className="relative flex-1 overflow-hidden bg-gradient-to-br from-white/[0.04] via-transparent to-black/40">
+            <pre className="flex h-[228px] flex-col justify-start gap-0 overflow-hidden px-6 py-4 font-mono text-xs leading-7 text-white/55">
+              {configLines.map((line, index) => (
+                <code key={`code-${index}`} className="whitespace-pre">
+                  {renderHighlightedLine(line, highlightRegex)}
+                </code>
+              ))}
+            </pre>
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-black via-black/35 to-transparent" />
+          </div>
         </div>
       </div>
-      <div className="flex flex-col mt-8 ratelimits-fade-gradient">
-        <div className="flex items-center">
-          <div className="font-mono text-xs text-white sm:font-sm whitespace-nowrap">
-            <span className="text-[#ffffff]/40">Rate limiting</span>
-            <span className="text-[#ffffff]/40 tracking-[-5px]">...</span>
-            <span className="inline-flex w-[4px] h-[12px] bg-white ratelimits-bar-shadow ml-3 relative top-[1px] flicker" />
+      <div className="mt-8 flex flex-col gap-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-4 font-mono text-xs text-white">
+            <BudgetMeterIcon className="h-7 w-7 text-white/70" />
+            <div className="flex flex-col gap-2">
+              <span className="text-white/70">{t("creditsLabel")}</span>
+              <div className="relative h-[6px] w-[180px] overflow-hidden rounded-full bg-white/10">
+                <span className="absolute inset-y-0 left-0 w-[32.4%] rounded-full bg-[#3CEEAE] ratelimits-bar-shadow" />
+              </div>
+            </div>
           </div>
-          <div className="inline-flex items-center overflow-hidden ml-4 h-[36px] text-white font-mono text-sm ratelimits-key-gradient border-[.75px] border-[#ffffff]/20 rounded-xl">
-            <div className="w-[62px] h-[36px]">
+          <div className="inline-flex items-center gap-3 self-end rounded-xl border-[0.75px] border-white/20 bg-white/5 px-5 py-2 font-mono text-xs text-white/85 sm:self-auto">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#3CEEAE]/20">
               <svg
-                className="ratelimits-key-icon "
+                className="h-5 w-5 text-[#3CEEAE]"
                 xmlns="http://www.w3.org/2000/svg"
-                width="62"
-                height="36"
-                viewBox="0 0 62 36"
                 fill="none"
+                viewBox="0 0 24 24"
               >
-                <g filter="url(#filter0_d_840_1930)">
-                  <rect
-                    x="8"
-                    y="6"
-                    width="24"
-                    height="24"
-                    rx="6"
-                    fill="#3CEEAE"
-                    shapeRendering="crispEdges"
-                  />
-                  <rect
-                    x="8"
-                    y="6"
-                    width="24"
-                    height="24"
-                    rx="6"
-                    fill="black"
-                    fillOpacity="0.15"
-                    shapeRendering="crispEdges"
-                  />
-                  <rect
-                    x="8.375"
-                    y="6.375"
-                    width="23.25"
-                    height="23.25"
-                    rx="5.625"
-                    stroke="white"
-                    strokeOpacity="0.1"
-                    strokeWidth="0.75"
-                    shapeRendering="crispEdges"
-                  />
-                  <path
-                    d="M21.5 15L23 16.5M14.5 23.5H17.5V21.5H19.5V20.5L21.5 18.5L19.5 16.5L14.5 21.5V23.5ZM18 15L23 20L26.5 16.5L21.5 11.5L18 15Z"
-                    stroke="white"
-                  />
-                </g>
-                <defs>
-                  <filter
-                    id="filter0_d_840_1930"
-                    x="-22"
-                    y="-24"
-                    width="84"
-                    height="84"
-                    filterUnits="userSpaceOnUse"
-                    colorInterpolationFilters="sRGB"
-                  >
-                    <feFlood floodOpacity="0" result="BackgroundImageFix" />
-                    <feColorMatrix
-                      in="SourceAlpha"
-                      type="matrix"
-                      values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-                      result="hardAlpha"
-                    />
-                    <feOffset />
-                    <feGaussianBlur stdDeviation="15" />
-                    <feComposite in2="hardAlpha" operator="out" />
-                    <feColorMatrix
-                      type="matrix"
-                      values="0 0 0 0 0.235294 0 0 0 0 0.933333 0 0 0 0 0.682353 0 0 0 1 0"
-                    />
-                    <feBlend
-                      mode="normal"
-                      in2="BackgroundImageFix"
-                      result="effect1_dropShadow_840_1930"
-                    />
-                    <feBlend
-                      mode="normal"
-                      in="SourceGraphic"
-                      in2="effect1_dropShadow_840_1930"
-                      result="shape"
-                    />
-                  </filter>
-                </defs>
+                <path
+                  d="M5 11V19C5 19.5523 5.44772 20 6 20H18C18.5523 20 19 19.5523 19 19V11"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M7 11V8C7 5.79086 8.79086 4 11 4H13C15.2091 4 17 5.79086 17 8V11"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
               </svg>
             </div>
-            <p className="relative text-xs right-4">sk_TEwCE9AY9BFTq1XJdIO</p>
+            <span>{t("projectPill")}</span>
           </div>
         </div>
-        <div className="inline-flex w-[205px] opacity-70 items-center ml-[150px] mt-[30px] h-[36px] text-white font-mono text-sm ratelimits-link ratelimits-key-gradient border-[.75px] border-[#ffffff]/20 rounded-xl [mask-image:linear-gradient(to_bottom_left,black_30%,transparent)]">
+        <div className="inline-flex h-9 items-center gap-3 rounded-xl border-[0.75px] border-white/20 bg-white/5 px-4 font-mono text-xs text-white/75">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="84"
@@ -204,38 +172,98 @@ export function RateLimits() {
               </filter>
             </defs>
           </svg>
-          <p className="relative text-xs right-4">dom@keyauth.dev</p>
+          <span>{t("rateLimitPill")}</span>
         </div>
       </div>
     </div>
   );
 }
 
+function renderHighlightedLine(line: string, regex: RegExp): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  const pattern = new RegExp(regex);
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(line)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(
+        <span key={`text-${match.index}`} className="text-white/45">
+          {line.slice(lastIndex, match.index)}
+        </span>,
+      );
+    }
+
+    nodes.push(
+      <span key={`highlight-${match.index}`} className="text-[#3CEEAE]">
+        {match[0]}
+      </span>,
+    );
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < line.length || nodes.length === 0) {
+    nodes.push(
+      <span key={`tail-${line.length}`} className="text-white/45">
+        {line.slice(lastIndex)}
+      </span>,
+    );
+  }
+
+  return nodes;
+}
+
 export function RateLimitsText() {
+  const t = useTranslations("Budgets");
+
   return (
-    <div className="flex flex-col text-white absolute left-[20px] sm:left-[40px] xl:left-[40px] bottom-[40px] max-w-[350px]">
-      <div className="flex items-center w-full">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-        >
-          <path
-            fillRule="evenodd"
-            clipRule="evenodd"
-            d="M21 4H18V3H21.5H22V3.5V8.42105V20.5V21H21.5H18V20H21V16H18V15H21V12H18V11H21V8.42105V8H18V7H21V4ZM9.85355 5.14645L9.5 4.79289L9.14645 5.14645L5.64645 8.64645L5.29289 9L5.64645 9.35355L6.79289 10.5L2.14645 15.1464L2 15.2929V15.5V17.5V18H2.5H5.5H6V17.5V16H7.5H8V15.5V14.7071L9.5 13.2071L10.6464 14.3536L11 14.7071L11.3536 14.3536L14.8536 10.8536L15.2071 10.5L14.8536 10.1464L9.85355 5.14645ZM7.85355 10.1464L7.5 9.79289L6.70711 9L9.5 6.20711L13.7929 10.5L11 13.2929L10.2071 12.5L9.85355 12.1464L7.85355 10.1464ZM3 15.7071L7.5 11.2071L8.79289 12.5L7.14645 14.1464L7 14.2929V14.5V15H5.5H5V15.5V17H3V15.7071ZM9.14645 9.35355L10.6464 10.8536L11.3536 10.1464L9.85355 8.64645L9.14645 9.35355Z"
-            fill="white"
-            fillOpacity="0.4"
-          />
-        </svg>
-        <h3 className="ml-4 text-lg font-medium text-white">Rate Limits</h3>
+    <div className="absolute bottom-10 left-6 z-30 max-w-[320px] text-white sm:bottom-12 sm:left-10 sm:max-w-[360px]">
+      <div className="relative">
+        <div className="pointer-events-none absolute -inset-x-6 -inset-y-8 rounded-[30px] bg-gradient-to-t from-black/85 via-black/40 to-transparent" />
+        <div className="relative flex flex-col">
+          <div className="flex w-full items-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+            >
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M21 4H18V3H21.5H22V3.5V8.42105V20.5V21H21.5H18V20H21V16H18V15H21V12H18V11H21V8.42105V8H18V7H21V4ZM9.85355 5.14645L9.5 4.79289L9.14645 5.14645L5.64645 8.64645L5.29289 9L5.64645 9.35355L6.79289 10.5L2.14645 15.1464L2 15.2929V15.5V17.5V18H2.5H5.5H6V17.5V16H7.5H8V15.5V14.7071L9.5 13.2071L10.6464 14.3536L11 14.7071L11.3536 14.3536L14.8536 10.8536L15.2071 10.5L14.8536 10.1464L9.85355 5.14645ZM7.85355 10.1464L7.5 9.79289L6.70711 9L9.5 6.20711L13.7929 10.5L11 13.2929L10.2071 12.5L9.85355 12.1464L7.85355 10.1464ZM3 15.7071L7.5 11.2071L8.79289 12.5L7.14645 14.1464L7 14.2929V14.5V15H5.5H5V15.5V17H3V15.7071ZM9.14645 9.35355L10.6464 10.8536L11.3536 10.1464L9.85355 8.64645L9.14645 9.35355Z"
+                fill="white"
+                fillOpacity="0.4"
+              />
+            </svg>
+            <h3 className="ml-3 text-lg font-medium text-white">{t("title")}</h3>
+          </div>
+          <p className="mt-4 text-sm leading-6 text-white/70">
+            {t("body")}
+          </p>
+        </div>
       </div>
-      <p className="mt-4 leading-6 text-white/60">
-        Per IP, per user, per API key, or any identifier that matters to you. Enforced on the edge,
-        as close to your users as possible, delivering fast and reliable rate limiting.
-      </p>
     </div>
+  );
+}
+
+function BudgetMeterIcon({ className }: { className?: string }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" fill="none" className={className}>
+      <rect
+        x="6"
+        y="11"
+        width="24"
+        height="16"
+        rx="4"
+        stroke="currentColor"
+        strokeWidth="1.4"
+      />
+      <path d="M10 15H22" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+      <circle cx="25.5" cy="19" r="2.5" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M6 16H4V22H6" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
   );
 }

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -197,6 +197,27 @@
       "privacy": "Privacy Policy"
     }
   },
+  "Security": {
+    "title": "AI Data & IP Protection",
+    "body": "Protect your company’s intellectual property and sensitive data as you adopt AI. Enforce policies, redact confidential content, and control where data flows—without slowing teams down.",
+    "badges": {
+      "confidential": "Policy: Confidential",
+      "internal": "Policy: Internal",
+      "public": "Policy: Public"
+    },
+    "captions": {
+      "pii": "PII Redaction",
+      "access": "Model Access Control",
+      "residency": "Data Residency"
+    }
+  },
+  "Budgets": {
+    "title": "Rate Limits & Team Budgets",
+    "body": "Assign budgets to teams and projects, set fair-use rates, and prevent overruns. Keep AI costs predictable while giving teams the headroom they need.",
+    "creditsLabel": "Credits: 3,240 / 10,000",
+    "projectPill": "#22",
+    "rateLimitPill": "Limit: 100 req / s"
+  },
   "Language": {
     "selectTitle": "Select language",
     "english": "English",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -197,6 +197,27 @@
       "privacy": "Privacybeleid"
     }
   },
+  "Security": {
+    "title": "Bescherming van AI-data en intellectueel eigendom",
+    "body": "Bescherm het intellectuele eigendom en de gevoelige data van je organisatie bij het inzetten van AI. Handhaaf policies, redacteer vertrouwelijke inhoud en beheer datastromen—zonder teams te vertragen.",
+    "badges": {
+      "confidential": "Beleid: Vertrouwelijk",
+      "internal": "Beleid: Intern",
+      "public": "Beleid: Publiek"
+    },
+    "captions": {
+      "pii": "PII-redactie",
+      "access": "Modeltoegangsbeheer",
+      "residency": "Data-residentie"
+    }
+  },
+  "Budgets": {
+    "title": "Rate limits & teambudgetten",
+    "body": "Wijs budgetten toe aan teams en projecten, stel fair-use-limieten in en voorkom overschrijdingen. Houd AI-kosten voorspelbaar met voldoende ruimte voor teams.",
+    "creditsLabel": "Credits: 3.240 / 10.000",
+    "projectPill": "#22",
+    "rateLimitPill": "Limiet: 100 req / s"
+  },
   "Language": {
     "selectTitle": "Selecteer taal",
     "english": "Engels",


### PR DESCRIPTION
## Summary
- Define safe text zones on the AI data/IP protection card, reposition the compliance chips along the radar rings, and soften their styling so nothing overlaps the copy.
- Rebuild the budgets card’s code preview into a fixed seven-line panel with highlighted keys, refreshed pill row, and a right-aligned “#22” project badge to keep the layout tidy.
- Update English and Dutch catalogs plus project logs to capture the refined visuals and semantics.

## Plan
- Adjust the AI protection card layout to reserve a bottom-left safe area and redistribute the policy chips away from the text block.
- Tweak the budgets card structure to constrain the JSON preview, highlight key metrics, and realign the credits meter with the project pill.
- Refresh localized strings and documentation to reflect the polished presentation and new pill label.

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: pre-existing ESLint findings across the www workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc22f0b34832a8ef736ee6c18edc8