### PR TITLE
Restore hero copy to original messaging

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,24 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-09-18 — “Restore homepage hero messaging to original copy”
+
+- **User ask / Bug:** Keep the updated hero layout and localized CTAs but revert the hero heading and paragraph to the original English/Dutch “Transformation Partner” messaging.
+- **Fix:**
+  - Replaced the `Hero.title`/`Hero.body` strings in the English and Dutch catalogs with the original copy while leaving the component wiring and CTA localization intact.
+  - Recorded the change in the project logs for future reference.
+- **Files:** `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `UPDATE.md`, `FIX.md`.
+- **Follow-ups:** None.
+
+## 2025-11-05 — “Prompt for coding agent — update homepage hero section”
+
+- **User ask / Bug:** Raise the homepage hero copy block closer to the hero background while replacing its heading, body, and CTA labels with localized English/Dutch strings.
+- **Fix:**
+  - Added the new hero messaging under `Hero.title`/`Hero.body` in the locale catalogs and updated the hero component to read the CTA labels from the existing translation namespace.
+  - Replaced the hard-coded hero copy on the landing page with the translation helper and reduced the section’s top margin so the heading/button stack sits higher across breakpoints, polishing the Dutch “Explore All projects” label.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `apps/www/components/hero/hero-main-section.tsx`, `apps/www/components/hero/hero.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `UPDATE.md`.
+- **Follow-ups:** None.
+
 ## 2025-11-04 — “Prompt for the coding agent — swap visual + text (keep SVG, match size)”
 
 - **User ask / Bug:** Replace the latency map section visual with the provided workflow PNG and refresh the heading, description, and alt text with localized English/Dutch copy while preserving the layout and original SVG asset in the repo.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,14 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-09-18
