### PR TITLE
Center hero CTA stack within hero background

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,24 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-11-08 — “Recenter hero CTA stack vertically”
+
+- **User ask / Bug:** Move the "Optimised for AI Productivity and Performance" heading, paragraph, and buttons noticeably higher
+  so the block sits near the vertical middle of the hero background on desktop while keeping other layout pieces untouched.
+- **Fix:** Applied responsive negative top margins to the secondary hero `SectionTitle`, pulling the entire text/button stack up
+  ~130px on large screens without altering its internal spacing or the surrounding cards, and leaving mobile spacing relaxed.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `UPDATE.md`, `FIX.md`.
+- **Follow-ups:** None.
+
+## 2025-11-07 — “Center CTA heading between hero cards”
+
+- **User ask / Bug:** Raise the "Optimised for AI Productivity and Performance" block so it aligns between the two hero cards
+  without shifting the rest of the layout.
+- **Fix:** Added a tighter top margin to the secondary hero `SectionTitle`, lifting the heading/paragraph stack while leaving the
+  card grid, CTAs, and background treatments untouched.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `UPDATE.md`, `FIX.md`.
+- **Follow-ups:** None.
+
 ## 2025-11-06 — “Decouple hero copy for stacked sections”
 
 - **User ask / Bug:** Keep the top-of-page hero text on the original “Transformation Partner” messaging while letting the lower CTA section display the new AI productivity copy; both blocks were sharing the same translation keys so they changed together.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,17 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-11-08
+
+- Re-centered the secondary hero CTA copy block within the hero background on desktop by
+  applying responsive negative margins that pull the heading, body, and buttons higher while
+  retaining their internal spacing and mobile breathing room.
+
+## 2025-11-07
+
+- Raised the secondary hero CTA heading stack so it sits closer to the paired security and
+  budgeting cards while keeping the rest of the section layout untouched.
+
 ## 2025-11-06
 
 - Split the homepage hero translations so the main headline keeps the "Transformation Partner" copy while the lower CTA section now reads the new AI productivity messaging in both English and Dutch.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -127,6 +127,7 @@ export default async function Landing() {
 
           <Section className="mt-10 md:mt-20 lg:mt-24">
             <SectionTitle
+              className="mt-2 md:-mt-10 lg:-mt-20 xl:-mt-32 2xl:-mt-36"
               title={hero("secondaryTitle")}
               text={hero("secondaryBody")}
               align="center"


### PR DESCRIPTION
## Summary
- lift the homepage secondary hero CTA block higher on desktop with responsive negative margins so the heading, body, and buttons sit near the hero’s midpoint
- keep the CTA stack’s internal spacing and mobile layout unchanged while documenting the adjustment in the project logs

## Plan
- Review the secondary hero SectionTitle spacing to quantify how much vertical lift is required for the CTA block
- Apply breakpoint-specific negative margins that center the text/button stack without disturbing the surrounding cards
- Verify that mobile spacing remains comfortable and record the change in UPDATE.md and FIX.md for continuity

## Testing
- `pnpm --filter www run typecheck` *(fails: repository still missing next-intl type declarations)*
- `pnpm --filter www run lint` *(fails: repository still missing the next-intl package referenced by next.config.mjs)*
- `pnpm -w turbo run build --filter=www` *(fails: repository still missing the next-intl package referenced by next.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68cc49bd919c832aa50749a5cb7a7186