### PR TITLE
Refine rate limits card layout

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,24 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-11-02 — “Rate limits card follow-up adjustments”
+
+- **User ask / Bug:** Restore the rate limits card so the JSON sample remains visible within a seven-line window, relocate the project pill beside the credits line as “project 22,” and reorder the metrics so the limit badge precedes the heading and body copy.
+- **Fix:**
+  - Rebuilt the code preview container with a shared scroll region capped at seven lines and retained the bottom fade so overflow stays readable without hiding the block.
+  - Moved the project badge markup into the credits row, widened its padding, renamed the translation to “project 22,” and shifted the heading block beneath the limit badge for clear spacing.
+- **Files:** `apps/www/components/rate-limits-bento.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `UPDATE.md`.
+- **Follow-ups:** None.
+
+## 2025-11-01 — “Prompt for coding agent — small UI adjustments”
+
+- **User ask / Bug:** Update the paired AI protection and budget cards so the security title drops the “& IP” phrasing and the budget metrics appear in the specified order without clipping the project pill.
+- **Fix:**
+  - Trimmed the security title translation in English and Dutch to “AI Data Protection,” leaving the existing body copy and policy chips untouched.
+  - Reordered the credits meter, rate limit badge, and project pill in the budget card layout while anchoring the pill to the left edge to keep it visible at every breakpoint.
+- **Files:** `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `apps/www/components/rate-limits-bento.tsx`, `UPDATE.md`.
+- **Follow-ups:** None.
+
 ## 2025-10-31 — “Follow-up prompt for the coding agent — polish the two cards”
 
 - **User ask / Bug:** Deliver production-ready layouts for the AI protection and team budgets cards so copy never collides with floating chips or the JSON panel across breakpoints.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,14 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-11-02
+
+- Rebuilt the rate limits card stack so the JSON pane stays visible with a seven-line cap, the credits row anchors the “project 22” pill, and the heading block sits cleanly beneath the limit badge.
+
+## 2025-11-01
+
+- Updated the AI protection and budget cards so the security heading reads “AI Data Protection” and the credits, rate limit, and project pill stack cleanly without clipping at any breakpoint.
+
 ## 2025-10-31
 
 - Rebalanced the AI protection and team budgets cards by anchoring policy chips outside the text safe area, deepening the supporting gradients, fixing the JSON viewer height, and aligning the credits row with its project pill so nothing collides across breakpoints.

--- a/apps/www/components/rate-limits-bento.tsx
+++ b/apps/www/components/rate-limits-bento.tsx
@@ -7,7 +7,6 @@ export function RateLimitsBento() {
   return (
     <div className="w-full md:mt-5 relative border-[.75px] h-[520px] rounded-[32px] border-[#ffffff]/10 flex overflow-x-hidden rate-limits-background-gradient bg-gradient-to-t backdrop-blur-[1px] from-black/20 via-black/20 via-20% to-transparent">
       <RateLimits />
-      <RateLimitsText />
     </div>
   );
 }
