### PR TITLE
Localize About page FAQ

### DIFF
--- a/WRITE_HERE/UPDATES/2025-09-21T0656--localized-about-faq.md
+++ b/WRITE_HERE/UPDATES/2025-09-21T0656--localized-about-faq.md
@@ -1,0 +1,7 @@
+# Localized About page FAQ
+_When:_ 2025-09-21 06:56 UTC · _Scope:_ apps/www · _Author:_ AI Assistant
+
+- **What:** Updated the About page Q&A accordion to pull localized copy for three questions and answers.
+- **Why:** Replace placeholder Unkey content with accurate messaging and support EN/NL translations.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -341,37 +341,26 @@ export default async function Page({ params }: PageProps) {
                     value="item-1"
                     className="border border-white/10 rounded-tr-[20px] rounded-tl-[20px]"
                   >
-                    <AccordionTriggerAbout>What's your goal with Unkey?</AccordionTriggerAbout>
+                    <AccordionTriggerAbout>
+                      {t("FAQ.q1.title")}
+                    </AccordionTriggerAbout>
                     <AccordionContent className="pl-10">
-                      Our goal with Unkey is build an open source API management platform that
-                      doesn’t require the burden or cost of traditional API management platforms
-                      like Kong or Azure APM. We want to embrace what developers know today, a
-                      global REST API that allows you to deploy and protect your API on the edge in
-                      under 5 minutes.{" "}
+                      {t("FAQ.q1.body")}
                     </AccordionContent>
                   </AccordionItem>
                   <AccordionItem value="item-2" className="border border-white/10">
-                    <AccordionTriggerAbout>
-                      What's something you're particularly happy about at Unkey?
-                    </AccordionTriggerAbout>
+                    <AccordionTriggerAbout>{t("FAQ.q2.title")}</AccordionTriggerAbout>
                     <AccordionContent className="pl-10">
-                      We are extremely happy with the culture we have built at Unkey, our team is
-                      small but powerful. Everyone in our team has input on the next feature or idea
-                      we have for Unkey, allowing us to build the best API management platform.{" "}
+                      {t("FAQ.q2.body")}
                     </AccordionContent>
                   </AccordionItem>
                   <AccordionItem
                     value="item-3"
                     className="border border-white/10 rounded-br-[20px] rounded-bl-[20px]"
                   >
-                    <AccordionTriggerAbout>
-                      What's something you're less happy about?
-                    </AccordionTriggerAbout>
+                    <AccordionTriggerAbout>{t("FAQ.q3.title")}</AccordionTriggerAbout>
                     <AccordionContent className="pl-10">
-                      While we are happy with Unkey overall knowing when to build tall or wide is a
-                      problem we run into frequently. Having a small team and focusing on incredible
-                      DX means that adding new features or improving currents ones means that we
-                      have to be certain that it will bring value to our users.{" "}
+                      {t("FAQ.q3.body")}
                     </AccordionContent>
                   </AccordionItem>
                 </Accordion>

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -156,6 +156,20 @@
       "subtitle": "Why we started TransformAI",
       "body": "Hi, my name is Yergush. I founded TransformAI after seeing how many organizations struggled with the complexity and pace of AI adoption. I wanted to help build a future where businesses can truly harness the power of AI.<br/><br/>With TransformAI, we’re heading in the right direction. It’s inspiring to see our team grow with such talented people and to witness the impact of the projects we’ve already delivered. At the same time, there is still so much more to achieve — and that excites me. I look forward to working with future partners to keep building the future, together."
     },
