### PR TITLE
Localize About page founder content

### DIFF
--- a/apps/www/app/about/page.tsx
+++ b/apps/www/app/about/page.tsx
@@ -1,6 +1,10 @@
 import { ArrowRight } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { cookies, headers } from "next/headers";
+import { createTranslator } from "next-intl";
+import type { AbstractIntlMessages } from "next-intl";
+import type { ReactNode } from "react";
 
 import { BorderBeam } from "@/components/border-beam";
 import { RainbowDarkButton } from "@/components/button";
@@ -20,6 +24,8 @@ import { CTA } from "@/components/cta";
 import { AboutLight } from "@/components/svg/about-light";
 import { StarDots } from "@/components/svg/star-dots";
 import { authors } from "@/content/blog/authors";
+import enMessages from "@/messages/en.json";
+import nlMessages from "@/messages/nl.json";
 
 import { allPosts } from "content-collections";
 
@@ -110,8 +116,160 @@ const offsiteImages = [
   { src: yardwork, label: "Caffeinated" },
 ];
 
-export default async function Page() {
+type PageSearchParams = Record<string, string | string[] | undefined>;
+
+type FounderTranslator = {
+  (key: "title"): string;
+  rich(
+    key: "body",
+    values: {
+      founder: (chunks: ReactNode) => ReactNode;
+    },
+  ): ReactNode;
+};
+
+const SUPPORTED_LOCALES = ["en", "nl"] as const;
+type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+const DEFAULT_LOCALE: Locale = "en";
+const LOCALE_COOKIE = "NEXT_LOCALE";
+
+const LOCALE_MESSAGES: Record<Locale, AbstractIntlMessages> = {
+  en: enMessages as AbstractIntlMessages,
+  nl: nlMessages as AbstractIntlMessages,
+};
+
+function pickFirstValue(value?: string | string[]): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+}
+
+function isSupportedLocale(locale: string | null | undefined): locale is Locale {
+  if (!locale) {
+    return false;
+  }
+
+  return (SUPPORTED_LOCALES as readonly string[]).includes(locale);
+}
+
+function parseAcceptLanguage(acceptLanguage?: string | null): Locale | null {
+  if (!acceptLanguage) {
+    return null;
+  }
+
+  const candidates = acceptLanguage.split(",").map((part) => {
+    const [language] = part.trim().split(";");
+    return language.toLowerCase();
+  });
+
+  for (const candidate of candidates) {
+    const base = candidate.split("-")[0];
+    if (isSupportedLocale(base)) {
+      return base;
+    }
+  }
+
+  return null;
+}
+
+function resolveLocale({
+  searchParams,
+  cookieLocale,
+  acceptLanguage,
+}: {
+  searchParams?: PageSearchParams;
+  cookieLocale?: string;
+  acceptLanguage?: string | null;
+}): Locale {
+  const searchParamLocale = pickFirstValue(searchParams?.locale);
+  if (isSupportedLocale(searchParamLocale)) {
+    return searchParamLocale;
+  }
+
+  if (isSupportedLocale(cookieLocale)) {
+    return cookieLocale;
+  }
+
+  const headerLocale = parseAcceptLanguage(acceptLanguage);
+  if (headerLocale) {
+    return headerLocale;
+  }
+
+  return DEFAULT_LOCALE;
+}
+
+function mergeMessages(
+  base: AbstractIntlMessages,
+  override?: AbstractIntlMessages,
+): AbstractIntlMessages {
+  const result = structuredClone(base) as AbstractIntlMessages;
+
+  if (!override) {
+    return result;
+  }
+
+  for (const [key, value] of Object.entries(override)) {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const existing = result[key];
+      if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+        result[key] = mergeMessages(
+          existing as AbstractIntlMessages,
+          value as AbstractIntlMessages,
+        );
+      } else {
+        result[key] = structuredClone(value) as AbstractIntlMessages;
+      }
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+function getMessages(locale: Locale): AbstractIntlMessages {
+  if (locale === DEFAULT_LOCALE) {
+    return LOCALE_MESSAGES[DEFAULT_LOCALE];
+  }
+
+  return mergeMessages(
+    LOCALE_MESSAGES[DEFAULT_LOCALE],
+    LOCALE_MESSAGES[locale],
+  );
+}
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams?: PageSearchParams;
+}) {
   const posts = allPosts.filter((post) => SELECTED_POSTS.includes(post.slug));
+
+  const cookieStore = cookies();
+  const headerList = headers();
+
+  const locale = resolveLocale({
+    searchParams,
+    cookieLocale: cookieStore.get(LOCALE_COOKIE)?.value,
+    acceptLanguage: headerList.get("accept-language"),
+  });
+
+  const messages = getMessages(locale);
+
+  const founderTranslator = createTranslator({
+    locale,
+    namespace: "About.Founder",
+    messages,
+  }) as unknown as FounderTranslator;
+
+  const founderTitle = founderTranslator("title");
+  const founderBody = founderTranslator.rich("body", {
+    founder: (chunks) => <span className="font-medium text-white">{chunks}</span>,
+  });
+
   return (
     <div>
       <Container>
@@ -161,14 +319,10 @@ export default async function Page() {
             </div>
             <div className="about-radial relative px-[50px] md:px-[144px] pb-[100px] pt-[60px] overflow-hidden bg-black text-white flex flex-col items-center rounded-[48px] border-l border-r border-b border-white/[0.15]">
               <h2 className="text-[32px] font-medium leading-[48px] mt-10 text-center text-balance">
-                Founded to redefine the API management landscape
+                {founderTitle}
               </h2>
               <p className="mt-[40px] text-white/50 leading-[32px] max-w-[720px] text-center">
-                Unkey emerged in 2023 from the frustration of{" "}
-                <span className="font-medium text-white">James Perkins</span> and
-                <span className="font-medium text-white"> Andreas Thomas</span> with the lack of a
-                straightforward, fast, and scalable API management solution. This void prompted a
-                mission to create a tool themselves.
+                {founderBody}
               </p>
               <div className="absolute pointer-events-none scale-[1.5] bottom-[-350px]">
                 <AboutLight />

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -1,0 +1,8 @@
+{
+  "About": {
+    "Founder": {
+      "title": "Founded to redefine the AI transformation landscape",
+      "body": "TransformAI was founded by <founder>Yergush Bloetjes</founder> out of frustration with the slow and poorly executed way companies were adapting to the most transformative technology of our time. Combining deep theoretical knowledge, hands-on experience in the AI field, and successful integrations at other firms, he recognized the lack of high-quality solutions for business-wide AI transformation. This gap led to the creation of TransformAI, with the mission of making AI adoption both successful and sustainable."
+    }
+  }
+}

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -1,0 +1,8 @@
+{
+  "About": {
+    "Founder": {
+      "title": "Opgericht om AI-transformatie opnieuw vorm te geven",
+      "body": "TransformAI is opgericht door <founder>Yergush Bloetjes</founder> uit frustratie over de trage en slecht uitgevoerde manier waarop bedrijven de meest ingrijpende technologie van onze tijd omarmen. Met diepgaande theoretische kennis, praktijkervaring in AI en succesvolle implementaties bij andere organisaties, zag hij dat er een groot tekort was aan hoogwaardige oplossingen voor bedrijfsbrede AI-transformatie. Dit leidde tot de oprichting van TransformAI, met de missie om AI-adoptie zowel succesvol als duurzaam te maken."
+    }
+  }
+}

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -47,6 +47,7 @@
     "mermaid": "^11.6.0",
     "nanoid": "^5.0.9",
     "next": "14.2.26",
+    "next-intl": "^4.3.9",
     "next-mdx-remote": "^4.4.1",
     "prism-react-renderer": "^2.3.1",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,9 @@ importers:
       next:
         specifier: 14.2.26
         version: 14.2.26(@opentelemetry/api@1.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-intl:
+        specifier: ^4.3.9
+        version: 4.3.9(next@14.2.26(@opentelemetry/api@1.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       next-mdx-remote:
         specifier: ^4.4.1
         version: 4.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1271,8 +1274,23 @@ packages:
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
+  '@formatjs/ecma402-abstract@2.3.4':
+    resolution: {integrity: sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==}
+
+  '@formatjs/fast-memoize@2.2.7':
+    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
+
+  '@formatjs/icu-messageformat-parser@2.11.2':
+    resolution: {integrity: sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==}
+
+  '@formatjs/icu-skeleton-parser@1.8.14':
+    resolution: {integrity: sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==}
+
   '@formatjs/intl-localematcher@0.5.10':
     resolution: {integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==}
+
+  '@formatjs/intl-localematcher@0.6.1':
+    resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
 
   '@google-cloud/precise-date@4.0.0':
     resolution: {integrity: sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA==}
@@ -2883,6 +2901,9 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@schummar/icu-type-parser@1.21.5':
+    resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
+
   '@shikijs/core@1.29.2':
     resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
 
@@ -3922,6 +3943,9 @@ packages:
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decode-formdata@0.9.0:
     resolution: {integrity: sha512-q5uwOjR3Um5YD+ZWPOF/1sGHVW9A5rCrRwITQChRXlmPkxDFBqCm4jNTIVdGHNH9OnR+V9MoZVgRhsFb+ARbUw==}
 
@@ -4726,6 +4750,9 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  intl-messageformat@10.7.16:
+    resolution: {integrity: sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==}
+
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
 
@@ -5494,6 +5521,16 @@ packages:
   neverthrow@8.2.0:
     resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
     engines: {node: '>=18'}
+
+  next-intl@4.3.9:
+    resolution: {integrity: sha512-4oSROHlgy8a5Qr2vH69wxo9F6K0uc6nZM2GNzqSe6ET79DEzOmBeSijCRzD5txcI4i+XTGytu4cxFsDXLKEDpQ==}
+    peerDependencies:
+      next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   next-mdx-remote@4.4.1:
     resolution: {integrity: sha512-1BvyXaIou6xy3XoNF4yaMZUCb6vD2GTAa5ciOa6WoO+gAUTYsb1K4rI/HSC2ogAWLrb/7VSV52skz07vOzmqIQ==}
@@ -6630,6 +6667,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-intl@4.3.9:
+    resolution: {integrity: sha512-bZu+h13HIgOvsoGleQtUe4E6gM49CRm+AH36KnJVB/qb1+Beo7jr7HNrR8YWH8oaOkQfGNm6vh0HTepxng8UTg==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
   use-sidecar@1.1.3:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
@@ -7881,7 +7923,33 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
+  '@formatjs/ecma402-abstract@2.3.4':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/intl-localematcher': 0.6.1
+      decimal.js: 10.6.0
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@2.2.7':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/icu-messageformat-parser@2.11.2':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/icu-skeleton-parser': 1.8.14
+      tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@1.8.14':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      tslib: 2.8.1
+
   '@formatjs/intl-localematcher@0.5.10':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.6.1':
     dependencies:
       tslib: 2.8.1
 
@@ -9758,6 +9826,8 @@ snapshots:
   '@rollup/rollup-linux-x64-gnu@4.44.2':
     optional: true
 
+  '@schummar/icu-type-parser@1.21.5': {}
+
   '@shikijs/core@1.29.2':
     dependencies:
       '@shikijs/engine-javascript': 1.29.2
@@ -10926,6 +10996,8 @@ snapshots:
 
   decimal.js-light@2.5.1: {}
 
+  decimal.js@10.6.0: {}
+
   decode-formdata@0.9.0: {}
 
   decode-named-character-reference@1.1.0:
@@ -11758,6 +11830,13 @@ snapshots:
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
+
+  intl-messageformat@10.7.16:
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/icu-messageformat-parser': 2.11.2
+      tslib: 2.8.1
 
   is-alphabetical@1.0.4: {}
 
@@ -13007,6 +13086,16 @@ snapshots:
   neverthrow@8.2.0:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.44.2
+
+  next-intl@4.3.9(next@14.2.26(@opentelemetry/api@1.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.8.2):
+    dependencies:
+      '@formatjs/intl-localematcher': 0.5.10
+      negotiator: 1.0.0
+      next: 14.2.26(@opentelemetry/api@1.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      use-intl: 4.3.9(react@18.3.1)
+    optionalDependencies:
+      typescript: 5.8.2
 
   next-mdx-remote@4.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -14426,6 +14515,13 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.8
+
+  use-intl@4.3.9(react@18.3.1):
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      '@schummar/icu-type-parser': 1.21.5
+      intl-messageformat: 10.7.16
+      react: 18.3.1
 
   use-sidecar@1.1.3(@types/react@18.3.20)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary
- add next-intl dependency and localized founder copy for English and Dutch
- load localized founder text on the About page with fallback handling and highlight formatting
- resolve locale via search params, cookies, or Accept-Language so English remains the fallback

## Testing
- CI=1 pnpm --filter landing build *(fails: fetch to external data source ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68ce78078104832aab825edac5e7228d