### PR TITLE
feat: update pricing header copy and styling

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-12T0900--refreshed-pricing-header.md
+++ b/WRITE_HERE/UPDATES/2025-11-12T0900--refreshed-pricing-header.md
@@ -1,0 +1,7 @@
+# Refreshed pricing header gradient and copy
+_When:_ 2025-11-12 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Updated the pricing page hero heading to localized gradient text that matches the enterprise CTA palette and added new translation keys.
+- **Why:** Aligns the section title with the updated comparison table, reinforces the gradient motif, and ensures English/Dutch localization coverage.
+- **Files:** `apps/www/app/[locale]/(site)/pricing/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/pricing/page.tsx
+++ b/apps/www/app/[locale]/(site)/pricing/page.tsx
@@ -7,6 +7,7 @@ import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/hero
 import { Check, Stars } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { useState } from "react";
 import {
   BelowEnterpriseSvg,
@@ -59,6 +60,7 @@ const buckets: Array<{ price: string; requests: number }> = [
 
 export default function PricingPage() {
   const { format } = Intl.NumberFormat(undefined, { notation: "compact" });
+  const t = useTranslations("Pricing.Header");
 
   const [selectedBucketIndex, setSelectedBucketIndex] = useState(0);
   return (
@@ -86,8 +88,10 @@ export default function PricingPage() {
       </div>
 
       <div className="flex flex-col items-center justify-center my-16 xl:my-24">
-        <h1 className="section-title-heading-gradient max-sm:mx-6 max-sm:text-4xl font-medium text-[4rem] leading-[4rem] max-w-xl text-center ">
-          Start for free, scale as you go
+        <h1
+          className="max-sm:mx-6 max-sm:text-4xl font-medium text-[4rem] leading-[4rem] max-w-xl text-center bg-gradient-to-r from-[#02DEFC] via-[#0239FC] to-[#7002FC] bg-clip-text text-transparent drop-shadow-[0_0_24px_rgba(32,57,252,0.45)]"
+        >
+          {t("title")}
         </h1>
 
         {/* <p className="mt-8 bg-gradient-to-br text-transparent bg-gradient-stop bg-clip-text from-white via-white via-40% to-white/30 max-w-lg text-center">

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -31,6 +31,9 @@
     }
   },
   "Pricing": {
+    "Header": {
+      "title": "Solutions We Offer"
+    },
     "Table": {
       "title": "Compare plans",
       "headers": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -31,6 +31,9 @@
     }
   },
   "Pricing": {
+    "Header": {
+      "title": "Oplossingen die wij bieden"
+    },
     "Table": {
       "title": "Vergelijk pakketten",
       "headers": {


### PR DESCRIPTION
## Summary
- replace the pricing hero heading with localized copy pulled from next-intl
- restyle the heading with the blue-to-purple gradient used by the Contact Us CTA and add a subtle glow
- add EN/NL message entries and log the change in WRITE_HERE/UPDATES

## Testing
- `pnpm --filter www run typecheck` *(fails: repository currently cannot resolve \\"next-intl\\" type declarations)*
- `pnpm --filter www run lint` *(fails: repository currently cannot resolve the \\"next-intl\\" package inside next.config.mjs)*

## Plan
- Update the pricing header markup to load localized text and mirror the CTA gradient in `apps/www/app/[locale]/(site)/pricing/page.tsx`.
- Add the new English and Dutch header strings in `apps/www/messages/en.json` and `apps/www/messages/nl.json`.
- Capture the change in WRITE_HERE/UPDATES and run www typecheck/lint (risk: mismatched gradient styling versus existing theme).


------
https://chatgpt.com/codex/tasks/task_e_68ce97a08180832aa055e785db0418c3