### PR TITLE
Swap latency section visual for workflow diagram

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,15 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-11-04 — “Prompt for the coding agent — swap visual + text (keep SVG, match size)”
+
+- **User ask / Bug:** Replace the latency map section visual with the provided workflow PNG and refresh the heading, description, and alt text with localized English/Dutch copy while preserving the layout and original SVG asset in the repo.
+- **Fix:**
+  - Swapped the map SVG import for the workflow PNG, loading translations from a new `Workflows` namespace so the heading, body, and alt strings stay localized.
+  - Added the corresponding English and Dutch message entries to support the new copy and alt text.
+- **Files:** `apps/www/components/latency-bento.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `UPDATE.md`.
+- **Follow-ups:** None.
+
 ## 2025-11-03 — “Follow-up prompt — reveal full project pill”
 
 - **User ask / Bug:** Shift the budgets card’s “project 22” pill slightly left so the label is fully visible instead of clipping against the card edge.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,10 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-11-04
+
+- Swapped the latency map block for the workflow composition visual, matching the original layout while localizing the new English and Dutch copy plus alt text.
+
 ## 2025-11-03
 
 - Nudged the budgets card project pill inward so the “project 22” label remains fully visible while preserving the refreshed metrics stack.

--- a/apps/www/components/latency-bento.tsx
+++ b/apps/www/components/latency-bento.tsx
@@ -1,21 +1,29 @@
-import map from "../images/map.svg";
+import { getTranslations } from "next-intl/server";
+
+import chainOfApp from "../images/Chain_ofapp.png";
 import { ImageWithBlur } from "./image-with-blur";
 
-export function LatencyBento() {
+export async function LatencyBento() {
+  const t = await getTranslations("Workflows");
+
   return (
     <div className="w-full relative border-[.75px] h-[576px] rounded-[32px] border-[#ffffff]/10 flex overflow-x-hidden">
-      {/* <LatencyMap className="h-[500px] w-full" /> */}
       <ImageWithBlur
-        src={map}
-        alt="Animated map showing Unkey latency globally"
+        src={chainOfApp}
+        alt={t("imageAlt")}
         className="h-full sm:h-auto"
       />
-      <LatencyText />
+      <LatencyText title={t("title")} body={t("body")} />
     </div>
   );
 }
 
-export function LatencyText() {
+type LatencyTextProps = {
+  title: string;
+  body: string;
+};
+
+export function LatencyText({ title, body }: LatencyTextProps) {
   return (
     <div className="flex flex-col text-white absolute left-[20px] sm:left-[40px] xl:left-[40px] bottom-[40px] max-w-[330px]">
       <div className="flex items-center w-full">
@@ -34,11 +42,10 @@ export function LatencyText() {
             fillOpacity="0.4"
           />
         </svg>
-        <h3 className="ml-4 text-lg font-medium text-white">Global low latency</h3>
+        <h3 className="ml-4 text-lg font-medium text-white">{title}</h3>
       </div>
       <p className="mt-4 leading-6 text-white/60">
-        Unkey is fast globally, regardless of which cloud providers you're using or where your users
-        are located.
+        {body}
       </p>
     </div>
   );

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -211,12 +211,17 @@
       "residency": "Data Residency"
     }
   },
+  "Workflows": {
+    "title": "Organise Team Workflows",
+    "body": "The app lets teams design custom workflows to create and deliver the best AI-powered products.",
+    "imageAlt": "Workflow composition diagram"
+  },
   "Budgets": {
     "title": "Rate Limits & Team Budgets",
     "body": "Assign budgets to teams and projects, set fair-use rates, and prevent overruns. Keep AI costs predictable while giving teams the headroom they need.",
     "creditsLabel": "Credits: 3,240 / 10,000",
-  "projectPill": "project 22",
-  "rateLimitPill": "Limit: 100 req/s"
+    "projectPill": "project 22",
+    "rateLimitPill": "Limit: 100 req/s"
   },
   "Language": {
     "selectTitle": "Select language",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -211,12 +211,17 @@
       "residency": "Data-residentie"
     }
   },
+  "Workflows": {
+    "title": "Organiseer teamworkflows",
+    "body": "Met de app ontwerpen teams aangepaste workflows om de beste AI-gedreven producten te maken en te leveren.",
+    "imageAlt": "Workflowcompositie-diagram"
+  },
   "Budgets": {
     "title": "Rate limits & teambudgetten",
     "body": "Wijs budgetten toe aan teams en projecten, stel fair-use-limieten in en voorkom overschrijdingen. Houd AI-kosten voorspelbaar met voldoende ruimte voor teams.",
     "creditsLabel": "Credits: 3.240 / 10.000",
-  "projectPill": "project 22",
-  "rateLimitPill": "Limiet: 100 req/s"
+    "projectPill": "project 22",
+    "rateLimitPill": "Limiet: 100 req/s"
   },
   "Language": {
     "selectTitle": "Selecteer taal",


### PR DESCRIPTION
## Summary
- replace the latency bento image with the new workflow composition PNG while keeping the existing layout intact
- localize the refreshed heading, description, and image alt text through a new `Workflows` namespace
- log the change in the project UPDATE and FIX records

## Plan
- audit the existing latency bento component to understand its layout and translation requirements
- swap in the new PNG asset and ensure the component reads localized copy for text and alt content
- add English and Dutch strings for the new namespace and update project logs
- run the website lint and typecheck commands to confirm nothing regressed

## Testing
- [ ] `pnpm --filter www run lint` *(fails: repository already contains numerous lint errors unrelated to this change)*
- [x] `pnpm --filter www run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68cbe43fe838832ab1dea7d7ba75b507