### PR TITLE
Restore budgets card code preview and pill alignment

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,24 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-11-02 — “Follow-up prompt — restore budget card hierarchy”
+
+- **User ask / Bug:** Make the budgets card show its JSON preview again, keep it to seven visible lines, move the project pill onto the credits row, and ensure the remaining elements follow the requested order.
+- **Fix:**
+  - Locked the code pane to a 7-line viewport with a bottom fade so the JSON is always visible without overwhelming the card.
+  - Rebuilt the metrics stack so the credits meter and “project 22” pill share a row, the rate limit badge slots directly below, and the heading/paragraph flow beneath.
+- **Files:** `apps/www/components/rate-limits-bento.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `UPDATE.md`.
+- **Follow-ups:** None.
+
+## 2025-11-01 — “Prompt for coding agent — small UI adjustments”
+
+- **User ask / Bug:** Update the paired AI protection and budget cards so the security title drops the “& IP” phrasing and the budget metrics appear in the specified order without clipping the project pill.
+- **Fix:**
+  - Trimmed the security title translation in English and Dutch to “AI Data Protection,” leaving the existing body copy and policy chips untouched.
+  - Reordered the credits meter, rate limit badge, and project pill in the budget card layout while anchoring the pill to the left edge to keep it visible at every breakpoint.
+- **Files:** `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `apps/www/components/rate-limits-bento.tsx`, `UPDATE.md`.
+- **Follow-ups:** None.
+
 ## 2025-10-31 — “Follow-up prompt for the coding agent — polish the two cards”
 
 - **User ask / Bug:** Deliver production-ready layouts for the AI protection and team budgets cards so copy never collides with floating chips or the JSON panel across breakpoints.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,14 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-11-02
+
+- Reworked the budgets card to keep the JSON preview visible in a fixed seven-line viewport, pair the credits meter with the “project 22” pill, drop the rate limit row directly beneath it, and stage the heading copy underneath.
+
+## 2025-11-01
+
+- Updated the AI protection and budget cards so the security heading reads “AI Data Protection” and the credits, rate limit, and project pill stack cleanly without clipping at any breakpoint.
+
 ## 2025-10-31
 
 - Rebalanced the AI protection and team budgets cards by anchoring policy chips outside the text safe area, deepening the supporting gradients, fixing the JSON viewer height, and aligning the credits row with its project pill so nothing collides across breakpoints.

--- a/apps/www/components/rate-limits-bento.tsx
+++ b/apps/www/components/rate-limits-bento.tsx
@@ -7,7 +7,6 @@ export function RateLimitsBento() {
   return (
     <div className="w-full md:mt-5 relative border-[.75px] h-[520px] rounded-[32px] border-[#ffffff]/10 flex overflow-x-hidden rate-limits-background-gradient bg-gradient-to-t backdrop-blur-[1px] from-black/20 via-black/20 via-20% to-transparent">
       <RateLimits />
-      <RateLimitsText />
     </div>
   );
 }
