### PR TITLE
Ensure Dutch About hero translation renders

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-11T0900--restored-about-hero-dutch-copy.md
+++ b/WRITE_HERE/FIXES/2025-11-11T0900--restored-about-hero-dutch-copy.md
@@ -1,0 +1,5 @@
+# Restored Dutch About hero copy
+- **What:** Ensured the About page hero reads translations using the active locale before rendering the headline, body, and CTA.
+- **Why:** The hero defaulted to the English fallback, so Dutch visitors continued to see the English messaging instead of the localized copy.
+- **Files:** apps/www/app/[locale]/(site)/about/page.tsx
+- **Follow-ups:** None.

--- a/WRITE_HERE/UPDATES/2025-09-19T0900--localized-about-hero-copy.md
+++ b/WRITE_HERE/UPDATES/2025-09-19T0900--localized-about-hero-copy.md
@@ -1,0 +1,5 @@
+# Localized About hero copy
+- **What:** Updated the About page hero to pull new headline, body, and CTA text from next-intl translations in both English and Dutch.
+- **Why:** Aligns the hero messaging with the agency's AI adaptation positioning while ensuring localization coverage.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -1,6 +1,8 @@
 import { ArrowRight } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
 
 import { BorderBeam } from "@/components/border-beam";
 import { RainbowDarkButton } from "@/components/button";
@@ -52,6 +54,7 @@ import james from "@/images/team/james.jpg";
 
 import { ImageWithBlur } from "@/components/image-with-blur";
 import { cn } from "@/lib/utils";
+import { isLocale } from "@/i18n/routing";
 
 export const metadata = {
   title: "About | Unkey",
@@ -110,7 +113,24 @@ const offsiteImages = [
   { src: yardwork, label: "Caffeinated" },
 ];
 
-export default async function Page() {
+type PageProps = {
+  params: {
+    locale: string;
+  };
+};
+
+export default async function Page({ params }: PageProps) {
+  const { locale } = params;
+
+  if (!isLocale(locale)) {
+    notFound();
+  }
+
+  const t = await getTranslations({ locale, namespace: "About" });
+  const heroTitle = t("Hero.title");
+  const heroBody = t("Hero.body");
+  const heroCta = t("Hero.cta");
+
   const posts = allPosts.filter((post) => SELECTED_POSTS.includes(post.slug));
   return (
     <div>
@@ -134,12 +154,12 @@ export default async function Page() {
           </div>
           <div className="mt-12">
             <Link href="/blog/introducing-ratelimiting" target="">
-              <RainbowDarkButton label="New: global rate limiting" IconRight={ArrowRight} />
+              <RainbowDarkButton label={heroCta} IconRight={ArrowRight} />
             </Link>
             <SectionTitle
-              title="API management for fast and scalable software"
+              title={heroTitle}
               align="center"
-              text="Unkey redefines API management for developers. You can add authentication, analytics, and rate-limiting to your APIs in minutes. "
+              text={heroBody}
             />
           </div>
           <div className="relative mt-[200px] xl:mt-[400px]">

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -36,6 +36,13 @@
     "secondaryTitle": "Optimised for AI Productivity and Performance",
     "secondaryBody": "Our platform helps companies boost productivity, cut costs, and improve AI performance. It builds on existing structures to amplify results, while offering customisation, long-term reliability, and seamless model selection for every use case."
   },
+  "About": {
+    "Hero": {
+      "title": "Creating and integrating resilient AI structures within companies",
+      "body": "AI is transformative, demanding structural change across all business departments. Because of its complexity, successful integration can be challenging. With our expertise, your company can adapt sustainably and thrive in the AI era.",
+      "cta": "Case study: AI adaptation"
+    }
+  },
   "LogoCloud": {
     "label": "Partners"
   },

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -36,6 +36,13 @@
     "secondaryTitle": "Geoptimaliseerd voor AI-productiviteit en prestaties",
     "secondaryBody": "Ons platform helpt bedrijven productiever te werken, kosten te verlagen en AI-prestaties te verbeteren. Het bouwt voort op bestaande structuren om resultaten te versterken, en biedt aanpasbaarheid, langdurige betrouwbaarheid en eenvoudige modelselectie voor elke use-case."
   },
+  "About": {
+    "Hero": {
+      "title": "Het bouwen van veerkrachtige AI-structuren binnen organisaties",
+      "body": "AI verandert alles en vraagt om structurele aanpassingen in iedere afdeling van je bedrijf. Door de complexiteit is het niet eenvoudig om dit succesvol te realiseren. Dankzij onze expertise kan jouw organisatie zich duurzaam aanpassen en profiteren van de voordelen van AI.",
+      "cta": "Casestudy: AI-integratie"
+    }
+  },
   "LogoCloud": {
     "label": "Partners"
   },


### PR DESCRIPTION
## Summary
- validate the About page locale before rendering and fetch translations with the active locale so the hero copy reflects Dutch strings when applicable
- log the localization fix under WRITE_HERE/FIXES for project continuity

## Plan
- Guard the About page with locale validation using the shared routing helper
- Request the About hero namespace from next-intl using the resolved locale to avoid falling back to English
- Record the change in the fixes log

## Testing
- `pnpm --filter www run typecheck` *(fails: repository TypeScript configuration cannot resolve next-intl modules across the app)*
- `pnpm --filter www run lint` *(fails: next lint cannot resolve the next-intl import referenced from next.config.mjs)*
- `pnpm -w turbo run build --filter=www` *(fails: Next.js build aborts because next.config.mjs cannot import next-intl)*

------
https://chatgpt.com/codex/tasks/task_e_68ce73b85734832aa599e0317fe046f5