### PR TITLE
Lift secondary hero CTA heading

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,15 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-11-07 — “Center CTA heading between hero cards”
+
+- **User ask / Bug:** Raise the "Optimised for AI Productivity and Performance" block so it aligns between the two hero cards
+  without shifting the rest of the layout.
+- **Fix:** Added a tighter top margin to the secondary hero `SectionTitle`, lifting the heading/paragraph stack while leaving the
+  card grid, CTAs, and background treatments untouched.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `UPDATE.md`, `FIX.md`.
+- **Follow-ups:** None.
+
 ## 2025-11-06 — “Decouple hero copy for stacked sections”
 
 - **User ask / Bug:** Keep the top-of-page hero text on the original “Transformation Partner” messaging while letting the lower CTA section display the new AI productivity copy; both blocks were sharing the same translation keys so they changed together.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,11 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-11-07
+
+- Raised the secondary hero CTA heading stack so it sits closer to the paired security and
+  budgeting cards while keeping the rest of the section layout untouched.
+
 ## 2025-11-06
 
 - Split the homepage hero translations so the main headline keeps the "Transformation Partner" copy while the lower CTA section now reads the new AI productivity messaging in both English and Dutch.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -127,6 +127,7 @@ export default async function Landing() {
 
           <Section className="mt-10 md:mt-20 lg:mt-24">
             <SectionTitle
+              className="mt-2 md:mt-8 lg:mt-16"
               title={hero("secondaryTitle")}
               text={hero("secondaryBody")}
               align="center"


### PR DESCRIPTION
## Summary
- lift the secondary hero CTA heading block higher by tightening its top margin so it sits between the two hero cards
- document the change in UPDATE.md and FIX.md with the new request and resolution details

## Plan
- inspect the hero CTA layout to confirm which component controls the secondary heading spacing
- adjust the SectionTitle margin so the copy block shifts upward without moving the surrounding cards
- record the user request and implementation notes in the project logs
- run the www workspace typecheck, lint, and build commands

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: pre-existing lint errors in unrelated files)*
- `pnpm -w turbo run build --filter=www` *(fails: same lint errors surfaced during build)*

------
https://chatgpt.com/codex/tasks/task_e_68cc49bd919c832aa50749a5cb7a7186