### PR TITLE
Update hero copy and layout

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,15 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-11-05 — “Prompt for coding agent — update hero section text & layout”
+
+- **User ask / Bug:** Move the homepage hero copy block upward and replace the heading and paragraph with the provided English and Dutch messaging while keeping both CTA buttons intact.
+- **Fix:**
+  - Tightened the hero wrapper spacing with responsive margins and padding so the text stack sits closer to the navigation without losing vertical breathing room.
+  - Replaced the hero description key with a body string, loaded the new copy through next-intl, and fed translated CTA labels into the button components.
+- **Files:** `apps/www/components/hero/hero.tsx`, `apps/www/components/hero/hero-main-section.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `UPDATE.md`.
+- **Follow-ups:** None.
+
 ## 2025-11-04 — “Prompt for the coding agent — swap visual + text (keep SVG, match size)”
 
 - **User ask / Bug:** Replace the latency map section visual with the provided workflow PNG and refresh the heading, description, and alt text with localized English/Dutch copy while preserving the layout and original SVG asset in the repo.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,10 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-11-05
+
+- Lifted the homepage hero content closer to the top with responsive padding while refreshing the English and Dutch copy plus CTA labels to spotlight AI productivity and performance.
+
 ## 2025-11-04
 
 - Swapped the latency map block for the workflow composition visual, matching the original layout while localizing the new English and Dutch copy plus alt text.

--- a/apps/www/components/hero/hero-main-section.tsx
+++ b/apps/www/components/hero/hero-main-section.tsx
@@ -5,27 +5,43 @@ import { BookOpen, ChevronRight, LogIn } from "lucide-react";
 
 type HeroMainSectionProps = {
   title: string;
-  description: string;
+  body: string;
+  primaryCtaLabel: string;
+  secondaryCtaLabel: string;
 };
 
-export function HeroMainSection({ title, description }: HeroMainSectionProps) {
+export function HeroMainSection({
+  title,
+  body,
+  primaryCtaLabel,
+  secondaryCtaLabel,
+}: HeroMainSectionProps) {
   return (
-    <div className="relative flex flex-col items-center text-center ">
+    <div className="relative flex flex-col items-center text-center">
       <h1 className="bg-gradient-to-br text-balance text-transparent bg-gradient-stop bg-clip-text from-white via-white via-30% to-white/30  font-medium text-6xl leading-none xl:text-[82px] tracking-tighter">
         {title}
       </h1>
 
       <p className="mt-6 sm:mt-8 bg-gradient-to-br text-transparent text-balance bg-gradient-stop bg-clip-text max-w-sm sm:max-w-lg xl:max-w-4xl from-white/70 via-white/70 via-40% to-white/30 text-base md:text-lg">
-        {description}
+        {body}
       </p>
 
       <div className="flex items-center gap-6 mt-16">
         <Link href="https://app.unkey.com" className="group">
-          <PrimaryButton shiny IconLeft={LogIn} label="Get started" className="h-10" />
+          <PrimaryButton
+            shiny
+            IconLeft={LogIn}
+            label={primaryCtaLabel}
+            className="h-10"
+          />
         </Link>
 
         <Link href="/docs" className="hidden sm:flex">
-          <SecondaryButton IconLeft={BookOpen} label="Documentation" IconRight={ChevronRight} />
+          <SecondaryButton
+            IconLeft={BookOpen}
+            label={secondaryCtaLabel}
+            IconRight={ChevronRight}
+          />
         </Link>
       </div>
     </div>

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -8,6 +8,7 @@ import mainboard from "@/images/mainboard.svg";
 import { SubHeroMainboard } from "./hero-sub-mainboard";
 export const Hero: React.FC = () => {
   const t = useTranslations("Hero");
+  const cta = useTranslations("CTA");
 
   const containerVariants = {
     hidden: {},
@@ -29,7 +30,7 @@ export const Hero: React.FC = () => {
 
   return (
     <motion.div
-      className="relative w-full flex flex-col items-center justify-between mt-48"
+      className="relative w-full flex flex-col items-center justify-between mt-24 sm:mt-28 md:mt-32 lg:mt-36 xl:mt-40 pb-20 sm:pb-24 md:pb-32 lg:pb-36"
       variants={containerVariants}
       initial="hidden"
       animate="visible"
@@ -37,7 +38,9 @@ export const Hero: React.FC = () => {
       <motion.div variants={childVariants}>
         <HeroMainSection
           title={t("title")}
-          description={t("description")}
+          body={t("body")}
+          primaryCtaLabel={cta("getStarted")}
+          secondaryCtaLabel={cta("exploreProjects")}
         />
       </motion.div>
 

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -31,8 +31,8 @@
     }
   },
   "Hero": {
-    "title": "Your Transformation Partner for the Age of AI",
-    "description": "We help companies adapt successfully and sustainably to the challenges and opportunities that Artificial Intelligence brings."
+    "title": "Optimised for AI Productivity and Performance",
+    "body": "Our platform is built to maximise companies’ productivity, cost efficiency, and performance in the field of AI. It leverages existing business structures to amplify the gains regular AI systems already provide, while offering deep customisability and a focus on long-term usage. We ensure the best model is always available and selected for each use case, with a strong emphasis on ease of use."
   },
   "LogoCloud": {
     "label": "Partners"

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -31,8 +31,8 @@
     }
   },
   "Hero": {
-    "title": "Jouw transformatiepartner voor het AI-tijdperk",
-    "description": "Wij helpen bedrijven zich succesvol en duurzaam aan te passen aan de kansen en uitdagingen die Kunstmatige Intelligentie met zich meebrengt."
+    "title": "Geoptimaliseerd voor AI-productiviteit en prestaties",
+    "body": "Ons platform is ontworpen om de productiviteit, kostenefficiëntie en prestaties van bedrijven op het gebied van AI te maximaliseren. Het benut bestaande bedrijfsstructuren om de voordelen van reguliere AI-systemen te versterken, en biedt uitgebreide aanpasbaarheid met oog voor langdurig gebruik. We zorgen ervoor dat altijd het beste model voor elke use-case beschikbaar is en geselecteerd wordt, met gebruiksgemak als hoogste prioriteit."
   },
   "LogoCloud": {
     "label": "Partners"


### PR DESCRIPTION
## Summary
- Move the homepage hero stack closer to the navigation with responsive spacing so the block sits higher without crowding the top.
- Replace the hero heading and body copy with the new AI productivity messaging and wire the CTA labels through next-intl translations in both English and Dutch.
- Record the update in `UPDATE.md` and `FIX.md` for continuity.

## Plan
- Inspect `apps/www/components/hero/hero.tsx` and `hero-main-section.tsx` to identify the spacing hooks and translation usage.
- Adjust hero wrapper padding/margins to raise the text stack while keeping the decorative assets aligned across breakpoints.
- Update `messages/en.json` and `messages/nl.json` with the new hero body copy and reuse the CTA keys for button labels.
- Refresh the project logs (`UPDATE.md`, `FIX.md`) and run typecheck/lint/build to validate the change set.

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: pre-existing lint errors in unrelated routes)*
- `pnpm -w turbo run build --filter=www` *(fails: same pre-existing lint violations surfaced during build)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf37e68fc832a9a5cb352dc3c8e8d