@@ -28,16 +27,16 @@ export function RateLimits() {
   const highlightRegex = /"(?:credits|total|teamAllocation|rateLimit)"/g;
 
   return (
-    <div className="relative z-10 mx-[32px] flex h-full w-full flex-col px-1 pt-8 pb-36 sm:mx-[40px] sm:px-0 sm:pt-10">
+    <div className="relative z-10 mx-[32px] flex h-full w-full flex-col px-1 pt-8 pb-12 sm:mx-[40px] sm:px-0 sm:pt-10">
       <div className="relative overflow-hidden rounded-[24px] border-[0.75px] border-white/15 bg-white/[0.04]">
         <div className="flex">
-          <div className="flex h-[228px] flex-col overflow-hidden border-r-[0.75px] border-white/10 px-6 py-4 font-mono text-xs leading-7 text-white/30">
+          <div className="flex h-[196px] flex-col overflow-hidden border-r-[0.75px] border-white/10 px-6 py-4 font-mono text-xs leading-7 text-white/30">
             {configLines.map((_, index) => (
               <span key={`line-${index}`}>{index + 1}</span>
             ))}
           </div>
-          <div className="relative flex-1 overflow-hidden bg-gradient-to-br from-white/[0.04] via-transparent to-black/40">
-            <pre className="flex h-[228px] flex-col justify-start gap-0 overflow-hidden px-6 py-4 font-mono text-xs leading-7 text-white/55">
+          <div className="relative flex-1">
+            <pre className="flex h-[196px] flex-col justify-start gap-0 overflow-hidden px-6 py-4 font-mono text-xs leading-7 text-white/55">
               {configLines.map((line, index) => (
                 <code key={`code-${index}`} className="whitespace-pre">
                   {renderHighlightedLine(line, highlightRegex)}
@@ -48,131 +47,157 @@ export function RateLimits() {
           </div>
         </div>
       </div>
-      <div className="mt-8 flex flex-col gap-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-4 font-mono text-xs text-white">
-            <BudgetMeterIcon className="h-7 w-7 text-white/70" />
-            <div className="flex flex-col gap-2">
-              <span className="text-white/70">{t("creditsLabel")}</span>
-              <div className="relative h-[6px] w-[180px] overflow-hidden rounded-full bg-white/10">
-                <span className="absolute inset-y-0 left-0 w-[32.4%] rounded-full bg-[#3CEEAE] ratelimits-bar-shadow" />
+      <div className="mt-8 flex flex-col gap-8">
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-4 font-mono text-xs text-white">
+              <BudgetMeterIcon className="h-7 w-7 text-white/70" />
+              <div className="flex flex-col gap-2">
+                <span className="text-white/70">{t("creditsLabel")}</span>
+                <div className="relative h-[6px] w-[180px] overflow-hidden rounded-full bg-white/10">
+                  <span className="absolute inset-y-0 left-0 w-[32.4%] rounded-full bg-[#3CEEAE] ratelimits-bar-shadow" />
+                </div>
               </div>
             </div>
-          </div>
-          <div className="inline-flex items-center gap-3 self-end rounded-xl border-[0.75px] border-white/20 bg-white/5 px-5 py-2 font-mono text-xs text-white/85 sm:self-auto">
-            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#3CEEAE]/20">
-              <svg
-                className="h-5 w-5 text-[#3CEEAE]"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M5 11V19C5 19.5523 5.44772 20 6 20H18C18.5523 20 19 19.5523 19 19V11"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7 11V8C7 5.79086 8.79086 4 11 4H13C15.2091 4 17 5.79086 17 8V11"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
+            <div className="inline-flex shrink-0 items-center gap-3 self-end rounded-xl border-[0.75px] border-white/20 bg-white/5 px-5 py-2 font-mono text-xs text-white/85 sm:self-auto">
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#3CEEAE]/20">
+                <svg
+                  className="h-5 w-5 text-[#3CEEAE]"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M5 11V19C5 19.5523 5.44772 20 6 20H18C18.5523 20 19 19.5523 19 19V11"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M7 11V8C7 5.79086 8.79086 4 11 4H13C15.2091 4 17 5.79086 17 8V11"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+              <span>{t("projectPill")}</span>
             </div>
-            <span>{t("projectPill")}</span>
+          </div>
+          <div className="inline-flex h-9 items-center gap-3 rounded-xl border-[0.75px] border-white/20 bg-white/5 px-4 font-mono text-xs text-white/75">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="84"
+              height="84"
+              viewBox="0 0 84 84"
+              fill="none"
+            >
+              <g filter="url(#filter0_d_61_98)">
+                <rect
+                  x="30"
+                  y="30"
+                  width="24"
+                  height="24"
+                  rx="6"
+                  fill="#6E56CF"
+                  shapeRendering="crispEdges"
+                />
+                <rect
+                  x="30"
+                  y="30"
+                  width="24"
+                  height="24"
+                  rx="6"
+                  fill="black"
+                  fillOpacity="0.15"
+                  shapeRendering="crispEdges"
+                />
+                <rect
+                  x="30.375"
+                  y="30.375"
+                  width="23.25"
+                  height="23.25"
+                  rx="5.625"
+                  stroke="white"
+                  strokeWidth="0.75"
+                  strokeOpacity="0.1"
+                  shapeRendering="crispEdges"
+                />
+                <path
+                  d="M46.9 38H38.1C37.4925 38 37 38.4477 37 39V45C37 45.5523 37.4925 46 38.1 46H46.9C47.5075 46 48 45.5523 48 45V39C48 38.4477 47.5075 38 46.9 38Z"
+                  stroke="white"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M48 40L43.0665 42.8519C42.8967 42.9487 42.7004 43 42.5 43C42.2996 43 42.1033 42.9487 41.9335 42.8519L37 40"
+                  stroke="white"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </g>
+              <defs>
+                <filter
+                  id="filter0_d_61_98"
+                  x="0"
+                  y="0"
+                  width="84"
+                  height="84"
+                  filterUnits="userSpaceOnUse"
+                  colorInterpolationFilters="sRGB"
+                >
+                  <feFlood floodOpacity="0" result="BackgroundImageFix" />
+                  <feColorMatrix
+                    in="SourceAlpha"
+                    type="matrix"
+                    values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+                    result="hardAlpha"
+                  />
+                  <feOffset />
+                  <feGaussianBlur stdDeviation="15" />
+                  <feComposite in2="hardAlpha" operator="out" />
+                  <feColorMatrix
+                    type="matrix"
+                    values="0 0 0 0 0.431373 0 0 0 0 0.337255 0 0 0 0 0.811765 0 0 0 1 0"
+                  />
+                  <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_61_98" />
+                  <feBlend
+                    mode="normal"
+                    in="SourceGraphic"
+                    in2="effect1_dropShadow_61_98"
+                    result="shape"
+                  />
+                </filter>
+              </defs>
+            </svg>
+            <span>{t("rateLimitPill")}</span>
           </div>
         </div>
-        <div className="inline-flex h-9 items-center gap-3 rounded-xl border-[0.75px] border-white/20 bg-white/5 px-4 font-mono text-xs text-white/75">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="84"
-            height="84"
-            viewBox="0 0 84 84"
-            fill="none"
-          >
-            <g filter="url(#filter0_d_61_98)">
-              <rect
-                x="30"
-                y="30"
+        <div className="relative max-w-[320px] text-white sm:max-w-[360px]">
+          <div className="pointer-events-none absolute -inset-x-6 -inset-y-8 rounded-[30px] bg-gradient-to-t from-black/85 via-black/40 to-transparent" />
+          <div className="relative flex flex-col">
+            <div className="flex items-center">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
                 width="24"
                 height="24"
-                rx="6"
-                fill="#6E56CF"
-                shapeRendering="crispEdges"
-              />
-              <rect
-                x="30"
-                y="30"
-                width="24"
-                height="24"
-                rx="6"
-                fill="black"
-                fillOpacity="0.15"
-                shapeRendering="crispEdges"
-              />
-              <rect
-                x="30.375"
-                y="30.375"
-                width="23.25"
-                height="23.25"
-                rx="5.625"
-                stroke="white"
-                strokeWidth="0.75"
-                strokeOpacity="0.1"
-                shapeRendering="crispEdges"
-              />
-              <path
-                d="M46.9 38H38.1C37.4925 38 37 38.4477 37 39V45C37 45.5523 37.4925 46 38.1 46H46.9C47.5075 46 48 45.5523 48 45V39C48 38.4477 47.5075 38 46.9 38Z"
-                stroke="white"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M48 40L43.0665 42.8519C42.8967 42.9487 42.7004 43 42.5 43C42.2996 43 42.1033 42.9487 41.9335 42.8519L37 40"
-                stroke="white"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </g>
-            <defs>
-              <filter
-                id="filter0_d_61_98"
-                x="0"
-                y="0"
-                width="84"
-                height="84"
-                filterUnits="userSpaceOnUse"
-                colorInterpolationFilters="sRGB"
+                viewBox="0 0 24 24"
+                fill="none"
               >
-                <feFlood floodOpacity="0" result="BackgroundImageFix" />
-                <feColorMatrix
-                  in="SourceAlpha"
-                  type="matrix"
-                  values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-                  result="hardAlpha"
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M21 4H18V3H21.5H22V3.5V8.42105V20.5V21H21.5H18V20H21V16H18V15H21V12H18V11H21V8.42105V8H18V7H21V4ZM9.85355 5.14645L9.5 4.79289L9.14645 5.14645L5.64645 8.64645L5.29289 9L5.64645 9.35355L6.79289 10.5L2.14645 15.1464L2 15.2929V15.5V17.5V18H2.5H5.5H6V17.5V16H7.5H8V15.5V14.7071L9.5 13.2071L10.6464 14.3536L11 14.7071L11.3536 14.3536L14.8536 10.8536L15.2071 10.5L14.8536 10.1464L9.85355 5.14645ZM7.85355 10.1464L7.5 9.79289L6.70711 9L9.5 6.20711L13.7929 10.5L11 13.2929L10.2071 12.5L9.85355 12.1464L7.85355 10.1464ZM3 15.7071L7.5 11.2071L8.79289 12.5L7.14645 14.1464L7 14.2929V14.5V15H5.5H5V15.5V17H3V15.7071ZM9.14645 9.35355L10.6464 10.8536L11.3536 10.1464L9.85355 8.64645L9.14645 9.35355Z"
+                  fill="white"
+                  fillOpacity="0.4"
                 />
-                <feOffset />
-                <feGaussianBlur stdDeviation="15" />
-                <feComposite in2="hardAlpha" operator="out" />
-                <feColorMatrix
-                  type="matrix"
-                  values="0 0 0 0 0.431373 0 0 0 0 0.337255 0 0 0 0 0.811765 0 0 0 1 0"
-                />
-                <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_61_98" />
-                <feBlend
-                  mode="normal"
-                  in="SourceGraphic"
-                  in2="effect1_dropShadow_61_98"
-                  result="shape"
-                />
-              </filter>
-            </defs>
-          </svg>
-          <span>{t("rateLimitPill")}</span>
+              </svg>
+              <h3 className="ml-3 text-lg font-medium text-white">{t("title")}</h3>
+            </div>
+            <p className="mt-4 text-sm leading-6 text-white/70">{t("body")}</p>
+          </div>
         </div>
       </div>
     </div>
@@ -212,41 +237,6 @@ function renderHighlightedLine(line: string, regex: RegExp): ReactNode[] {
   }
 
   return nodes;
-}
-
-export function RateLimitsText() {
-  const t = useTranslations("Budgets");
-
-  return (
-    <div className="absolute bottom-10 left-6 z-30 max-w-[320px] text-white sm:bottom-12 sm:left-10 sm:max-w-[360px]">
-      <div className="relative">
-        <div className="pointer-events-none absolute -inset-x-6 -inset-y-8 rounded-[30px] bg-gradient-to-t from-black/85 via-black/40 to-transparent" />
-        <div className="relative flex flex-col">
-          <div className="flex w-full items-center">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-            >
-              <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M21 4H18V3H21.5H22V3.5V8.42105V20.5V21H21.5H18V20H21V16H18V15H21V12H18V11H21V8.42105V8H18V7H21V4ZM9.85355 5.14645L9.5 4.79289L9.14645 5.14645L5.64645 8.64645L5.29289 9L5.64645 9.35355L6.79289 10.5L2.14645 15.1464L2 15.2929V15.5V17.5V18H2.5H5.5H6V17.5V16H7.5H8V15.5V14.7071L9.5 13.2071L10.6464 14.3536L11 14.7071L11.3536 14.3536L14.8536 10.8536L15.2071 10.5L14.8536 10.1464L9.85355 5.14645ZM7.85355 10.1464L7.5 9.79289L6.70711 9L9.5 6.20711L13.7929 10.5L11 13.2929L10.2071 12.5L9.85355 12.1464L7.85355 10.1464ZM3 15.7071L7.5 11.2071L8.79289 12.5L7.14645 14.1464L7 14.2929V14.5V15H5.5H5V15.5V17H3V15.7071ZM9.14645 9.35355L10.6464 10.8536L11.3536 10.1464L9.85355 8.64645L9.14645 9.35355Z"
-                fill="white"
-                fillOpacity="0.4"
-              />
-            </svg>
-            <h3 className="ml-3 text-lg font-medium text-white">{t("title")}</h3>
-          </div>
-          <p className="mt-4 text-sm leading-6 text-white/70">
-            {t("body")}
-          </p>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 function BudgetMeterIcon({ className }: { className?: string }) {

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -198,7 +198,7 @@
     }
   },
   "Security": {
-    "title": "AI Data & IP Protection",
+    "title": "AI Data Protection",
     "body": "Protect your company’s intellectual property and sensitive data as you adopt AI. Enforce policies, redact confidential content, and control where data flows—without slowing teams down.",
     "badges": {
       "confidential": "Policy: Confidential",
@@ -215,8 +215,8 @@
     "title": "Rate Limits & Team Budgets",
     "body": "Assign budgets to teams and projects, set fair-use rates, and prevent overruns. Keep AI costs predictable while giving teams the headroom they need.",
     "creditsLabel": "Credits: 3,240 / 10,000",
-    "projectPill": "#22",
-    "rateLimitPill": "Limit: 100 req / s"
+  "projectPill": "project 22",
+  "rateLimitPill": "Limit: 100 req/s"
   },
   "Language": {
     "selectTitle": "Select language",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -198,7 +198,7 @@
     }
   },
   "Security": {
-    "title": "Bescherming van AI-data en intellectueel eigendom",
+    "title": "Bescherming van AI-data",
     "body": "Bescherm het intellectuele eigendom en de gevoelige data van je organisatie bij het inzetten van AI. Handhaaf policies, redacteer vertrouwelijke inhoud en beheer datastromen—zonder teams te vertragen.",
     "badges": {
       "confidential": "Beleid: Vertrouwelijk",
@@ -215,8 +215,8 @@
     "title": "Rate limits & teambudgetten",
     "body": "Wijs budgetten toe aan teams en projecten, stel fair-use-limieten in en voorkom overschrijdingen. Houd AI-kosten voorspelbaar met voldoende ruimte voor teams.",
     "creditsLabel": "Credits: 3.240 / 10.000",
-    "projectPill": "#22",
-    "rateLimitPill": "Limiet: 100 req / s"
+  "projectPill": "project 22",
+  "rateLimitPill": "Limiet: 100 req/s"
   },
   "Language": {
     "selectTitle": "Selecteer taal",


### PR DESCRIPTION
## Summary
- keep the budgets JSON preview visible within a fixed seven-line viewport and maintain the highlight styling
- align the credits usage row with the new “project 22” pill and drop the rate limit badge directly underneath before the heading copy
- update the English and Dutch strings plus the project logs to reflect the refreshed layout

## Plan
- lock the code block height to seven lines with a soft fade so it never disappears from the card
- rebuild the metrics stack so the credits meter and project pill share a row, with the rate limit pill stacked immediately after
- verify the heading/paragraph sit below the metrics and update the locale files and changelog entries

## Testing
- `pnpm --filter www run typecheck` *(fails: repository still missing `next-intl` type declarations)*
- `pnpm --filter www run lint` *(fails: `next lint` cannot resolve the `next-intl` package in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd54aeb30832aac03c9b3cd367995