### PR TITLE
Ensure landing CTA uses locale-specific translations

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,22 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-11-08 — “Dutch CTA fallback shows English copy”
+
+- **User ask / Bug:** The lower homepage CTA still rendered the English heading and paragraph when visiting the Dutch locale.
+- **Fix:**
+  - Updated the locale landing page to pass the active locale into each `getTranslations` call so the section resolves Dutch messages instead of the English fallback.
+  - Recorded the change in the project history files for future agents.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `UPDATE.md`, `FIX.md`.
+- **Follow-ups:** None.
+
+## 2025-11-07 — “Refine CTA translation copy”
+
+- **User ask / Bug:** Replace the hero CTA heading and paragraph text with the supplied refined English and Dutch messaging while leaving the rest of the page unchanged.
+- **Fix:** Updated the `Hero.secondaryBody` strings in the English and Dutch locale catalogs to match the provided copy without touching other sections.
+- **Files:** `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `UPDATE.md`, `FIX.md`.
+- **Follow-ups:** None.
+
 ## 2025-11-06 — “Decouple hero copy for stacked sections”
 
 - **User ask / Bug:** Keep the top-of-page hero text on the original “Transformation Partner” messaging while letting the lower CTA section display the new AI productivity copy; both blocks were sharing the same translation keys so they changed together.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,14 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-11-08
+
+- Ensured the homepage CTA section loads translations with the active locale so Dutch visitors see the localized heading and body copy instead of the English fallback.
+
+## 2025-11-07
+
+- Updated the hero CTA translations so the AI productivity heading keeps the refined English and Dutch body copy requested for the lower section.
+
 ## 2025-11-06
 
 - Split the homepage hero translations so the main headline keeps the "Transformation Partner" copy while the lower CTA section now reads the new AI productivity messaging in both English and Dutch.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -32,6 +32,12 @@ type LandingPageMetadataProps = {
   };
 };
 
+type LandingPageProps = {
+  params: {
+    locale: string;
+  };
+};
+
 export async function generateMetadata({
   params,
 }: LandingPageMetadataProps): Promise<Metadata> {
@@ -70,11 +76,19 @@ export async function generateMetadata({
   };
 }
 
-export default async function Landing() {
+export default async function Landing({
+  params,
+}: LandingPageProps) {
+  const { locale } = params;
+
+  if (!isLocale(locale)) {
+    notFound();
+  }
+
   const [cta, platform, hero] = await Promise.all([
-    getTranslations("CTA"),
-    getTranslations("Platform"),
-    getTranslations("Hero"),
+    getTranslations({ locale, namespace: "CTA" }),
+    getTranslations({ locale, namespace: "Platform" }),
+    getTranslations({ locale, namespace: "Hero" }),
   ]);
 
   return (

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -34,7 +34,7 @@
     "title": "Your Transformation Partner for the Age of AI",
     "body": "We help companies adapt successfully and sustainably to the challenges and opportunities that Artificial Intelligence brings.",
     "secondaryTitle": "Optimised for AI Productivity and Performance",
-    "secondaryBody": "Our platform is built to maximise companies' productivity, cost efficiency, and performance in the field of AI. It leverages existing business structures to amplify the gains regular AI systems already provide, while offering deep customisability and a focus on long-term usage. We ensure the best model is always available and selected for each use case, with a strong emphasis on ease of use."
+    "secondaryBody": "Our platform helps companies boost productivity, cut costs, and improve AI performance. It builds on existing structures to amplify results, while offering customisation, long-term reliability, and seamless model selection for every use case."
   },
   "LogoCloud": {
     "label": "Partners"

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -34,7 +34,7 @@
     "title": "Jouw transformatiepartner voor het AI-tijdperk",
     "body": "Wij helpen bedrijven zich succesvol en duurzaam aan te passen aan de kansen en uitdagingen die Kunstmatige Intelligentie met zich meebrengt.",
     "secondaryTitle": "Geoptimaliseerd voor AI-productiviteit en prestaties",
-    "secondaryBody": "Ons platform is ontworpen om de productiviteit, kostenefficiëntie en prestaties van bedrijven op het gebied van AI te maximaliseren. Het benut bestaande bedrijfsstructuren om de voordelen van reguliere AI-systemen te versterken, en biedt uitgebreide aanpasbaarheid met oog voor langdurig gebruik. We zorgen ervoor dat altijd het beste model voor elke use-case beschikbaar is en geselecteerd wordt, met gebruiksgemak als hoogste prioriteit."
+    "secondaryBody": "Ons platform helpt bedrijven productiever te werken, kosten te verlagen en AI-prestaties te verbeteren. Het bouwt voort op bestaande structuren om resultaten te versterken, en biedt aanpasbaarheid, langdurige betrouwbaarheid en eenvoudige modelselectie voor elke use-case."
   },
   "LogoCloud": {
     "label": "Partners"


### PR DESCRIPTION
## Plan
- Pass the active locale into the landing page translation lookups.
- Verify the Dutch CTA renders the localized copy instead of the English fallback.
- Document the fix in the project logs and run the www workspace checks.

## Summary
- Updated the landing page to accept the locale route parameter and fetch CTA, platform, and hero translations with the explicit locale so Dutch visitors no longer see English copy.
- Added dated entries to UPDATE.md and FIX.md describing the localization fix and its context.

## Testing
- pnpm --filter www run typecheck
- pnpm --filter www run lint *(fails: long-standing lint violations across legacy marketing pages)*
- pnpm -w turbo run build --filter=www *(fails: build re-runs lint and hits the same legacy violations)*

------
https://chatgpt.com/codex/tasks/task_e_68ccfcdd9b20832a94c9b6c38154b1e3