@@ -28,62 +27,62 @@ export function RateLimits() {
   const highlightRegex = /"(?:credits|total|teamAllocation|rateLimit)"/g;
 
   return (
-    <div className="relative z-10 mx-[32px] flex h-full w-full flex-col px-1 pt-8 pb-36 sm:mx-[40px] sm:px-0 sm:pt-10">
+    <div className="relative z-10 mx-[32px] flex h-full w-full flex-col px-1 pt-8 pb-10 sm:mx-[40px] sm:px-0 sm:pt-10">
       <div className="relative overflow-hidden rounded-[24px] border-[0.75px] border-white/15 bg-white/[0.04]">
-        <div className="flex">
-          <div className="flex h-[228px] flex-col overflow-hidden border-r-[0.75px] border-white/10 px-6 py-4 font-mono text-xs leading-7 text-white/30">
+        <div className="relative flex max-h-[228px] overflow-y-auto">
+          <div className="flex flex-none flex-col border-r-[0.75px] border-white/10 px-6 py-4 font-mono text-xs leading-7 text-white/30">
             {configLines.map((_, index) => (
               <span key={`line-${index}`}>{index + 1}</span>
             ))}
           </div>
-          <div className="relative flex-1 overflow-hidden bg-gradient-to-br from-white/[0.04] via-transparent to-black/40">
-            <pre className="flex h-[228px] flex-col justify-start gap-0 overflow-hidden px-6 py-4 font-mono text-xs leading-7 text-white/55">
+          <div className="relative flex-1 bg-gradient-to-br from-white/[0.04] via-transparent to-black/40">
+            <pre className="flex min-h-full flex-col justify-start gap-0 px-6 py-4 font-mono text-xs leading-7 text-white/55">
               {configLines.map((line, index) => (
                 <code key={`code-${index}`} className="whitespace-pre">
                   {renderHighlightedLine(line, highlightRegex)}
                 </code>
               ))}
             </pre>
-            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-black via-black/35 to-transparent" />
           </div>
         </div>
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-black via-black/35 to-transparent" />
       </div>
       <div className="mt-8 flex flex-col gap-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-4 font-mono text-xs text-white">
-            <BudgetMeterIcon className="h-7 w-7 text-white/70" />
-            <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-3 font-mono text-xs text-white">
+            <div className="flex items-center gap-4 text-white">
+              <BudgetMeterIcon className="h-7 w-7 text-white/70" />
               <span className="text-white/70">{t("creditsLabel")}</span>
-              <div className="relative h-[6px] w-[180px] overflow-hidden rounded-full bg-white/10">
-                <span className="absolute inset-y-0 left-0 w-[32.4%] rounded-full bg-[#3CEEAE] ratelimits-bar-shadow" />
+            </div>
+            <div className="ml-auto inline-flex shrink-0 items-center gap-3 rounded-xl border-[0.75px] border-white/20 bg-white/5 px-5 py-2 font-mono text-xs text-white/85">
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#3CEEAE]/20">
+                <svg
+                  className="h-5 w-5 text-[#3CEEAE]"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M5 11V19C5 19.5523 5.44772 20 6 20H18C18.5523 20 19 19.5523 19 19V11"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M7 11V8C7 5.79086 8.79086 4 11 4H13C15.2091 4 17 5.79086 17 8V11"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
               </div>
+              <span className="whitespace-nowrap">{t("projectPill")}</span>
             </div>
           </div>
-          <div className="inline-flex items-center gap-3 self-end rounded-xl border-[0.75px] border-white/20 bg-white/5 px-5 py-2 font-mono text-xs text-white/85 sm:self-auto">
-            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#3CEEAE]/20">
-              <svg
-                className="h-5 w-5 text-[#3CEEAE]"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M5 11V19C5 19.5523 5.44772 20 6 20H18C18.5523 20 19 19.5523 19 19V11"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M7 11V8C7 5.79086 8.79086 4 11 4H13C15.2091 4 17 5.79086 17 8V11"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-            <span>{t("projectPill")}</span>
+          <div className="relative h-[6px] w-[180px] overflow-hidden rounded-full bg-white/10">
+            <span className="absolute inset-y-0 left-0 w-[32.4%] rounded-full bg-[#3CEEAE] ratelimits-bar-shadow" />
           </div>
         </div>
         <div className="inline-flex h-9 items-center gap-3 rounded-xl border-[0.75px] border-white/20 bg-white/5 px-4 font-mono text-xs text-white/75">
@@ -175,6 +174,7 @@ export function RateLimits() {
           <span>{t("rateLimitPill")}</span>
         </div>
       </div>
+      <RateLimitsText className="mt-auto pt-8 sm:pt-10" />
     </div>
   );
 }
@@ -214,11 +214,19 @@ function renderHighlightedLine(line: string, regex: RegExp): ReactNode[] {
   return nodes;
 }
 
-export function RateLimitsText() {
+export function RateLimitsText({ className = "" }: { className?: string }) {
   const t = useTranslations("Budgets");
+  const containerClasses = [
+    "max-w-[320px]",
+    "text-white",
+    "sm:max-w-[360px]",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
-    <div className="absolute bottom-10 left-6 z-30 max-w-[320px] text-white sm:bottom-12 sm:left-10 sm:max-w-[360px]">
+    <div className={containerClasses}>
       <div className="relative">
         <div className="pointer-events-none absolute -inset-x-6 -inset-y-8 rounded-[30px] bg-gradient-to-t from-black/85 via-black/40 to-transparent" />
         <div className="relative flex flex-col">

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -198,7 +198,7 @@
     }
   },
   "Security": {
-    "title": "AI Data & IP Protection",
+    "title": "AI Data Protection",
     "body": "Protect your company’s intellectual property and sensitive data as you adopt AI. Enforce policies, redact confidential content, and control where data flows—without slowing teams down.",
     "badges": {
       "confidential": "Policy: Confidential",
@@ -215,7 +215,7 @@
     "title": "Rate Limits & Team Budgets",
     "body": "Assign budgets to teams and projects, set fair-use rates, and prevent overruns. Keep AI costs predictable while giving teams the headroom they need.",
     "creditsLabel": "Credits: 3,240 / 10,000",
-    "projectPill": "#22",
+    "projectPill": "project 22",
     "rateLimitPill": "Limit: 100 req / s"
   },
   "Language": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -198,7 +198,7 @@
     }
   },
   "Security": {
-    "title": "Bescherming van AI-data en intellectueel eigendom",
+    "title": "Bescherming van AI-data",
     "body": "Bescherm het intellectuele eigendom en de gevoelige data van je organisatie bij het inzetten van AI. Handhaaf policies, redacteer vertrouwelijke inhoud en beheer datastromen—zonder teams te vertragen.",
     "badges": {
       "confidential": "Beleid: Vertrouwelijk",
@@ -215,7 +215,7 @@
     "title": "Rate limits & teambudgetten",
     "body": "Wijs budgetten toe aan teams en projecten, stel fair-use-limieten in en voorkom overschrijdingen. Houd AI-kosten voorspelbaar met voldoende ruimte voor teams.",
     "creditsLabel": "Credits: 3.240 / 10.000",
-    "projectPill": "#22",
+    "projectPill": "project 22",
     "rateLimitPill": "Limiet: 100 req / s"
   },
   "Language": {


### PR DESCRIPTION
## Summary
- rename the security card heading string to “AI Data Protection” in both locales while keeping body copy and badges unchanged
- rebuild the rate limits card stack so the JSON pane stays visible with a seven-line cap, the credits row anchors the “project 22” pill, and the heading block sits beneath the limit badge
- document the work in UPDATE.md and FIX.md

## Plan
- audit the rate limits card layout to ensure the code sample stays visible and capped at seven lines
- reposition the credits, limit badge, and project pill to match the requested ordering and alignment
- run the www workspace typecheck and lint commands

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: pre-existing violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd54aeb30832aac03c9b3cd367995