+
+- Restored the homepage hero headline and paragraph to the original “Your Transformation Partner” messaging while keeping the tightened layout and CTA localization from the prior update.
+
+## 2025-11-05
+
+- Refreshed the homepage hero CTA block with new localized English and Dutch messaging, lifted the heading group higher within the hero, and wired the project explorer button through the CTA translations.
+
 ## 2025-11-04
 
 - Swapped the latency map block for the workflow composition visual, matching the original layout while localizing the new English and Dutch copy plus alt text.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -71,9 +71,10 @@ export async function generateMetadata({
 }
 
 export default async function Landing() {
-  const [cta, platform] = await Promise.all([
+  const [cta, platform, hero] = await Promise.all([
     getTranslations("CTA"),
     getTranslations("Platform"),
+    getTranslations("Hero"),
   ]);
 
   return (
@@ -124,10 +125,10 @@ export default async function Landing() {
             <OssLight className="absolute scale-[2] left-[-70px] sm:left-[70px] md:left-[150px] lg:left-[200px] xl:left-[420px] top-[-250px]" />
           </div>
 
-          <Section className="mt-16 md:mt-32">
+          <Section className="mt-10 md:mt-20 lg:mt-24">
             <SectionTitle
-              title="Secure and scalable from day one"
-              text="Start secure. Our platform includes essential security features such as one-way hashed keys, audit logs, and rate limiting, enabling rapid API iteration and scaling."
+              title={hero("title")}
+              text={hero("body")}
               align="center"
             >
               <div className="flex mt-10 mb-10 space-x-6">

--- a/apps/www/components/hero/hero-main-section.tsx
+++ b/apps/www/components/hero/hero-main-section.tsx
@@ -5,10 +5,17 @@ import { BookOpen, ChevronRight, LogIn } from "lucide-react";
 
 type HeroMainSectionProps = {
   title: string;
-  description: string;
+  body: string;
+  primaryCtaLabel: string;
+  secondaryCtaLabel: string;
 };
 
-export function HeroMainSection({ title, description }: HeroMainSectionProps) {
+export function HeroMainSection({
+  title,
+  body,
+  primaryCtaLabel,
+  secondaryCtaLabel,
+}: HeroMainSectionProps) {
   return (
     <div className="relative flex flex-col items-center text-center ">
       <h1 className="bg-gradient-to-br text-balance text-transparent bg-gradient-stop bg-clip-text from-white via-white via-30% to-white/30  font-medium text-6xl leading-none xl:text-[82px] tracking-tighter">
@@ -16,16 +23,25 @@ export function HeroMainSection({ title, description }: HeroMainSectionProps) {
       </h1>
 
       <p className="mt-6 sm:mt-8 bg-gradient-to-br text-transparent text-balance bg-gradient-stop bg-clip-text max-w-sm sm:max-w-lg xl:max-w-4xl from-white/70 via-white/70 via-40% to-white/30 text-base md:text-lg">
-        {description}
+        {body}
       </p>
 
       <div className="flex items-center gap-6 mt-16">
         <Link href="https://app.unkey.com" className="group">
-          <PrimaryButton shiny IconLeft={LogIn} label="Get started" className="h-10" />
+          <PrimaryButton
+            shiny
+            IconLeft={LogIn}
+            label={primaryCtaLabel}
+            className="h-10"
+          />
         </Link>
 
         <Link href="/docs" className="hidden sm:flex">
-          <SecondaryButton IconLeft={BookOpen} label="Documentation" IconRight={ChevronRight} />
+          <SecondaryButton
+            IconLeft={BookOpen}
+            label={secondaryCtaLabel}
+            IconRight={ChevronRight}
+          />
         </Link>
       </div>
     </div>

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -7,7 +7,8 @@ import { HeroMainSection } from "./hero-main-section";
 import mainboard from "@/images/mainboard.svg";
 import { SubHeroMainboard } from "./hero-sub-mainboard";
 export const Hero: React.FC = () => {
-  const t = useTranslations("Hero");
+  const hero = useTranslations("Hero");
+  const cta = useTranslations("CTA");
 
   const containerVariants = {
     hidden: {},
@@ -36,8 +37,10 @@ export const Hero: React.FC = () => {
     >
       <motion.div variants={childVariants}>
         <HeroMainSection
-          title={t("title")}
-          description={t("description")}
+          title={hero("title")}
+          body={hero("body")}
+          primaryCtaLabel={cta("getStarted")}
+          secondaryCtaLabel={cta("exploreProjects")}
         />
       </motion.div>
 

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -32,7 +32,7 @@
   },
   "Hero": {
     "title": "Your Transformation Partner for the Age of AI",
-    "description": "We help companies adapt successfully and sustainably to the challenges and opportunities that Artificial Intelligence brings."
+    "body": "We help companies adapt successfully and sustainably to the challenges and opportunities that Artificial Intelligence brings."
   },
   "LogoCloud": {
     "label": "Partners"

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -32,7 +32,7 @@
   },
   "Hero": {
     "title": "Jouw transformatiepartner voor het AI-tijdperk",
-    "description": "Wij helpen bedrijven zich succesvol en duurzaam aan te passen aan de kansen en uitdagingen die Kunstmatige Intelligentie met zich meebrengt."
+    "body": "Wij helpen bedrijven zich succesvol en duurzaam aan te passen aan de kansen en uitdagingen die Kunstmatige Intelligentie met zich meebrengt."
   },
   "LogoCloud": {
     "label": "Partners"
@@ -49,7 +49,7 @@
   },
   "CTA": {
     "getStarted": "Begin Nu",
-    "exploreProjects": "Ontdek Alle projecten"
+    "exploreProjects": "Ontdek alle projecten"
   },
   "Analytics": {
     "requestAccess": "Vraag Toegang",


### PR DESCRIPTION
## Plan
- Reinstate the original English and Dutch hero headline/body copy while leaving the CTA localization and layout tweaks untouched.
- Update the project logs to document the revert for future agents.
- Re-run the website typecheck and lint tasks to confirm nothing regressed.

## Summary
- Replaced the `Hero.title`/`Hero.body` strings in the English and Dutch catalogs with the original “Transformation Partner” messaging that the user requested.
- Logged the adjustment in `UPDATE.md` and `FIX.md` so future contributors know why the hero copy reverted while other enhancements remain.

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: existing lint violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf7bf7df8832aba19d01b9a981905