+    "FAQ": {
+      "q1": {
+        "title": "What’s your goal with TransformAI?",
+        "body": "Our goal is to make AI adoption clear, structured, and achievable for every organization. Too often, businesses struggle with complexity and uncertainty. We help by creating resilient workflows, guiding strategic decisions, and ensuring AI is integrated at the right time, in the right way."
+      },
+      "q2": {
+        "title": "What’s something you’re most proud of at TransformAI?",
+        "body": "We are proud of how we bring together research, education, and hands-on integration. Our team combines technical expertise with business understanding, which allows us to deliver practical solutions that create real value. Seeing companies become more productive and future-proof is what motivates us every day."
+      },
+      "q3": {
+        "title": "What’s something that still challenges you?",
+        "body": "AI evolves quickly, and so do the regulations and expectations around it. One of our ongoing challenges is balancing innovation with responsibility — making sure that companies can move fast, but always with the right governance, timing, and ethical considerations."
+      }
+    },
     "ValuesIntro": {
       "title": "Driven by values",
       "body": "AI transformation touches every part of a business — from technology to people, processes, and strategy. To maximize outcomes, we work from a set of guiding values that shape how we integrate AI sustainably and effectively."

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -156,6 +156,20 @@
       "subtitle": "Waarom we TransformAI zijn gestart",
       "body": "Hallo, mijn naam is Yergush. Ik heb TransformAI opgericht nadat ik zag hoe veel organisaties worstelden met de complexiteit en het tempo van AI-adoptie. Ik wilde bijdragen aan een toekomst waarin bedrijven de kracht van AI echt kunnen benutten.<br/><br/>Met TransformAI zetten we de juiste stappen. Het is inspirerend om ons team te zien groeien met zoveel talent en om het resultaat van onze projecten terug te zien bij onze klanten. Tegelijkertijd ligt er nog een enorme weg voor ons — en dat maakt mij enthousiast. Ik kijk ernaar uit om samen met toekomstige partners verder te bouwen aan de toekomst."
     },
+    "FAQ": {
+      "q1": {
+        "title": "Wat is jullie doel met TransformAI?",
+        "body": "Ons doel is om AI-adoptie helder, gestructureerd en haalbaar te maken voor elke organisatie. Bedrijven worstelen vaak met complexiteit en onzekerheid. Wij helpen door robuuste workflows te bouwen, strategische keuzes te begeleiden en te zorgen dat AI op het juiste moment en op de juiste manier wordt geïntegreerd."
+      },
+      "q2": {
+        "title": "Waar zijn jullie het meest trots op bij TransformAI?",
+        "body": "Wij zijn trots dat we onderzoek, educatie en praktische integratie samenbrengen. Ons team combineert technische kennis met zakelijk inzicht, waardoor we oplossingen leveren die écht waarde creëren. Het zien van bedrijven die productiever en toekomstbestendig worden, motiveert ons elke dag."
+      },
+      "q3": {
+        "title": "Wat blijft nog een uitdaging?",
+        "body": "AI ontwikkelt zich razendsnel, net als de regelgeving en verwachtingen daaromheen. Een blijvende uitdaging is de balans tussen innovatie en verantwoordelijkheid — zorgen dat organisaties snel kunnen handelen, maar altijd met de juiste governance, timing en ethische afwegingen."
+      }
+    },
     "ValuesIntro": {
       "title": "Gedreven door waarden",
       "body": "AI-transformatie raakt alle onderdelen van een organisatie — van technologie tot mensen, processen en strategie. Om het maximale resultaat te behalen, werken wij vanuit kernwaarden die richting geven aan hoe wij AI duurzaam en effectief integreren."


### PR DESCRIPTION
## Summary
- replace the About page accordion’s hard-coded Q&A copy with translations from the About.FAQ namespace
- add English and Dutch strings for the three FAQ entries while keeping EN as the fallback
- log the localization update in WRITE_HERE/UPDATES

## Testing
- pnpm --filter www run typecheck
- pnpm --filter www run lint *(fails: existing lint issues in unrelated components)*
- pnpm -w turbo run build --filter=www *(fails: same lint errors from untouched files)*

## Plan
- update the About accordion JSX to consume localized FAQ strings
- define the new About.FAQ keys in en.json and nl.json
- record the content update in WRITE_HERE
- run typecheck, lint, and build to surface any regressions

------
https://chatgpt.com/codex/tasks/task_e_68cfa15503f8832a85e508ca72cf4ae4