### PR TITLE
Add breathing room below hero CTA block

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,35 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-11-09 — “Add breathing room below hero CTA block”
+
+- **User ask / Bug:** After raising the "Optimised for AI Productivity and Performance"
+  stack, it now sits too close to the policy/security cards beneath it, leaving the
+  sections feeling cramped across breakpoints.
+- **Fix:** Added a responsive bottom margin to the secondary hero `SectionTitle`,
+  keeping the heading/paragraph/buttons anchored in their higher position while
+  opening an ~80–100px gap before the card grid on mobile, tablet, and desktop.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `UPDATE.md`, `FIX.md`.
+- **Follow-ups:** None.
+
+## 2025-11-08 — “Recenter hero CTA stack vertically”
+
+- **User ask / Bug:** Move the "Optimised for AI Productivity and Performance" heading, paragraph, and buttons noticeably higher
+  so the block sits near the vertical middle of the hero background on desktop while keeping other layout pieces untouched.
+- **Fix:** Applied responsive negative top margins to the secondary hero `SectionTitle`, pulling the entire text/button stack up
+  ~130px on large screens without altering its internal spacing or the surrounding cards, and leaving mobile spacing relaxed.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `UPDATE.md`, `FIX.md`.
+- **Follow-ups:** None.
+
+## 2025-11-07 — “Center CTA heading between hero cards”
+
+- **User ask / Bug:** Raise the "Optimised for AI Productivity and Performance" block so it aligns between the two hero cards
+  without shifting the rest of the layout.
+- **Fix:** Added a tighter top margin to the secondary hero `SectionTitle`, lifting the heading/paragraph stack while leaving the
+  card grid, CTAs, and background treatments untouched.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `UPDATE.md`, `FIX.md`.
+- **Follow-ups:** None.
+
 ## 2025-11-06 — “Decouple hero copy for stacked sections”
 
 - **User ask / Bug:** Keep the top-of-page hero text on the original “Transformation Partner” messaging while letting the lower CTA section display the new AI productivity copy; both blocks were sharing the same translation keys so they changed together.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,23 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-11-09
+
+- Added a responsive bottom margin to the secondary hero CTA `SectionTitle` so the
+  heading, body, and buttons stay elevated while leaving roughly 80–100px of
+  breathing room before the policy/security card grid on every breakpoint.
+
+## 2025-11-08
+
+- Re-centered the secondary hero CTA copy block within the hero background on desktop by
+  applying responsive negative margins that pull the heading, body, and buttons higher while
+  retaining their internal spacing and mobile breathing room.
+
+## 2025-11-07
+
+- Raised the secondary hero CTA heading stack so it sits closer to the paired security and
+  budgeting cards while keeping the rest of the section layout untouched.
+
 ## 2025-11-06
 
 - Split the homepage hero translations so the main headline keeps the "Transformation Partner" copy while the lower CTA section now reads the new AI productivity messaging in both English and Dutch.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -127,6 +127,7 @@ export default async function Landing() {
 
           <Section className="mt-10 md:mt-20 lg:mt-24">
             <SectionTitle
+              className="mt-2 md:-mt-10 lg:-mt-20 xl:-mt-32 2xl:-mt-36 mb-20 lg:mb-24"
               title={hero("secondaryTitle")}
               text={hero("secondaryBody")}
               align="center"


### PR DESCRIPTION
## Summary
- add responsive bottom margin to the secondary hero CTA SectionTitle so the AI productivity block keeps its raised position while opening ~80–100px of space before the policy cards
- log the spacing adjustment in UPDATE.md and FIX.md for future agents

## Plan
- Inspect the homepage secondary hero SectionTitle to pinpoint where to introduce additional spacing beneath the CTA stack
- Apply Tailwind margin utilities that preserve the elevated top offset while creating the required gap before the card grid
- Update the project change/fix logs and re-run the standard www typecheck/lint/build commands

## Testing
- `pnpm --filter www run typecheck` *(fails: repository still missing next-intl packages/types)*
- `pnpm --filter www run lint` *(fails: next-intl package missing for next.config.mjs)*
- `pnpm -w turbo run build --filter=www` *(fails: next-intl package missing for next.config.mjs during build)*

------
https://chatgpt.com/codex/tasks/task_e_68cc49bd919c832aa50749a5cb7a7186