### PR TITLE
Update About values content and localization

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-13T0900--updated-about-values-grid.md
+++ b/WRITE_HERE/UPDATES/2025-11-13T0900--updated-about-values-grid.md
@@ -1,0 +1,7 @@
+# Updated About page values grid
+_When:_ 2025-11-13 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Replaced the About page values cards with localized copy, icons, and translation keys stored under a new `Values` namespace.
+- **Why:** Aligns the section with TransformAI messaging while preserving layout and enabling Dutch/English localization.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -1,4 +1,13 @@
-import { ArrowRight } from "lucide-react";
+import {
+  ArrowRight,
+  Clock,
+  Handshake,
+  RefreshCcw,
+  ShieldCheck,
+  Sparkles,
+  Users2,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -137,6 +146,45 @@ export default async function Page({ params }: PageProps) {
     ),
   });
 
+  const values = [
+    {
+      key: "integrityInAi",
+      title: t("Values.integrityInAi.title"),
+      text: t("Values.integrityInAi.body"),
+      icon: ShieldCheck,
+    },
+    {
+      key: "rightTimedAdaptation",
+      title: t("Values.rightTimedAdaptation.title"),
+      text: t("Values.rightTimedAdaptation.body"),
+      icon: Clock,
+    },
+    {
+      key: "reinforcingWorkforce",
+      title: t("Values.reinforcingWorkforce.title"),
+      text: t("Values.reinforcingWorkforce.body"),
+      icon: Users2,
+    },
+    {
+      key: "innovationWithPurpose",
+      title: t("Values.innovationWithPurpose.title"),
+      text: t("Values.innovationWithPurpose.body"),
+      icon: Sparkles,
+    },
+    {
+      key: "strategicAgility",
+      title: t("Values.strategicAgility.title"),
+      text: t("Values.strategicAgility.body"),
+      icon: RefreshCcw,
+    },
+    {
+      key: "partnership",
+      title: t("Values.partnership.title"),
+      text: t("Values.partnership.body"),
+      icon: Handshake,
+    },
+  ];
+
   const posts = allPosts.filter((post) => SELECTED_POSTS.includes(post.slug));
   return (
     <div>
@@ -240,30 +288,9 @@ export default async function Page({ params }: PageProps) {
             />
             <div className="mx-auto md:px-5 lg:px-8">
               <div className="bg-white/10 overflow-hidden text-white mt-[62px] w-full gap-px grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 border-[1px] border-transparent rounded-3xl mb-10 ">
-                <Value
-                  text="We don't meet expectations; we redefine them by doing all the hard work upfront to craft an effortless user experience."
-                  title="Quality"
-                />
-                <Value
-                  text="Our default is to be open rather than closed. Simplicity, transparency, and honesty lead to the best results."
-                  title="Open company"
-                />
-                <Value
-                  title="Ownership"
-                  text="Our team members are given a high degree of autonomy to develop, implement, and iterate on their ideas."
-                />
-                <Value
-                  text="We prioritize quality while ensuring our team has a work-life balance that ensures they can deliver maximum value."
-                  title="Sustainability"
-                />
-                <Value
-                  text="We ship fast and work together with our users to solve real problems."
-                  title="Customer obsessed"
-                />
-                <Value
-                  text="We take security seriously and don't compromise in favour of velocity or user experience."
-                  title="Security first"
-                />
+                {values.map(({ key, title, text, icon }) => (
+                  <Value key={key} title={title} text={text} icon={icon} />
+                ))}
               </div>
             </div>
           </div>
@@ -432,11 +459,22 @@ function PhotoLabel({ text, className }: { text: string; className: string }) {
   );
 }
 
-function Value({ title, text }: { title: string; text: string }) {
+function Value({
+  title,
+  text,
+  icon: Icon,
+}: {
+  title: string;
+  text: string;
+  icon: LucideIcon;
+}) {
   return (
     <div className="flex bg-black p-10">
       <div>
-        <div className="flex items-center">
+        <div className="flex items-center gap-4">
+          <span className="flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-white/5">
+            <Icon aria-hidden="true" className="h-6 w-6 text-white" />
+          </span>
           <h3 className="font-medium">{title}</h3>
         </div>
         <p className="text-white/60 text-sm leading-6 lg:max-w-[4500px] xl:max-w-[280px] pt-2">

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -154,6 +154,32 @@
     "Founder": {
       "title": "Founded to redefine the AI transformation landscape",
       "body": "TransformAI was founded by <highlight>Yergush Bloetjes</highlight> out of frustration with the slow and poorly executed way companies were adapting to the most transformative technology of our time. Combining deep theoretical knowledge, hands-on experience in the AI field, and successful integrations at other firms, he recognized the lack of high-quality solutions for business-wide AI transformation. This gap led to the creation of TransformAI, with the mission of making AI adoption both successful and sustainable."
+    },
+    "Values": {
+      "integrityInAi": {
+        "title": "Integrity in AI",
+        "body": "We ensure that every AI integration is transparent, ethical, and aligned with your company’s values — building trust at every step."
+      },
+      "rightTimedAdaptation": {
+        "title": "Right-Timed Adaptation",
+        "body": "We introduce AI solutions at the right phase. We never push what isn’t needed — we guide adoption where and when it delivers the most value."
+      },
+      "reinforcingWorkforce": {
+        "title": "Reinforcing Workforce",
+        "body": "We strengthen your existing teams. Through training and support, your people stay essential, productive, and future-ready in the AI era."
+      },
+      "innovationWithPurpose": {
+        "title": "Innovation with Purpose",
+        "body": "Our research-driven approach brings cutting-edge AI to real business problems — value over hype, outcomes over buzzwords."
+      },
+      "strategicAgility": {
+        "title": "Strategic Agility",
+        "body": "We move fast so you don’t fall behind. A lean structure enables rapid implementation and continuous improvement."
+      },
+      "partnership": {
+        "title": "Partnership, not just Service",
+        "body": "We don’t deliver and leave. We collaborate deeply, co-creating workflows and strategy so AI becomes a lasting advantage."
+      }
     }
   },
   "LogoCloud": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -154,6 +154,32 @@
     "Founder": {
       "title": "Opgericht om AI-transformatie opnieuw vorm te geven",
       "body": "TransformAI is opgericht door <highlight>Yergush Bloetjes</highlight> uit frustratie over de trage en slecht uitgevoerde manier waarop bedrijven de meest ingrijpende technologie van onze tijd omarmen. Met diepgaande theoretische kennis, praktijkervaring in AI en succesvolle implementaties bij andere organisaties, zag hij dat er een groot tekort was aan hoogwaardige oplossingen voor bedrijfsbrede AI-transformatie. Dit leidde tot de oprichting van TransformAI, met de missie om AI-adoptie zowel succesvol als duurzaam te maken."
+    },
+    "Values": {
+      "integrityInAi": {
+        "title": "Integriteit in AI",
+        "body": "Wij zorgen dat elke AI-integratie transparant, ethisch en in lijn met jullie waarden gebeurt — vertrouwen staat altijd voorop."
+      },
+      "rightTimedAdaptation": {
+        "title": "Tijdige Adaptatie",
+        "body": "We introduceren AI-oplossingen in de juiste fase. We adviseren nooit wat niet nodig is — we sturen op adoptie waar en wanneer dit de meeste waarde oplevert."
+      },
+      "reinforcingWorkforce": {
+        "title": "Versterken van het Werkpersoneel",
+        "body": "We maken bestaande teams sterker. Met training en ondersteuning blijven medewerkers essentieel, productief en toekomstbestendig."
+      },
+      "innovationWithPurpose": {
+        "title": "Innovatie met Doel",
+        "body": "Onze onderzoeksgerichte aanpak brengt de nieuwste AI naar échte bedrijfsuitdagingen — waarde boven hype, resultaten boven buzzwords."
+      },
+      "strategicAgility": {
+        "title": "Strategische Wendbaarheid",
+        "body": "We schakelen snel zodat jouw organisatie niet achterraakt. Onze slanke structuur maakt snelle implementatie en continue verbetering mogelijk."
+      },
+      "partnership": {
+        "title": "Partnerschap, geen Dienstverlening",
+        "body": "We leveren niet en vertrekken. We werken nauw samen en co-creëren workflows en strategie zodat AI een blijvend voordeel wordt."
+      }
     }
   },
   "LogoCloud": {


### PR DESCRIPTION
## Summary
- add new About.Values translation entries for the refreshed values copy in English and Dutch
- render the values grid from localized data with the requested lucide icons while preserving layout
- log the content change in WRITE_HERE/UPDATES for future reference

## Plan
- define translation keys for each value card under the About.Values namespace in en/nl message catalogs
- refactor the About page values grid to consume those keys and attach the appropriate icons
- run checks, capture localized screenshots, and record the update log entry

## Testing
- `pnpm --filter www run lint` *(fails: existing repository lint violations unrelated to this change)*
- `pnpm --filter www run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68cf0968e580832abd19b89789e83cc5