### PR TITLE
Add pricing comparison table above pricing tiers

### DIFF
--- a/WRITE_HERE/TASK_PLANNING/2025-09-20T1021--pricing-table.md
+++ b/WRITE_HERE/TASK_PLANNING/2025-09-20T1021--pricing-table.md
@@ -1,0 +1,60 @@
+# Pricing comparison table plan
+
+## Scope
+- Introduce a reusable pricing comparison table component with gradient backdrop and particle layer inspired by the enterprise card.
+- Wire the component into `/pricing` above existing tier cards without modifying current pricing card layout or logic.
+- Define structured data for tiers/categories/rows and power copy via new i18n keys (EN + NL with EN fallback).
+- Ensure responsive behaviors: full table on desktop/tablet, accordion-style stacks on mobile, respecting reduced motion preferences.
+
+## Files to touch
+- `apps/www/components/pricing/pricing-compare-table.tsx` (new component & styles).
+- `apps/www/app/[locale]/(site)/pricing/page.tsx` (import + placement, optional CTA anchors).
+- `apps/www/messages/en.json` & `apps/www/messages/nl.json` (new translation keys).
+- `WRITE_HERE/UPDATES/` (log change after completion).
+
+## Risks & mitigations
+- **Layout shift / page rhythm**: match container widths & spacing tokens used by tier grid; test on initial load to avoid CLS.
+- **Overflow on mobile**: use CSS grid with minmax + accordion to prevent horizontal scroll; verify across breakpoints.
+- **Contrast & readability**: stick to white text, gray tokenized prices, and ensure gradient/particles do not overpower content; check in light mode too.
+- **Performance / reduced motion**: disable particle animation when `prefers-reduced-motion` is set; reuse existing particle component responsibly.
+
+## Test plan
+- Visual spot-check in dev server (desktop/tablet/mobile sizes via responsive mode).
+- `pnpm --filter www run lint`.
+- `pnpm --filter www run typecheck`.
+- `pnpm --filter www run build --filter=www` (if time permits; otherwise ensure no build regressions via typecheck/lint + component review).
+
+## Wireframes
+### Desktop
+- Section header “Compare plans” centered above table.
+- Gradient container with subtle particles.
+- Table layout: first column (feature names) left-aligned, three equal plan columns with tier name + price chips + CTA buttons underneath.
+- Category headers as sticky row separators spanning all columns.
+
+### Tablet
+- Same 4-column table but tighter padding and reduced font sizes; CTAs align under headers.
+- Category headers remain sticky; ensure columns collapse gracefully within max width.
+
+### Mobile
+- Accordion per category; trigger shows category name.
+- Accordion content: feature list with each item showing tier availability in a 3-column mini-grid beneath the feature name (stacked rows, no horizontal scroll).
+- Optional inline CTA buttons per tier stacked at bottom of table.
+
+## Token & component reuse
+- Colors: reuse enterprise gradient `from-[#02DEFC] via-[#0239FC] to-[#7002FC]` and purple highlights already used in pricing card.
+- Radii: apply `rounded-4xl` / `rounded-3xl` tokens consistent with enterprise card corners.
+- Shadows: reuse soft shadow utility from shiny/enterprise cards (e.g., `shadow-[0_0_40px_rgba(32,8,72,0.45)]` if available; otherwise use existing tokenized `shadow-[...]/shadow-glow`).
+- Background: leverage existing `Particles` component for starfield; gate with reduced-motion check.
+- Typography: use section title styles & existing text classes (`section-title-heading-gradient`, `text-white/60`, `font-semibold`).
+- Buttons: prefer `@/components/button` primary/ghost variants for CTA anchors.
+
+## i18n keys to add (`Pricing.Table.*`)
+- `Pricing.Table.title`
+- `Pricing.Table.tiers.t1`, `.t2`, `.t3`
+- `Pricing.Table.tiers.price.t1`, `.t2`, `.t3`
+- `Pricing.Table.categories.research`, `.education`
+- Row labels: `.rows.analyzeIntegrations`, `.rows.buildCustomModel`, `.rows.exploreResearch`, `.rows.courseV1`, `.rows.courseV2`, `.rows.courseV3`
+- Availability labels: `.availability.included`, `.availability.notIncluded`, `.availability.partial`
+- Notes: `.notes.limitedScope`, `.notes.fullSupport` (for tooltips/footnotes as needed)
+- CTA labels: `.cta.chooseT1`, `.cta.chooseT2`, `.cta.chooseT3`
+- Column label: `.columns.features`

