### PR TITLE
Adjust security card title and budget layout

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,15 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-11-01 — “Prompt for coding agent — small UI adjustments”
+
+- **User ask / Bug:** Update the paired AI protection and budget cards so the security title drops the “& IP” phrasing and the budget metrics appear in the specified order without clipping the project pill.
+- **Fix:**
+  - Trimmed the security title translation in English and Dutch to “AI Data Protection,” leaving the existing body copy and policy chips untouched.
+  - Reordered the credits meter, rate limit badge, and project pill in the budget card layout while anchoring the pill to the left edge to keep it visible at every breakpoint.
+- **Files:** `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `apps/www/components/rate-limits-bento.tsx`, `UPDATE.md`.
+- **Follow-ups:** None.
+
 ## 2025-10-31 — “Follow-up prompt for the coding agent — polish the two cards”
 
 - **User ask / Bug:** Deliver production-ready layouts for the AI protection and team budgets cards so copy never collides with floating chips or the JSON panel across breakpoints.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,10 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-11-01
+
+- Updated the AI protection and budget cards so the security heading reads “AI Data Protection” and the credits, rate limit, and project pill stack cleanly without clipping at any breakpoint.
+
 ## 2025-10-31
 
 - Rebalanced the AI protection and team budgets cards by anchoring policy chips outside the text safe area, deepening the supporting gradients, fixing the JSON viewer height, and aligning the credits row with its project pill so nothing collides across breakpoints.

--- a/apps/www/components/rate-limits-bento.tsx
+++ b/apps/www/components/rate-limits-bento.tsx
@@ -49,41 +49,13 @@ export function RateLimits() {
         </div>
       </div>
       <div className="mt-8 flex flex-col gap-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-4 font-mono text-xs text-white">
-            <BudgetMeterIcon className="h-7 w-7 text-white/70" />
-            <div className="flex flex-col gap-2">
-              <span className="text-white/70">{t("creditsLabel")}</span>
-              <div className="relative h-[6px] w-[180px] overflow-hidden rounded-full bg-white/10">
-                <span className="absolute inset-y-0 left-0 w-[32.4%] rounded-full bg-[#3CEEAE] ratelimits-bar-shadow" />
-              </div>
+        <div className="flex items-center gap-4 font-mono text-xs text-white">
+          <BudgetMeterIcon className="h-7 w-7 text-white/70" />
+          <div className="flex flex-col gap-2">
+            <span className="text-white/70">{t("creditsLabel")}</span>
+            <div className="relative h-[6px] w-[180px] overflow-hidden rounded-full bg-white/10">
+              <span className="absolute inset-y-0 left-0 w-[32.4%] rounded-full bg-[#3CEEAE] ratelimits-bar-shadow" />
             </div>
-          </div>
-          <div className="inline-flex items-center gap-3 self-end rounded-xl border-[0.75px] border-white/20 bg-white/5 px-5 py-2 font-mono text-xs text-white/85 sm:self-auto">
-            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#3CEEAE]/20">
-              <svg
-                className="h-5 w-5 text-[#3CEEAE]"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M5 11V19C5 19.5523 5.44772 20 6 20H18C18.5523 20 19 19.5523 19 19V11"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7 11V8C7 5.79086 8.79086 4 11 4H13C15.2091 4 17 5.79086 17 8V11"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-            <span>{t("projectPill")}</span>
           </div>
         </div>
         <div className="inline-flex h-9 items-center gap-3 rounded-xl border-[0.75px] border-white/20 bg-white/5 px-4 font-mono text-xs text-white/75">
@@ -173,6 +145,32 @@ export function RateLimits() {
             </defs>
           </svg>
           <span>{t("rateLimitPill")}</span>
+        </div>
+        <div className="inline-flex items-center gap-3 self-start rounded-xl border-[0.75px] border-white/20 bg-white/5 px-5 py-2 font-mono text-xs text-white/85">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#3CEEAE]/20">
+            <svg
+              className="h-5 w-5 text-[#3CEEAE]"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M5 11V19C5 19.5523 5.44772 20 6 20H18C18.5523 20 19 19.5523 19 19V11"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M7 11V8C7 5.79086 8.79086 4 11 4H13C15.2091 4 17 5.79086 17 8V11"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </div>
+          <span>{t("projectPill")}</span>
         </div>
       </div>
     </div>

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -198,7 +198,7 @@
     }
   },
   "Security": {
-    "title": "AI Data & IP Protection",
+    "title": "AI Data Protection",
     "body": "Protect your company’s intellectual property and sensitive data as you adopt AI. Enforce policies, redact confidential content, and control where data flows—without slowing teams down.",
     "badges": {
       "confidential": "Policy: Confidential",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -198,7 +198,7 @@
     }
   },
   "Security": {
-    "title": "Bescherming van AI-data en intellectueel eigendom",
+    "title": "Bescherming van AI-data",
     "body": "Bescherm het intellectuele eigendom en de gevoelige data van je organisatie bij het inzetten van AI. Handhaaf policies, redacteer vertrouwelijke inhoud en beheer datastromen—zonder teams te vertragen.",
     "badges": {
       "confidential": "Beleid: Vertrouwelijk",


### PR DESCRIPTION
## Summary
- rename the security card heading string to “AI Data Protection” in both locales while keeping body copy and badges unchanged
- reorder the budget card’s usage rows so credits lead, the rate limit badge follows, and the project pill anchors left without clipping
- document the work in UPDATE.md and FIX.md

## Plan
- inspect the security card translation keys and update the heading copy per request
- adjust the rate limit card layout to match the new element order and ensure the project pill stays visible
- verify the UI against acceptance criteria and run the www workspace checks

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: pre-existing lint violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd54aeb30832aac03c9b3cd367995