### PR TITLE
Elevate secondary hero CTA block

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,24 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-11-08 — “Lift secondary CTA block into hero center”
+
+- **User ask / Bug:** Shift the "Optimised for AI Productivity and Performance" heading, paragraph, and button stack upward so
+  it sits closer to the middle of the hero background without disturbing adjacent content.
+- **Fix:** Replaced the secondary hero `SectionTitle` margin stack with responsive negative offsets so the block rises ~120px on
+  desktop while preserving the internal spacing between heading, body, and CTAs across breakpoints.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `UPDATE.md`, `FIX.md`.
+- **Follow-ups:** None.
+
+## 2025-11-07 — “Center CTA heading between hero cards”
+
+- **User ask / Bug:** Raise the "Optimised for AI Productivity and Performance" block so it aligns between the two hero cards
+  without shifting the rest of the layout.
+- **Fix:** Added a tighter top margin to the secondary hero `SectionTitle`, lifting the heading/paragraph stack while leaving the
+  card grid, CTAs, and background treatments untouched.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `UPDATE.md`, `FIX.md`.
+- **Follow-ups:** None.
+
 ## 2025-11-06 — “Decouple hero copy for stacked sections”
 
 - **User ask / Bug:** Keep the top-of-page hero text on the original “Transformation Partner” messaging while letting the lower CTA section display the new AI productivity copy; both blocks were sharing the same translation keys so they changed together.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,17 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-11-08
+
+- Lifted the “Optimised for AI Productivity and Performance” heading/paragraph/button stack
+  further into the hero background by tightening its responsive top margins while preserving
+  the surrounding layout.
+
+## 2025-11-07
+
+- Raised the secondary hero CTA heading stack so it sits closer to the paired security and
+  budgeting cards while keeping the rest of the section layout untouched.
+
 ## 2025-11-06
 
 - Split the homepage hero translations so the main headline keeps the "Transformation Partner" copy while the lower CTA section now reads the new AI productivity messaging in both English and Dutch.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -127,6 +127,7 @@ export default async function Landing() {
 
           <Section className="mt-10 md:mt-20 lg:mt-24">
             <SectionTitle
+              className="mt-6 md:-mt-16 lg:-mt-20 xl:-mt-[6.5rem]"
               title={hero("secondaryTitle")}
               text={hero("secondaryBody")}
               align="center"


### PR DESCRIPTION
## Summary
- retune the secondary hero SectionTitle margins so the "Optimised for AI Productivity and Performance" block sits closer to the center of the background on larger screens without altering its internal spacing
- record the new request and response in FIX.md and UPDATE.md for future agents

## Plan
- inspect the secondary hero SectionTitle spacing within page.tsx
- adjust its responsive margin utilities to lift the block on desktop while maintaining the existing heading/paragraph/button rhythm
- update FIX.md and UPDATE.md with the new request context and implementation notes
- run the www workspace typecheck, lint, and build commands

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: pre-existing lint violations in other files)*
- `pnpm -w turbo run build --filter=www` *(fails: same lint violations surfaced during the build step)*

------
https://chatgpt.com/codex/tasks/task_e_68cc49bd919c832aa50749a5cb7a7186