### PR TITLE
Update global CTA messaging via i18n

### DIFF
--- a/FIX.md
+++ b/FIX.md
@@ -3,6 +3,15 @@
 > Track **what the user wanted** and **how you fixed it** (technical detail).
 > Always add a new entry at the **top**; reference files, functions, and rationale.
 
+## 2025-11-10 — “Replace global CTA block copy via i18n”
+
+- **User ask / Bug:** Refresh the reusable CTA near the footer with the new English and Dutch messaging, updated button labels, and localized urgency note without altering its layout or behavior.
+- **Fix:**
+  - Added a `Cta` translation namespace with the supplied English and Dutch strings and wired the CTA component to read them through `next-intl`.
+  - Rendered the localized body copy and urgency note while keeping the existing analytics tracking, button styling, and links intact.
+- **Files:** `apps/www/components/cta.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `UPDATE.md`, `FIX.md`.
+- **Follow-ups:** None.
+
 ## 2025-11-09 — “Refocus AI adoption feature section”
 
 - **User ask / Bug:** Replace the “Leveled-up API development” heading and nine Unkey-era feature boxes with new AI adoption messaging and lucide icons, localized for English and Dutch visitors.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,10 @@
 
 > Append a new dated entry at the **top** for every meaningful change. Keep it short, factual, and useful for future agents.
 
+## 2025-11-10
+
+- Updated the global CTA component to load localized headings, body copy, button labels, and urgency note from a dedicated `Cta` translation namespace while keeping the existing layout and analytics tracking intact.
+
 ## 2025-11-09
 
 - Refocused the API feature section around AI adoption by wiring new localized copy, lucide icons, and feature data into the existing grid while preserving the legacy boxes for reference.

--- a/apps/www/components/cta.tsx
+++ b/apps/www/components/cta.tsx
@@ -2,23 +2,22 @@
 import { SectionTitle } from "@/components/section";
 import { track } from "@vercel/analytics/server";
 import { CalendarDays, ChevronRight } from "lucide-react";
+import { useTranslations } from "next-intl";
 import Link from "next/link";
 import type React from "react";
 import { PrimaryButton, SecondaryButton } from "./button";
 
 export const CTA: React.FC = () => {
+  const t = useTranslations("Cta");
+
   return (
     <div className="w-full h-full overflow-hidden">
       <div className="relative pb-40 pt-14 ">
         <Highlights className="absolute inset-x-0 w-full mx-auto pointer-events-none -bottom-80 max-sm:w-8" />
         <SectionTitle
           align="center"
-          title={
-            <>
-              Protect your API.
-              <br /> Start today.
-            </>
-          }
+          title={t("title")}
+          text={t("body")}
         >
           <div className="flex flex-col items-center justify-center gap-6 mt-2 sm:mt-5 sm:flex-row">
             <Link
@@ -28,7 +27,7 @@ export const CTA: React.FC = () => {
               }}
               href="https://cal.com/team/unkey/user-interview?utm_source=banner&utm_campaign=oss"
             >
-              <SecondaryButton label="Chat with us" IconRight={CalendarDays} />
+              <SecondaryButton label={t("primary")} IconRight={CalendarDays} />
             </Link>
             <Link
               onClick={async () => {
@@ -36,13 +35,13 @@ export const CTA: React.FC = () => {
               }}
               href="https://app.unkey.com"
             >
-              <PrimaryButton shiny label="Start Now" IconRight={ChevronRight} />
+              <PrimaryButton shiny label={t("secondary")} IconRight={ChevronRight} />
             </Link>
           </div>
         </SectionTitle>
         <div className="mt-8 sm:mt-10 text-balance">
           <p className="w-full mx-auto text-sm leading-6 text-center text-white/60 max-w-[500px]">
-            150,000 requests per month. No CC required.
+            {t("note")}
           </p>
         </div>
       </div>

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -53,6 +53,13 @@
     "getStarted": "Get Started",
     "exploreProjects": "Explore All projects"
   },
+  "Cta": {
+    "title": "Unlock your company’s AI advantage",
+    "body": "Experience the boost in productivity, efficiency, and innovation that comes with a seamless AI transition.",
+    "primary": "Chat with us",
+    "secondary": "Get Started",
+    "note": "We only support a limited number of companies at the same time—reach out quickly to secure your spot."
+  },
   "Analytics": {
     "requestAccess": "Request Access",
     "caption": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -53,6 +53,13 @@
     "getStarted": "Begin Nu",
     "exploreProjects": "Ontdek alle projecten"
   },
+  "Cta": {
+    "title": "Zet de stap naar het AI-tijdperk",
+    "body": "Wij helpen jouw bedrijf naar meer productiviteit, efficiëntie en innovatie met een naadloze AI-transitie.",
+    "primary": "Chat met ons",
+    "secondary": "Aan de slag",
+    "note": "We helpen slechts een beperkt aantal bedrijven tegelijk—neem snel contact op om jouw plek te verzekeren."
+  },
   "Analytics": {
     "requestAccess": "Vraag Toegang",
     "caption": {


### PR DESCRIPTION
## Summary
- add a dedicated `Cta` translation namespace with the refreshed English and Dutch CTA strings
- wire the global CTA component to render the localized heading, body, buttons, and urgency note
- log the change in UPDATE.md and FIX.md for future context

## Plan
- update the CTA component to read copy from a new translation namespace
- add the supplied English and Dutch strings to the locale message catalogs
- replace the legacy quota line with the localized urgency note in the CTA
- run typecheck and lint to confirm the update doesn’t break existing flows

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5f69879c832aa5d68f9f8227dad8