### PR TITLE
Update About founder copy with translations

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-11T0900--updated-about-founder-story.md
+++ b/WRITE_HERE/UPDATES/2025-11-11T0900--updated-about-founder-story.md
@@ -1,0 +1,7 @@
+# Updated About founder story
+_When:_ 2025-11-11 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Replaced the About page founder heading and body copy with new localized content pulled from the translation catalog.
+- **Why:** Aligns the founder story with TransformAI messaging in both English and Dutch while preserving layout and styling.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -130,6 +130,12 @@ export default async function Page({ params }: PageProps) {
   const heroTitle = t("Hero.title");
   const heroBody = t("Hero.body");
   const heroCta = t("Hero.cta");
+  const founderTitle = t("Founder.title");
+  const founderBody = t.rich("Founder.body", {
+    highlight: (chunks) => (
+      <span className="font-medium text-white">{chunks}</span>
+    ),
+  });
 
   const posts = allPosts.filter((post) => SELECTED_POSTS.includes(post.slug));
   return (
@@ -181,14 +187,10 @@ export default async function Page({ params }: PageProps) {
             </div>
             <div className="about-radial relative px-[50px] md:px-[144px] pb-[100px] pt-[60px] overflow-hidden bg-black text-white flex flex-col items-center rounded-[48px] border-l border-r border-b border-white/[0.15]">
               <h2 className="text-[32px] font-medium leading-[48px] mt-10 text-center text-balance">
-                Founded to redefine the API management landscape
+                {founderTitle}
               </h2>
               <p className="mt-[40px] text-white/50 leading-[32px] max-w-[720px] text-center">
-                Unkey emerged in 2023 from the frustration of{" "}
-                <span className="font-medium text-white">James Perkins</span> and
-                <span className="font-medium text-white"> Andreas Thomas</span> with the lack of a
-                straightforward, fast, and scalable API management solution. This void prompted a
-                mission to create a tool themselves.
+                {founderBody}
               </p>
               <div className="absolute pointer-events-none scale-[1.5] bottom-[-350px]">
                 <AboutLight />

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -41,6 +41,10 @@
       "title": "Creating and integrating resilient AI structures within companies",
       "body": "AI is transformative, demanding structural change across all business departments. Because of its complexity, successful integration can be challenging. With our expertise, your company can adapt sustainably and thrive in the AI era.",
       "cta": "Case study: AI adaptation"
+    },
+    "Founder": {
+      "title": "Founded to redefine the AI transformation landscape",
+      "body": "TransformAI was founded by <highlight>Yergush Bloetjes</highlight> out of frustration with the slow and poorly executed way companies were adapting to the most transformative technology of our time. Combining deep theoretical knowledge, hands-on experience in the AI field, and successful integrations at other firms, he recognized the lack of high-quality solutions for business-wide AI transformation. This gap led to the creation of TransformAI, with the mission of making AI adoption both successful and sustainable."
     }
   },
   "LogoCloud": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -41,6 +41,10 @@
       "title": "Het bouwen van veerkrachtige AI-structuren binnen organisaties",
       "body": "AI verandert alles en vraagt om structurele aanpassingen in iedere afdeling van je bedrijf. Door de complexiteit is het niet eenvoudig om dit succesvol te realiseren. Dankzij onze expertise kan jouw organisatie zich duurzaam aanpassen en profiteren van de voordelen van AI.",
       "cta": "Casestudy: AI-integratie"
+    },
+    "Founder": {
+      "title": "Opgericht om AI-transformatie opnieuw vorm te geven",
+      "body": "TransformAI is opgericht door <highlight>Yergush Bloetjes</highlight> uit frustratie over de trage en slecht uitgevoerde manier waarop bedrijven de meest ingrijpende technologie van onze tijd omarmen. Met diepgaande theoretische kennis, praktijkervaring in AI en succesvolle implementaties bij andere organisaties, zag hij dat er een groot tekort was aan hoogwaardige oplossingen voor bedrijfsbrede AI-transformatie. Dit leidde tot de oprichting van TransformAI, met de missie om AI-adoptie zowel succesvol als duurzaam te maken."
     }
   },
   "LogoCloud": {


### PR DESCRIPTION
## Summary
- add About.Founder title and body copy in the English and Dutch message catalogs
- render the About founder heading/body through next-intl with markup support for the highlighted name
- log the content refresh in WRITE_HERE/UPDATES

## Plan
- add new translation entries for the founder section in en/nl
- refactor the About founder block to read the strings from the About namespace
- verify localization loading and record the change in the updates log

## Testing
- `pnpm --filter www run lint` *(fails: existing lint violations throughout the app unrelated to this change)*
- `pnpm --filter www run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ce7fb7c978832ab320b06052e69713