--- a/WRITE_HERE/UPDATES/2025-09-20T1029--pricing-comparison-table.md
+++ b/WRITE_HERE/UPDATES/2025-09-20T1029--pricing-comparison-table.md
@@ -1,0 +1,7 @@
+# Add pricing comparison table above tiers
+_When:_ 2025-09-20 10:29 UTC · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Introduced a gradient-backed pricing comparison table with responsive accordion fallback, wired it into `/pricing`, and localized all copy for English and Dutch including CTA anchors to each tier card.
+- **Why:** Surfaces a quick side-by-side view of plan capabilities before the detailed tiers, improving clarity for prospects across devices.
+- **Files:** `apps/www/components/pricing/pricing-compare-table.tsx`, `apps/www/app/[locale]/(site)/pricing/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Ensure shared environments install `next-intl` so lint/typecheck/dev commands succeed without missing-module errors.

--- a/apps/www/app/[locale]/(site)/pricing/page.tsx
+++ b/apps/www/app/[locale]/(site)/pricing/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { CTA } from "@/components/cta";
 import { Particles } from "@/components/particles";
+import { PricingCompareTable } from "@/components/pricing/pricing-compare-table";
 import { ShinyCardGroup } from "@/components/shiny-card";
 import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/hero";
 import { Check, Stars } from "lucide-react";
@@ -95,8 +96,11 @@ export default function PricingPage() {
         </p>  */}
       </div>
 
-      <ShinyCardGroup className="grid h-full max-w-4xl grid-cols-2 gap-6 mx-auto group">
-        <PricingCard color={Color.White} className="col-span-2 md:col-span-1">
+      <PricingCompareTable />
+
+      <ShinyCardGroup className="grid h-full max-w-4xl grid-cols-2 gap-6 mx-auto mt-16 group">
+        <div id="tier-1" className="col-span-2 md:col-span-1">
+          <PricingCard color={Color.White} className="h-full">
           <FreeCardHighlight className="absolute top-0 right-0 pointer-events-none" />
 
           <PricingCardHeader
@@ -149,7 +153,9 @@ export default function PricingPage() {
             </div>
           </PricingCardFooter>
         </PricingCard>
-        <PricingCard color={Color.Yellow} className="col-span-2 md:col-span-1">
+        </div>
+        <div id="tier-2" className="col-span-2 md:col-span-1">
+          <PricingCard color={Color.Yellow} className="h-full">
           <ProCardHighlight className="absolute top-0 right-0 pointer-events-none" />
 
           <PricingCardHeader
@@ -217,9 +223,11 @@ export default function PricingPage() {
               </p>
             </div>
           </PricingCardFooter>
-        </PricingCard>
+          </PricingCard>
+        </div>
 
-        <PricingCard color={Color.Purple} className="col-span-2">
+        <div id="tier-3" className="col-span-2">
+          <PricingCard color={Color.Purple} className="h-full">
           <EnterpriseCardHighlight className="absolute top-0 right-0 pointer-events-none" />
 
           <div className="flex flex-col h-full md:flex-row">
@@ -274,7 +282,8 @@ export default function PricingPage() {
               </Bullets>
             </div>
           </div>
-        </PricingCard>
+          </PricingCard>
+        </div>
       </ShinyCardGroup>
       <BelowEnterpriseSvg className="container inset-x-0 top-0 mx-auto -mt-64 -mb-32" />
 

--- a/apps/www/components/pricing/pricing-compare-table.tsx
+++ b/apps/www/components/pricing/pricing-compare-table.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { Particles } from "@/components/particles";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { cn } from "@/lib/utils";
+import { useReducedMotion } from "framer-motion";
+import { ArrowRight, Check, Info, Minus, X } from "lucide-react";
+import Link from "next/link";
+import { Fragment } from "react";
+import { useTranslations } from "next-intl";
+
+type TierId = "t1" | "t2" | "t3";
+
+type Availability = "yes" | "no" | "partial";
+
+type TierDefinition = {
+  id: TierId;
+  labelKey: string;
+  priceKey: string;
+  ctaKey: string;
+  href?: string;
+};
+
+type RowDefinition = {
+  id: string;
+  labelKey: string;
+  availability: Record<TierId, Availability>;
+  noteKey?: Partial<Record<TierId, string>>;
+};
+
+type CategoryDefinition = {
+  id: string;
+  labelKey: string;
+  rows: RowDefinition[];
+};
+
+const tiers: TierDefinition[] = [
+  {
+    id: "t1",
+    labelKey: "tiers.t1",
+    priceKey: "tiers.price.t1",
+    ctaKey: "cta.chooseT1",
+    href: "#tier-1",
+  },
+  {
+    id: "t2",
+    labelKey: "tiers.t2",
+    priceKey: "tiers.price.t2",
+    ctaKey: "cta.chooseT2",
+    href: "#tier-2",
+  },
+  {
+    id: "t3",
+    labelKey: "tiers.t3",
+    priceKey: "tiers.price.t3",
+    ctaKey: "cta.chooseT3",
+    href: "#tier-3",
+  },
+];
+
+const categories: CategoryDefinition[] = [
+  {
+    id: "research",
+    labelKey: "categories.research",
+    rows: [
+      {
+        id: "analyzeIntegrations",
+        labelKey: "rows.analyzeIntegrations",
+        availability: {
+          t1: "yes",
+          t2: "yes",
+          t3: "yes",
+        },
+      },
+      {
+        id: "buildCustomModel",
+        labelKey: "rows.buildCustomModel",
+        availability: {
+          t1: "no",
+          t2: "partial",
+          t3: "yes",
+        },
+        noteKey: {
+          t2: "notes.limitedScope",
+          t3: "notes.fullSupport",
+        },
+      },
+      {
+        id: "exploreResearch",
+        labelKey: "rows.exploreResearch",
+        availability: {
+          t1: "no",
+          t2: "yes",
+          t3: "yes",
+        },
+      },
+    ],
+  },
+  {
+    id: "education",
+    labelKey: "categories.education",
+    rows: [
+      {
+        id: "courseV1",
+        labelKey: "rows.courseV1",
+        availability: {
+          t1: "yes",
+          t2: "yes",
+          t3: "yes",
+        },
+      },
+      {
+        id: "courseV2",
+        labelKey: "rows.courseV2",
+        availability: {
+          t1: "no",
+          t2: "yes",
+          t3: "yes",
+        },
+      },
+      {
+        id: "courseV3",
+        labelKey: "rows.courseV3",
+        availability: {
+          t1: "no",
+          t2: "no",
+          t3: "yes",
+        },
+      },
+    ],
+  },
+];
+
+const availabilityIcon: Record<Availability, typeof Check> = {
+  yes: Check,
+  no: X,
+  partial: Minus,
+};
+
+const availabilityTone: Record<Availability, string> = {
+  yes: "border-emerald-400/40 bg-emerald-500/10 text-emerald-300",
+  no: "border-white/10 bg-white/5 text-white/40",
+  partial: "border-amber-300/40 bg-amber-400/10 text-amber-200",
+};
+
+export const PricingCompareTable: React.FC = () => {
+  const t = useTranslations("Pricing.Table");
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <section className="mx-auto w-full max-w-4xl">
+      <div className="relative overflow-hidden rounded-4xl border border-white/10 bg-black/80 shadow-[0_0_60px_rgba(14,8,62,0.45)]">
+        <div className="absolute inset-0 bg-gradient-to-br from-[#7002FC]/30 via-[#0239FC]/20 to-transparent" aria-hidden />
+        <div className="absolute -inset-x-32 -top-32 h-64 bg-gradient-radial from-[#02DEFC]/40 via-transparent to-transparent opacity-60" aria-hidden />
+        {!shouldReduceMotion ? (
+          <Particles
+            className="absolute inset-0 opacity-60"
+            quantity={45}
+            color="#9D72FF"
+            vx={0.06}
+            vy={-0.08}
+          />
+        ) : null}
+
+        <div className="relative z-10 flex flex-col gap-8 px-4 py-8 sm:px-8">
+          <div className="text-center">
+            <h2 className="text-3xl font-semibold text-white sm:text-[2.25rem]">
+              {t("title")}
+            </h2>
+          </div>
+
+          <div className="hidden text-sm md:block">
+            <div className="overflow-hidden rounded-3xl border border-white/10 bg-white/5 backdrop-blur-sm">
+              <table className="w-full border-collapse text-left text-sm text-white">
+                <thead className="bg-white/10">
+                  <tr className="text-xs uppercase tracking-wide text-white/60">
+                    <th
+                      scope="col"
+                      className="px-6 py-4 text-left font-medium text-white/60"
+                    >
+                      {t("columns.features")}
+                    </th>
+                    {tiers.map((tier) => (
+                      <th
+                        key={tier.id}
+                        scope="col"
+                        className="px-6 py-4 text-center font-medium text-white"
+                      >
+                        <div className="flex flex-col items-center gap-1 text-sm">
+                          <span className="font-semibold text-white">
+                            {t(tier.labelKey)}
+                          </span>
+                          <span className="text-xs font-medium text-white/60">
+                            {t(tier.priceKey)}
+                          </span>
+                        </div>
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/10">
+                  {categories.map((category) => (
+                    <Fragment key={category.id}>
+                      <tr className="bg-white/10">
+                        <th
+                          colSpan={tiers.length + 1}
+                          scope="colgroup"
+                          className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-white/70"
+                        >
+                          {t(category.labelKey)}
+                        </th>
+                      </tr>
+                      {category.rows.map((row) => (
+                        <tr key={row.id} className="align-top text-sm">
+                          <th
+                            scope="row"
+                            className="px-6 py-4 text-left font-medium text-white"
+                          >
+                            {t(row.labelKey)}
+                          </th>
+                          {tiers.map((tier) => (
+                            <td key={tier.id} className="px-6 py-4">
+                              <AvailabilityBadge
+                                state={row.availability[tier.id]}
+                                label={t(`availability.${row.availability[tier.id]}`)}
+                                note={row.noteKey?.[tier.id] ? t(row.noteKey[tier.id] as string) : undefined}
+                              />
+                            </td>
+                          ))}
+                        </tr>
+                      ))}
+                    </Fragment>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-4 text-sm md:hidden">
+            <Accordion type="multiple" defaultValue={categories.map((category) => category.id)}>
+              {categories.map((category) => (
+                <AccordionItem
+                  key={category.id}
+                  value={category.id}
+                  className="rounded-3xl border border-white/10 bg-white/5 px-4"
+                >
+                  <AccordionTrigger className="text-left text-base font-semibold text-white">
+                    {t(category.labelKey)}
+                  </AccordionTrigger>
+                  <AccordionContent className="space-y-4">
+                    {category.rows.map((row) => (
+                      <div
+                        key={row.id}
+                        className="rounded-2xl border border-white/10 bg-black/40 p-4"
+                      >
+                        <p className="text-sm font-medium text-white">
+                          {t(row.labelKey)}
+                        </p>
+                        <div className="mt-3 grid grid-cols-3 gap-3 text-center text-xs text-white/70">
+                          {tiers.map((tier) => (
+                            <div key={tier.id} className="flex flex-col items-center gap-2">
+                              <span className="font-medium text-white/70">
+                                {t(tier.labelKey)}
+                              </span>
+                              <AvailabilityBadge
+                                state={row.availability[tier.id]}
+                                label={t(`availability.${row.availability[tier.id]}`)}
+                                note={row.noteKey?.[tier.id] ? t(row.noteKey[tier.id] as string) : undefined}
+                                compact
+                              />
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            {tiers.map((tier) => (
+              <Link
+                key={tier.id}
+                href={tier.href ?? "#"}
+                className="group flex items-center justify-center gap-2 rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/20"
+              >
+                <span>{t(tier.ctaKey)}</span>
+                <ArrowRight className="h-4 w-4 text-white/60 transition group-hover:text-white" aria-hidden />
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+type AvailabilityBadgeProps = {
+  state: Availability;
+  label: string;
+  note?: string;
+  compact?: boolean;
+};
+
+const AvailabilityBadge: React.FC<AvailabilityBadgeProps> = ({ state, label, note, compact }) => {
+  const Icon = availabilityIcon[state];
+  const tone = availabilityTone[state];
+
+  return (
+    <div className="flex flex-col items-center gap-2 text-center">
+      <div
+        role="img"
+        aria-label={label}
+        className={cn(
+          "flex h-10 w-10 items-center justify-center rounded-full border text-base",
+          tone,
+          compact && "h-9 w-9 text-sm",
+        )}
+      >
+        <Icon aria-hidden className={cn("h-4 w-4", compact && "h-3.5 w-3.5")} />
+      </div>
+      {note ? (
+        <div className="flex items-center gap-1 text-[0.7rem] font-medium text-white/60">
+          <Info className="h-3.5 w-3.5" aria-hidden />
+          <span className="max-w-[9rem] text-left leading-tight">{note}</span>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -181,6 +181,50 @@
       }
     }
   },
+  "Pricing": {
+    "Table": {
+      "title": "Compare plans",
+      "columns": {
+        "features": "Features"
+      },
+      "tiers": {
+        "t1": "Tier 1",
+        "t2": "Tier 2",
+        "t3": "Tier 3",
+        "price": {
+          "t1": "$299/mo",
+          "t2": "$799/mo",
+          "t3": "$1,999/mo"
+        }
+      },
+      "categories": {
+        "research": "Research",
+        "education": "Education"
+      },
+      "rows": {
+        "analyzeIntegrations": "Analyze company integrations",
+        "buildCustomModel": "Build custom model",
+        "exploreResearch": "Explore research fields",
+        "courseV1": "Education course V1",
+        "courseV2": "Education course V2",
+        "courseV3": "Education course V3"
+      },
+      "availability": {
+        "included": "Included",
+        "notIncluded": "Not included",
+        "partial": "Limited availability"
+      },
+      "notes": {
+        "limitedScope": "Limited scope",
+        "fullSupport": "Full support"
+      },
+      "cta": {
+        "chooseT1": "Choose Tier 1",
+        "chooseT2": "Choose Tier 2",
+        "chooseT3": "Choose Tier 3"
+      }
+    }
+  },
   "Platform": {
     "title": "Our Platform (Beta)",
     "text": "We’re building the best platform to help businesses seamlessly integrate AI into their operations."

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -181,6 +181,50 @@
       }
     }
   },
+  "Pricing": {
+    "Table": {
+      "title": "Vergelijk pakketten",
+      "columns": {
+        "features": "Functies"
+      },
+      "tiers": {
+        "t1": "Pakket 1",
+        "t2": "Pakket 2",
+        "t3": "Pakket 3",
+        "price": {
+          "t1": "$299 p/m",
+          "t2": "$799 p/m",
+          "t3": "$1.999 p/m"
+        }
+      },
+      "categories": {
+        "research": "Onderzoek",
+        "education": "Educatie"
+      },
+      "rows": {
+        "analyzeIntegrations": "Analyseer bedrijfsintegraties",
+        "buildCustomModel": "Bouw een maatwerkmodel",
+        "exploreResearch": "Verken onderzoeksgebieden",
+        "courseV1": "Educatiecursus V1",
+        "courseV2": "Educatiecursus V2",
+        "courseV3": "Educatiecursus V3"
+      },
+      "availability": {
+        "included": "Inbegrepen",
+        "notIncluded": "Niet inbegrepen",
+        "partial": "Beperkte beschikbaarheid"
+      },
+      "notes": {
+        "limitedScope": "Beperkte scope",
+        "fullSupport": "Volledige ondersteuning"
+      },
+      "cta": {
+        "chooseT1": "Kies Pakket 1",
+        "chooseT2": "Kies Pakket 2",
+        "chooseT3": "Kies Pakket 3"
+      }
+    }
+  },
   "Platform": {
     "title": "Ons platform (Beta)",
     "text": "Wij bouwen aan het beste platform waarmee bedrijven AI moeiteloos in hun organisatie kunnen inzetten."


### PR DESCRIPTION
## Summary
- build a reusable `PricingCompareTable` component with gradient backdrop, particles, and responsive accordion fallback
- insert the comparison table ahead of the tier grid and add anchor wrappers for each pricing card CTA
- add English/Dutch translation keys plus planning/update docs for the new pricing table work

## Testing
- pnpm --filter www run lint *(fails: missing `next-intl` dependency in workspace environment)*
- pnpm --filter www run typecheck *(fails: missing `next-intl` dependency in workspace environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7fce244c832aa7c9c5068c426c11