### PR TITLE
Refocus AI adoption feature section

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,13 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-11-09 — “Refocus AI adoption feature section”
+
+- **User ask / Bug:** Replace the “Leveled-up API development” heading and nine Unkey-era feature boxes with new AI adoption messaging and lucide icons, localized for English and Dutch visitors.
+- **Fix:** Wired a dedicated `FeatureSection` translation namespace for the heading, paragraph, and feature copy, passed the translated data into the grid with the requested lucide icons, and preserved the legacy feature markup for future reuse while updating the section title rendering.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `apps/www/components/feature/feature-grid.tsx`, `apps/www/components/feature/feature.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `UPDATE.md`, `FIX.md`.
+- **Follow-ups:** None.
+
 ## 2025-11-08 — “Dutch CTA fallback shows English copy”
 
 - **User ask / Bug:** The lower homepage CTA still rendered the English heading and paragraph when visiting the Dutch locale.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,10 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-11-09
+
+- Refocused the API feature section around AI adoption by wiring new localized copy, lucide icons, and feature data into the existing grid while preserving the legacy boxes for reference.
+
 ## 2025-11-08
 
 - Ensured the homepage CTA section loads translations with the active locale so Dutch visitors see the localized heading and body copy instead of the English fallback.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -16,7 +16,19 @@ import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/hero
 import { OssLight } from "@/components/svg/oss-light";
 import { UsageBento } from "@/components/usage-bento";
 import { isLocale } from "@/i18n/routing";
-import { ChevronRight, LogIn } from "lucide-react";
+import {
+  BarChart3,
+  ChevronRight,
+  Clock,
+  GraduationCap,
+  LineChart,
+  LogIn,
+  Puzzle,
+  Rocket,
+  Scale,
+  Sprout,
+  Zap,
+} from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import type { Metadata } from "next";
@@ -85,11 +97,30 @@ export default async function Landing({
     notFound();
   }
 
-  const [cta, platform, hero] = await Promise.all([
+  const [cta, platform, hero, featureSection] = await Promise.all([
     getTranslations({ locale, namespace: "CTA" }),
     getTranslations({ locale, namespace: "Platform" }),
     getTranslations({ locale, namespace: "Hero" }),
+    getTranslations({ locale, namespace: "FeatureSection" }),
   ]);
+
+  const featureBoxes = [
+    { key: "futureProofWorkforce", icon: GraduationCap },
+    { key: "revenueStreamAnalysis", icon: BarChart3 },
+    { key: "newOpportunities", icon: Sprout },
+    { key: "platformEfficiency", icon: Zap },
+    { key: "rightTiming", icon: Clock },
+    { key: "legalAssurance", icon: Scale },
+    { key: "agileExecution", icon: Rocket },
+    { key: "multiFieldExpertise", icon: Puzzle },
+    { key: "dataDrivenDecisions", icon: LineChart },
+  ] as const;
+
+  const featureItems = featureBoxes.map(({ key, icon }) => ({
+    icon,
+    title: featureSection(`boxes.${key}.title`),
+    description: featureSection(`boxes.${key}.description`),
+  }));
 
   return (
     <>
@@ -193,8 +224,8 @@ export default async function Landing({
               {/* TODO: horizontal scroll */}
               <SectionTitle
                 className="mt-8 md:mt-16 lg:mt-32 xl:mt-48"
-                title="Leveled-up API development"
-                text="You gain enhanced security, low latency, and better control, enabling seamless API integration and unparalleled data protection."
+                title={featureSection("title")}
+                text={featureSection("text")}
               >
                 <div className="flex mt-10 mb-10 space-x-6">
                   <Link href="https://app.unkey.com" className="group">
@@ -215,7 +246,7 @@ export default async function Landing({
                 </div>
               </SectionTitle>
             </div>
-            <FeatureGrid className="relative z-50 mt-20" />
+            <FeatureGrid className="relative z-50 mt-20" items={featureItems} />
             <div className="relative -z-10">
               <FeatureGridChip className="absolute top-[50px] left-[400px]" />
             </div>

--- a/apps/www/components/feature/feature-grid.tsx
+++ b/apps/www/components/feature/feature-grid.tsx
@@ -2,10 +2,40 @@ import { cn } from "@/lib/utils";
 import { Feature, FeatureContent, FeatureHeader, FeatureIcon, FeatureTitle } from "./feature";
 
 import * as React from "react";
+import type { LucideIcon } from "lucide-react";
 
-const FeatureGrid = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className }, ref) => (
-    <div ref={ref} className={cn(className)}>
+type FeatureGridItem = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+};
+
+type FeatureGridProps = React.HTMLAttributes<HTMLDivElement> & {
+  items: FeatureGridItem[];
+};
+
+const FeatureGrid = React.forwardRef<HTMLDivElement, FeatureGridProps>(
+  ({ className, items, ...props }, ref) => (
+    <div ref={ref} className={cn(className)} {...props}>
+      <div className="grid grid-cols-1 gap-12 md:grid-cols-2 xl:grid-cols-3 sm:px-0">
+        {items.map(({ icon: Icon, title, description }) => (
+          <Feature key={title}>
+            <FeatureHeader>
+              <FeatureIcon Icon={Icon} className="text-white" />
+              <FeatureTitle>{title}</FeatureTitle>
+            </FeatureHeader>
+            <FeatureContent>{description}</FeatureContent>
+          </Feature>
+        ))}
+      </div>
+    </div>
+  ),
+);
+FeatureGrid.displayName = "FeatureGrid";
+
+const LegacyFeatureGrid = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn(className)} {...props}>
       <div className="grid grid-cols-1 gap-12 md:grid-cols-2 xl:grid-cols-3 sm:px-0">
         <Feature>
           <FeatureHeader>
@@ -13,8 +43,7 @@ const FeatureGrid = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
             <FeatureTitle>Multi-Cloud</FeatureTitle>
           </FeatureHeader>
           <FeatureContent>
-            Unkey works with any cloud provider, ensuring a fast global experience regardless of
-            your choice of infrastructure.
+            Unkey works with any cloud provider, ensuring a fast global experience regardless of your choice of infrastructure.
           </FeatureContent>
         </Feature>
         <Feature>
@@ -23,8 +52,7 @@ const FeatureGrid = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
             <FeatureTitle>Rate limiting</FeatureTitle>
           </FeatureHeader>
           <FeatureContent>
-            Protect your APIs with simple, configurable rate limiting. Unkey’s global rate limiting
-            requires zero setup and allows for custom configuration per customer.
+            Protect your APIs with simple, configurable rate limiting. Unkey’s global rate limiting requires zero setup and allows for custom configuration per customer.
           </FeatureContent>
         </Feature>
         <Feature>
@@ -33,8 +61,7 @@ const FeatureGrid = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
             <FeatureTitle>API-first / UI-first</FeatureTitle>
           </FeatureHeader>
           <FeatureContent>
-            Unkey is designed to be equally usable via its API and dashboard, ensuring a smooth
-            experience for developers and non-technical users alike.
+            Unkey is designed to be equally usable via its API and dashboard, ensuring a smooth experience for developers and non-technical users alike.
           </FeatureContent>
         </Feature>
         <Feature>
@@ -43,8 +70,7 @@ const FeatureGrid = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
             <FeatureTitle>Role-based access control</FeatureTitle>
           </FeatureHeader>
           <FeatureContent>
-            Granular access privileges with either role or permission-based control. Permission
-            changes are propagated globally in seconds.
+            Granular access privileges with either role or permission-based control. Permission changes are propagated globally in seconds.
           </FeatureContent>
         </Feature>
         <Feature>
@@ -53,8 +79,7 @@ const FeatureGrid = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
             <FeatureTitle>Proactive protection</FeatureTitle>
           </FeatureHeader>
           <FeatureContent>
-            Take immediate control over your system's security with the ability to instantly revoke
-            access , providing swift response to potential threats.
+            Take immediate control over your system's security with the ability to instantly revoke access, providing swift response to potential threats.
           </FeatureContent>
         </Feature>
         <Feature>
@@ -63,8 +88,7 @@ const FeatureGrid = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
             <FeatureTitle>SDKs</FeatureTitle>
           </FeatureHeader>
           <FeatureContent>
-            Hit the ground running and accelerate development with SDKs in the language of your
-            choice.
+            Hit the ground running and accelerate development with SDKs in the language of your choice.
           </FeatureContent>
         </Feature>
         {/* <div className="p-5 max-sm:hidden">
@@ -76,8 +100,7 @@ const FeatureGrid = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
             <FeatureTitle>Vercel Integration</FeatureTitle>
           </FeatureHeader>
           <FeatureContent>
-            Deploy applications with our official Vercel integration, streamlining the
-            development-to-deployment pipeline.
+            Deploy applications with our official Vercel integration, streamlining the development-to-deployment pipeline.
           </FeatureContent>
         </Feature>
         <Feature>
@@ -86,8 +109,7 @@ const FeatureGrid = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
             <FeatureTitle>Automatic Key Expiration</FeatureTitle>
           </FeatureHeader>
           <FeatureContent>
-            Simplify key management with automatic key expiration, reducing the risk of unauthorized
-            access over time.
+            Simplify key management with automatic key expiration, reducing the risk of unauthorized access over time.
           </FeatureContent>
         </Feature>
         <Feature>
@@ -96,14 +118,13 @@ const FeatureGrid = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
             <FeatureTitle>Usage Limits per Key</FeatureTitle>
           </FeatureHeader>
           <FeatureContent>
-            Create keys with a fixed amount of usage and the ability to refill periodically,
-            limiting the potential for abuse and allowing for usage-based billing with credits.
+            Create keys with a fixed amount of usage and the ability to refill periodically, limiting the potential for abuse and allowing for usage-based billing with credits.
           </FeatureContent>
         </Feature>
       </div>
     </div>
   ),
 );
-FeatureGrid.displayName = "FeatureGrid";
+LegacyFeatureGrid.displayName = "LegacyFeatureGrid";
 
-export { FeatureGrid };
+export { FeatureGrid, LegacyFeatureGrid };

--- a/apps/www/components/feature/feature.tsx
+++ b/apps/www/components/feature/feature.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import * as React from "react";
+import type { LucideIcon } from "lucide-react";
 import {
   ApiFirst,
   AutoKeyExpiration,
@@ -53,14 +54,18 @@ const FeatureTitle = React.forwardRef<
 ));
 FeatureTitle.displayName = "FeatureTitle";
 
-const FeatureIcon = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & { iconName: string }
->(({ className, iconName }, ref) => (
-  <div ref={ref} className={className}>
-    {getSvg(iconName)}
-  </div>
-));
+type FeatureIconProps = React.HTMLAttributes<HTMLDivElement> & {
+  iconName?: string;
+  Icon?: LucideIcon;
+};
+
+const FeatureIcon = React.forwardRef<HTMLDivElement, FeatureIconProps>(
+  ({ className, iconName, Icon, ...props }, ref) => (
+    <div ref={ref} className={cn("text-white", className)} {...props}>
+      {Icon ? <Icon aria-hidden className="h-6 w-6" /> : iconName ? getSvg(iconName) : null}
+    </div>
+  ),
+);
 FeatureIcon.displayName = "FeatureIcon";
 
 const FeatureContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -171,6 +171,48 @@
     "title": "Our Platform (Beta)",
     "text": "We’re building the best platform to help businesses seamlessly integrate AI into their operations."
   },
+  "FeatureSection": {
+    "title": "Take Your AI Adoption to the Next Level",
+    "text": "The transition to AI is about more than just a platform. Our solution combines best practices with hands-on guidance to help companies adapt across all facets—technology, people, and processes—so integrations deliver maximum success.",
+    "boxes": {
+      "futureProofWorkforce": {
+        "title": "Future-proof workforce",
+        "description": "Upskill employees to boost productivity and ensure they remain valuable contributors."
+      },
+      "revenueStreamAnalysis": {
+        "title": "Revenue stream analysis",
+        "description": "Assess how AI impacts current income streams and adapt strategies accordingly."
+      },
+      "newOpportunities": {
+        "title": "New opportunities",
+        "description": "Identify and develop potential future income streams enabled by AI."
+      },
+      "platformEfficiency": {
+        "title": "Platform efficiency",
+        "description": "Unlock 11x productivity, reduced costs, and greater organisational clarity with our platform."
+      },
+      "rightTiming": {
+        "title": "Right timing",
+        "description": "Ensure AI integrations are launched at the optimal moment for maximum results."
+      },
+      "legalAssurance": {
+        "title": "Legal assurance",
+        "description": "Stay fully aligned with data protection and AI regulations worldwide."
+      },
+      "agileExecution": {
+        "title": "Agile execution",
+        "description": "With a lean team, we adapt faster than competitors to keep you ahead."
+      },
+      "multiFieldExpertise": {
+        "title": "Multi-field expertise",
+        "description": "Research, training, integrations, and product development—our wide scope creates well-rounded solutions."
+      },
+      "dataDrivenDecisions": {
+        "title": "Data-driven decisions",
+        "description": "Our research and analytics teams ensure every step is backed by data."
+      }
+    }
+  },
   "Footer": {
     "tagline": "Build better APIs faster.",
     "copyright": "Unkeyed, Inc. {year}",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -171,6 +171,48 @@
     "title": "Ons platform (Beta)",
     "text": "Wij bouwen aan het beste platform waarmee bedrijven AI moeiteloos in hun organisatie kunnen inzetten."
   },
+  "FeatureSection": {
+    "title": "Breng jouw AI-adoptie naar een hoger niveau",
+    "text": "De overgang naar AI gaat verder dan alleen een platform. Onze oplossing bundelt best practices met praktische begeleiding om bedrijven te helpen zich op alle vlakken aan te passen—technologie, mensen en processen—zodat integraties het meeste succes opleveren.",
+    "boxes": {
+      "futureProofWorkforce": {
+        "title": "Toekomstbestendig personeelsbestand",
+        "description": "Leid medewerkers op om productiever te worden en hun waarde voor de organisatie te behouden."
+      },
+      "revenueStreamAnalysis": {
+        "title": "Analyse van inkomstenstromen",
+        "description": "Breng in kaart hoe AI huidige inkomstenstromen beïnvloedt en pas strategieën aan."
+      },
+      "newOpportunities": {
+        "title": "Nieuwe kansen",
+        "description": "Ontdek en ontwikkel nieuwe inkomstenstromen mogelijk gemaakt door AI."
+      },
+      "platformEfficiency": {
+        "title": "Platformefficiëntie",
+        "description": "Bereik 11x productiviteit, lagere kosten en meer organisatorisch overzicht met ons platform."
+      },
+      "rightTiming": {
+        "title": "Juiste timing",
+        "description": "Zorg dat AI-integraties op het juiste moment worden uitgerold voor maximale impact."
+      },
+      "legalAssurance": {
+        "title": "Juridische zekerheid",
+        "description": "Voldoe altijd aan data- en AI-regelgeving wereldwijd."
+      },
+      "agileExecution": {
+        "title": "Wendbare uitvoering",
+        "description": "Dankzij een klein team bewegen wij sneller dan concurrenten, zodat jij voorop blijft."
+      },
+      "multiFieldExpertise": {
+        "title": "Multidisciplinaire expertise",
+        "description": "Onderzoek, training, integraties en productontwikkeling—onze brede scope leidt tot complete oplossingen."
+      },
+      "dataDrivenDecisions": {
+        "title": "Data-gedreven beslissingen",
+        "description": "Onze onderzoeks- en datateams zorgen dat elke stap onderbouwd is met data."
+      }
+    }
+  },
   "Footer": {
     "tagline": "Bouw betere API's sneller.",
     "copyright": "Unkeyed, Inc. {year}",


### PR DESCRIPTION
## Summary
- add a FeatureSection translation namespace for the new heading, paragraph, and cards in English and Dutch
- refactor the feature grid to accept translated data with lucide-react icons while preserving the legacy Unkey cards
- wire the landing page to render the new copy, icons, and layout without disrupting the existing CTA or grid spacing

## Plan
- capture the copy changes in i18n messages and ensure English fallbacks exist
- update the feature grid component to handle new lucide icons and keep the legacy markup available
- load the new namespace on the landing page and verify layout integrity via existing components

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: numerous pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0527b67c832a9f518ab7a806ce7e