### PR TITLE
Update About founder copy

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-15T0900--updated-about-founder-message.md
+++ b/WRITE_HERE/UPDATES/2025-11-15T0900--updated-about-founder-message.md
@@ -1,0 +1,7 @@
+# Updated About founder message
+_When:_ 2025-11-15 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Replaced the About page founder heading, subtitle, and body copy with localized strings for English and Dutch via the translation catalog.
+- **Why:** Aligns the founder story with the latest TransformAI messaging while keeping existing layout and styling intact.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -140,10 +140,9 @@ export default async function Page({ params }: PageProps) {
   const heroBody = t("Hero.body");
   const heroCta = t("Hero.cta");
   const founderTitle = t("Founder.title");
+  const founderSubtitle = t("Founder.subtitle");
   const founderBody = t.rich("Founder.body", {
-    highlight: (chunks) => (
-      <span className="font-medium text-white">{chunks}</span>
-    ),
+    br: () => <br />,
   });
 
   const values = [
@@ -301,17 +300,12 @@ export default async function Page({ params }: PageProps) {
             <StarDots className="absolute pointer-events-none" />
             <SectionTitle
               className="mt-60 px-[10px] text-balance"
-              title="A few words from the founders"
+              title={founderTitle}
               align="center"
-              text="Why we started Unkey and what we believe in."
+              text={founderSubtitle}
             />
             <div className="border-[1px] border-white/10 mt-[78px] leading-8 rounded-[48px] py-[60px] xl:py-[96px] px-8 md:px-[88px] text-white text-center max-w-[1008px] flex flex-col justify-center items-center">
-              <p className="about-founders-text-gradient">
-                We're James and Andreas. We founded Unkey with the vision of creating an API
-                management platform that is both powerful and easy to use. We believe that APIs are
-                the building blocks of the modern web, and we want to make it easier for developers
-                to build and manage them.
-              </p>
+              <p className="about-founders-text-gradient">{founderBody}</p>
               <div className="flex flex-col mt-12 md:flex-row">
                 <div className="flex md:left-[5px]">
                   <div className="text-sm text-right">

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -152,8 +152,9 @@
       "cta": "Case study: AI adaptation"
     },
     "Founder": {
-      "title": "Founded to redefine the AI transformation landscape",
-      "body": "TransformAI was founded by <highlight>Yergush Bloetjes</highlight> out of frustration with the slow and poorly executed way companies were adapting to the most transformative technology of our time. Combining deep theoretical knowledge, hands-on experience in the AI field, and successful integrations at other firms, he recognized the lack of high-quality solutions for business-wide AI transformation. This gap led to the creation of TransformAI, with the mission of making AI adoption both successful and sustainable."
+      "title": "Few words from our Founder",
+      "subtitle": "Why we started TransformAI",
+      "body": "Hi, my name is Yergush. I founded TransformAI after seeing how many organizations struggled with the complexity and pace of AI adoption. I wanted to help build a future where businesses can truly harness the power of AI.<br/><br/>With TransformAI, we’re heading in the right direction. It’s inspiring to see our team grow with such talented people and to witness the impact of the projects we’ve already delivered. At the same time, there is still so much more to achieve — and that excites me. I look forward to working with future partners to keep building the future, together."
     },
     "ValuesIntro": {
       "title": "Driven by values",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -152,8 +152,9 @@
       "cta": "Casestudy: AI-integratie"
     },
     "Founder": {
-      "title": "Opgericht om AI-transformatie opnieuw vorm te geven",
-      "body": "TransformAI is opgericht door <highlight>Yergush Bloetjes</highlight> uit frustratie over de trage en slecht uitgevoerde manier waarop bedrijven de meest ingrijpende technologie van onze tijd omarmen. Met diepgaande theoretische kennis, praktijkervaring in AI en succesvolle implementaties bij andere organisaties, zag hij dat er een groot tekort was aan hoogwaardige oplossingen voor bedrijfsbrede AI-transformatie. Dit leidde tot de oprichting van TransformAI, met de missie om AI-adoptie zowel succesvol als duurzaam te maken."
+      "title": "Een woord van onze oprichter",
+      "subtitle": "Waarom we TransformAI zijn gestart",
+      "body": "Hallo, mijn naam is Yergush. Ik heb TransformAI opgericht nadat ik zag hoe veel organisaties worstelden met de complexiteit en het tempo van AI-adoptie. Ik wilde bijdragen aan een toekomst waarin bedrijven de kracht van AI echt kunnen benutten.<br/><br/>Met TransformAI zetten we de juiste stappen. Het is inspirerend om ons team te zien groeien met zoveel talent en om het resultaat van onze projecten terug te zien bij onze klanten. Tegelijkertijd ligt er nog een enorme weg voor ons — en dat maakt mij enthousiast. Ik kijk ernaar uit om samen met toekomstige partners verder te bouwen aan de toekomst."
     },
     "ValuesIntro": {
       "title": "Gedreven door waarden",


### PR DESCRIPTION
## Summary
- localize the About page founder heading, subtitle, and body copy through the `About.Founder` namespace
- refresh English and Dutch message catalogs with the new founder story strings and `<br/>` separators for paragraph spacing
- log the content change in WRITE_HERE updates for project continuity

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: repository has existing lint issues unrelated to this change, e.g., legacy copy with unescaped apostrophes)*
- `pnpm -w turbo run build --filter=www` *(fails: same lint violations surface during Next.js build)*

## Plan
- Update the About page founder section to pull its heading/subheading/body from the i18n catalog and support line breaks.
- Replace the English and Dutch founder entries with the supplied messaging.
- Record the change in WRITE_HERE updates and rerun workspace checks.

------
https://chatgpt.com/codex/tasks/task_e_68cf9ed56274832a9a017d446792b731