### PR TITLE
Update About page values intro copy

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-14T0900--refined-about-values-intro.md
+++ b/WRITE_HERE/UPDATES/2025-11-14T0900--refined-about-values-intro.md
@@ -1,0 +1,7 @@
+# Updated About values intro copy
+_When:_ 2025-11-14 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Replaced the About page values intro heading and description with localized strings powered by the translation catalog.
+- **Why:** Aligns the section with updated messaging in both English and Dutch while keeping layout and styling intact.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -185,6 +185,9 @@ export default async function Page({ params }: PageProps) {
     },
   ];
 
+  const valuesIntroTitle = t("ValuesIntro.title");
+  const valuesIntroBody = t("ValuesIntro.body");
+
   const posts = allPosts.filter((post) => SELECTED_POSTS.includes(post.slug));
   return (
     <div>
@@ -281,10 +284,10 @@ export default async function Page({ params }: PageProps) {
               className="absolute right-0 scale-x-[-1] left-[-300px] pointer-events-none"
             />
             <SectionTitle
-              title="Driven by values"
+              title={valuesIntroTitle}
               className="mt-[200px] max-w-full"
               align="center"
-              text="Just as significant as the products we craft is the culture we cultivate - a culture defined by our unwavering commitment to our core values"
+              text={valuesIntroBody}
             />
             <div className="mx-auto md:px-5 lg:px-8">
               <div className="bg-white/10 overflow-hidden text-white mt-[62px] w-full gap-px grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 border-[1px] border-transparent rounded-3xl mb-10 ">

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -155,6 +155,10 @@
       "title": "Founded to redefine the AI transformation landscape",
       "body": "TransformAI was founded by <highlight>Yergush Bloetjes</highlight> out of frustration with the slow and poorly executed way companies were adapting to the most transformative technology of our time. Combining deep theoretical knowledge, hands-on experience in the AI field, and successful integrations at other firms, he recognized the lack of high-quality solutions for business-wide AI transformation. This gap led to the creation of TransformAI, with the mission of making AI adoption both successful and sustainable."
     },
+    "ValuesIntro": {
+      "title": "Driven by values",
+      "body": "AI transformation touches every part of a business — from technology to people, processes, and strategy. To maximize outcomes, we work from a set of guiding values that shape how we integrate AI sustainably and effectively."
+    },
     "Values": {
       "integrityInAi": {
         "title": "Integrity in AI",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -155,6 +155,10 @@
       "title": "Opgericht om AI-transformatie opnieuw vorm te geven",
       "body": "TransformAI is opgericht door <highlight>Yergush Bloetjes</highlight> uit frustratie over de trage en slecht uitgevoerde manier waarop bedrijven de meest ingrijpende technologie van onze tijd omarmen. Met diepgaande theoretische kennis, praktijkervaring in AI en succesvolle implementaties bij andere organisaties, zag hij dat er een groot tekort was aan hoogwaardige oplossingen voor bedrijfsbrede AI-transformatie. Dit leidde tot de oprichting van TransformAI, met de missie om AI-adoptie zowel succesvol als duurzaam te maken."
     },
+    "ValuesIntro": {
+      "title": "Gedreven door waarden",
+      "body": "AI-transformatie raakt alle onderdelen van een organisatie — van technologie tot mensen, processen en strategie. Om het maximale resultaat te behalen, werken wij vanuit kernwaarden die richting geven aan hoe wij AI duurzaam en effectief integreren."
+    },
     "Values": {
       "integrityInAi": {
         "title": "Integriteit in AI",


### PR DESCRIPTION
## Summary
- localize the About page values intro heading and description
- add English and Dutch translations for the new values intro copy
- log the content update in WRITE_HERE/UPDATES for project traceability

## Plan
- locate the About page values intro section and replace hard-coded copy with translation hooks
- register the new values intro strings in the English and Dutch message catalogs
- confirm layout remains unchanged while verifying home page content is untouched

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint`
- `pnpm -w turbo run build --filter=www`


------
https://chatgpt.com/codex/tasks/task_e_68cf98bd9c34832aa67daffd0e5c8715