### PR TITLE
Update values section content and icons

### DIFF
--- a/WRITE_HERE/UPDATES/2025-09-20T1932--localized-values-icons.md
+++ b/WRITE_HERE/UPDATES/2025-09-20T1932--localized-values-icons.md
@@ -1,0 +1,5 @@
+# Localized values cards with icons
+- What: Updated the homepage values section to use new English and Dutch copy with lucide icons per card via the Values i18n namespace.
+- Why: Aligns the values messaging with the latest brief while ensuring locale switching and accessibility work as expected.
+- Files: apps/www/app/[locale]/(site)/page.tsx; apps/www/messages/en.json; apps/www/messages/nl.json.
+- Follow-ups: None.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -17,17 +17,14 @@ import { OssLight } from "@/components/svg/oss-light";
 import { UsageBento } from "@/components/usage-bento";
 import { isLocale } from "@/i18n/routing";
 import {
-  BarChart3,
   ChevronRight,
   Clock,
-  GraduationCap,
-  LineChart,
+  Handshake,
   LogIn,
-  Puzzle,
-  Rocket,
-  Scale,
-  Sprout,
-  Zap,
+  RefreshCcw,
+  ShieldCheck,
+  Sparkles,
+  Users2,
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -97,29 +94,26 @@ export default async function Landing({
     notFound();
   }
 
-  const [cta, platform, hero, featureSection] = await Promise.all([
+  const [cta, platform, hero, values] = await Promise.all([
     getTranslations({ locale, namespace: "CTA" }),
     getTranslations({ locale, namespace: "Platform" }),
     getTranslations({ locale, namespace: "Hero" }),
-    getTranslations({ locale, namespace: "FeatureSection" }),
+    getTranslations({ locale, namespace: "Values" }),
   ]);
 
   const featureBoxes = [
-    { key: "futureProofWorkforce", icon: GraduationCap },
-    { key: "revenueStreamAnalysis", icon: BarChart3 },
-    { key: "newOpportunities", icon: Sprout },
-    { key: "platformEfficiency", icon: Zap },
-    { key: "rightTiming", icon: Clock },
-    { key: "legalAssurance", icon: Scale },
-    { key: "agileExecution", icon: Rocket },
-    { key: "multiFieldExpertise", icon: Puzzle },
-    { key: "dataDrivenDecisions", icon: LineChart },
+    { key: "integrityInAI", icon: ShieldCheck },
+    { key: "rightTimedAdaptation", icon: Clock },
+    { key: "reinforcingWorkforce", icon: Users2 },
+    { key: "innovationWithPurpose", icon: Sparkles },
+    { key: "strategicAgility", icon: RefreshCcw },
+    { key: "partnershipNotService", icon: Handshake },
   ] as const;
 
   const featureItems = featureBoxes.map(({ key, icon }) => ({
     icon,
-    title: featureSection(`boxes.${key}.title`),
-    description: featureSection(`boxes.${key}.description`),
+    title: values(`${key}.title`),
+    description: values(`${key}.body`),
   }));
 
   return (
@@ -222,11 +216,11 @@ export default async function Landing({
           <Section className="mt-16 md:mt-32">
             <div className="relative">
               {/* TODO: horizontal scroll */}
-              <SectionTitle
-                className="mt-8 md:mt-16 lg:mt-32 xl:mt-48"
-                title={featureSection("title")}
-                text={featureSection("text")}
-              >
+            <SectionTitle
+              className="mt-8 md:mt-16 lg:mt-32 xl:mt-48"
+              title={values("sectionTitle")}
+              text={values("sectionText")}
+            >
                 <div className="flex mt-10 mb-10 space-x-6">
                   <Link href="https://app.unkey.com" className="group">
                     <PrimaryButton

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -298,46 +298,32 @@
     "title": "Our Platform (Beta)",
     "text": "We’re building the best platform to help businesses seamlessly integrate AI into their operations."
   },
-  "FeatureSection": {
-    "title": "Take Your AI Adoption to the Next Level",
-    "text": "The transition to AI is about more than just a platform. Our solution combines best practices with hands-on guidance to help companies adapt across all facets—technology, people, and processes—so integrations deliver maximum success.",
-    "boxes": {
-      "futureProofWorkforce": {
-        "title": "Future-proof workforce",
-        "description": "Upskill employees to boost productivity and ensure they remain valuable contributors."
-      },
-      "revenueStreamAnalysis": {
-        "title": "Revenue stream analysis",
-        "description": "Assess how AI impacts current income streams and adapt strategies accordingly."
-      },
-      "newOpportunities": {
-        "title": "New opportunities",
-        "description": "Identify and develop potential future income streams enabled by AI."
-      },
-      "platformEfficiency": {
-        "title": "Platform efficiency",
-        "description": "Unlock 11x productivity, reduced costs, and greater organisational clarity with our platform."
-      },
-      "rightTiming": {
-        "title": "Right timing",
-        "description": "Ensure AI integrations are launched at the optimal moment for maximum results."
-      },
-      "legalAssurance": {
-        "title": "Legal assurance",
-        "description": "Stay fully aligned with data protection and AI regulations worldwide."
-      },
-      "agileExecution": {
-        "title": "Agile execution",
-        "description": "With a lean team, we adapt faster than competitors to keep you ahead."
-      },
-      "multiFieldExpertise": {
-        "title": "Multi-field expertise",
-        "description": "Research, training, integrations, and product development—our wide scope creates well-rounded solutions."
-      },
-      "dataDrivenDecisions": {
-        "title": "Data-driven decisions",
-        "description": "Our research and analytics teams ensure every step is backed by data."
-      }
+  "Values": {
+    "sectionTitle": "Take Your AI Adoption to the Next Level",
+    "sectionText": "The transition to AI is about more than just a platform. Our solution combines best practices with hands-on guidance to help companies adapt across all facets—technology, people, and processes—so integrations deliver maximum success.",
+    "integrityInAI": {
+      "title": "Integrity in AI",
+      "body": "We ensure that every AI integration is transparent, ethical, and aligned with your company’s values — building trust at every step."
+    },
+    "rightTimedAdaptation": {
+      "title": "Right-Timed Adaptation",
+      "body": "We introduce AI solutions at the right phase. We never push what isn’t needed — we guide adoption where and when it delivers the most value."
+    },
+    "reinforcingWorkforce": {
+      "title": "Reinforcing Workforce",
+      "body": "We strengthen your existing teams. Through training and support, your people stay essential, productive, and future-ready in the AI era."
+    },
+    "innovationWithPurpose": {
+      "title": "Innovation with Purpose",
+      "body": "Our research-driven approach brings cutting-edge AI to real business problems — value over hype, outcomes over buzzwords."
+    },
+    "strategicAgility": {
+      "title": "Strategic Agility",
+      "body": "We move fast so you don’t fall behind. A lean structure enables rapid implementation and continuous improvement."
+    },
+    "partnershipNotService": {
+      "title": "Partnership, not just Service",
+      "body": "We don’t deliver and leave. We collaborate deeply, co-creating workflows and strategy so AI becomes a lasting advantage."
     }
   },
   "Footer": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -298,46 +298,32 @@
     "title": "Ons platform (Beta)",
     "text": "Wij bouwen aan het beste platform waarmee bedrijven AI moeiteloos in hun organisatie kunnen inzetten."
   },
-  "FeatureSection": {
-    "title": "Breng jouw AI-adoptie naar een hoger niveau",
-    "text": "De overgang naar AI gaat verder dan alleen een platform. Onze oplossing bundelt best practices met praktische begeleiding om bedrijven te helpen zich op alle vlakken aan te passen—technologie, mensen en processen—zodat integraties het meeste succes opleveren.",
-    "boxes": {
-      "futureProofWorkforce": {
-        "title": "Toekomstbestendig personeelsbestand",
-        "description": "Leid medewerkers op om productiever te worden en hun waarde voor de organisatie te behouden."
-      },
-      "revenueStreamAnalysis": {
-        "title": "Analyse van inkomstenstromen",
-        "description": "Breng in kaart hoe AI huidige inkomstenstromen beïnvloedt en pas strategieën aan."
-      },
-      "newOpportunities": {
-        "title": "Nieuwe kansen",
-        "description": "Ontdek en ontwikkel nieuwe inkomstenstromen mogelijk gemaakt door AI."
-      },
-      "platformEfficiency": {
-        "title": "Platformefficiëntie",
-        "description": "Bereik 11x productiviteit, lagere kosten en meer organisatorisch overzicht met ons platform."
-      },
-      "rightTiming": {
-        "title": "Juiste timing",
-        "description": "Zorg dat AI-integraties op het juiste moment worden uitgerold voor maximale impact."
-      },
-      "legalAssurance": {
-        "title": "Juridische zekerheid",
-        "description": "Voldoe altijd aan data- en AI-regelgeving wereldwijd."
-      },
-      "agileExecution": {
-        "title": "Wendbare uitvoering",
-        "description": "Dankzij een klein team bewegen wij sneller dan concurrenten, zodat jij voorop blijft."
-      },
-      "multiFieldExpertise": {
-        "title": "Multidisciplinaire expertise",
-        "description": "Onderzoek, training, integraties en productontwikkeling—onze brede scope leidt tot complete oplossingen."
-      },
-      "dataDrivenDecisions": {
-        "title": "Data-gedreven beslissingen",
-        "description": "Onze onderzoeks- en datateams zorgen dat elke stap onderbouwd is met data."
-      }
+  "Values": {
+    "sectionTitle": "Breng jouw AI-adoptie naar een hoger niveau",
+    "sectionText": "De overgang naar AI gaat verder dan alleen een platform. Onze oplossing bundelt best practices met praktische begeleiding om bedrijven te helpen zich op alle vlakken aan te passen—technologie, mensen en processen—zodat integraties het meeste succes opleveren.",
+    "integrityInAI": {
+      "title": "Integriteit in AI",
+      "body": "Wij zorgen dat elke AI-integratie transparant, ethisch en in lijn met jullie waarden gebeurt — vertrouwen staat altijd voorop."
+    },
+    "rightTimedAdaptation": {
+      "title": "Tijdige Adaptatie",
+      "body": "We introduceren AI-oplossingen in de juiste fase. We adviseren nooit wat niet nodig is — we sturen op adoptie waar en wanneer dit de meeste waarde oplevert."
+    },
+    "reinforcingWorkforce": {
+      "title": "Versterken van het Werkpersoneel",
+      "body": "We maken bestaande teams sterker. Met training en ondersteuning blijven medewerkers essentieel, productief en toekomstbestendig."
+    },
+    "innovationWithPurpose": {
+      "title": "Innovatie met Doel",
+      "body": "Onze onderzoeksgerichte aanpak brengt de nieuwste AI naar échte bedrijfsuitdagingen — waarde boven hype, resultaten boven buzzwords."
+    },
+    "strategicAgility": {
+      "title": "Strategische Wendbaarheid",
+      "body": "We schakelen snel zodat jouw organisatie niet achterraakt. Onze slanke structuur maakt snelle implementatie en continue verbetering mogelijk."
+    },
+    "partnershipNotService": {
+      "title": "Partnerschap, geen Dienstverlening",
+      "body": "We leveren niet en vertrekken. We werken nauw samen en co-creëren workflows en strategie zodat AI een blijvend voordeel wordt."
     }
   },
   "Footer": {


### PR DESCRIPTION
## Summary
- replace the homepage values data with six cards that use the new lucide icons and copy
- move the card strings into a dedicated `Values` translation namespace with English and Dutch entries
- log the change for continuity and verify type checking after the i18n updates

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: existing repository lint violations unrelated to this change)*

## Plan
- swap the values section data to reference lucide icons while keeping the layout intact
- add English and Dutch translations under a `Values` namespace and update lookups
- record the update and run lint/typecheck to confirm nothing regressed

------
https://chatgpt.com/codex/tasks/task_e_68cf009807b0832a84f1dc526ff301f3