### PR TITLE
Hide investor section on About page

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-16T0900--hid-about-investors-section.md
+++ b/WRITE_HERE/UPDATES/2025-11-16T0900--hid-about-investors-section.md
@@ -1,0 +1,7 @@
+# Hid About investors section
+_When:_ 2025-11-16 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Added a feature flag to disable rendering of the "Backed by the finest" investors block on the About page while keeping the original content in code for future reuse.
+- **Why:** The user requested that the investors section not be displayed on the About page but preserved in the source.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -90,6 +90,9 @@ export const metadata = {
   },
 };
 
+// Keep investor content available but disabled per TransformAI request.
+const SHOW_INVESTORS_SECTION = false;
+
 const investors = [
   { name: "Timothy Chen", firm: "Essence VC", image: tim },
   { name: "Liu Jiang", firm: "Sunflower Capital", image: liu },
@@ -387,29 +390,33 @@ export default async function Page({ params }: PageProps) {
             </div>
 
             <div className="flex flex-col max-w-full">
-              <SectionTitle
-                className="mt-[250px]"
-                align="center"
-                title="Backed by the finest"
-                text="At Unkey, we're privileged to receive backing from top-tier investors, visionary founders, and seasoned operators from across the globe. Here are just a few of them: "
-              />
-              <div className="grid justify-center w-full grid-cols-2 pt-24 mx-auto md:grid-cols-3 lg:grid-cols-5 ">
-                {investors.map(({ name, firm, image }) => {
-                  return (
-                    <div
-                      key={name}
-                      className="flex flex-col items-center justify-center pb-12 text-center md:last:col-span-3 lg:last:col-span-1"
-                    >
-                      <ImageWithBlur src={image} alt={name} className="w-12 h-12 rounded-full" />
-                      <p className="mt-8 text-sm font-bold text-white md:whitespace-nowrap">
-                        {name}
-                      </p>
-                      <p className="text-sm text-white/60 md:whitespace-nowrap">{firm}</p>
-                    </div>
-                  );
-                })}
-              </div>
-              <div className="w-full h-[1px] bg-gradient-to-r from-black to-black via-white/40 mt-[100px] lg:mt-[80px]" />
+              {SHOW_INVESTORS_SECTION ? (
+                <>
+                  <SectionTitle
+                    className="mt-[250px]"
+                    align="center"
+                    title="Backed by the finest"
+                    text="At Unkey, we're privileged to receive backing from top-tier investors, visionary founders, and seasoned operators from across the globe. Here are just a few of them: "
+                  />
+                  <div className="grid justify-center w-full grid-cols-2 pt-24 mx-auto md:grid-cols-3 lg:grid-cols-5 ">
+                    {investors.map(({ name, firm, image }) => {
+                      return (
+                        <div
+                          key={name}
+                          className="flex flex-col items-center justify-center pb-12 text-center md:last:col-span-3 lg:last:col-span-1"
+                        >
+                          <ImageWithBlur src={image} alt={name} className="w-12 h-12 rounded-full" />
+                          <p className="mt-8 text-sm font-bold text-white md:whitespace-nowrap">
+                            {name}
+                          </p>
+                          <p className="text-sm text-white/60 md:whitespace-nowrap">{firm}</p>
+                        </div>
+                      );
+                    })}
+                  </div>
+                  <div className="w-full h-[1px] bg-gradient-to-r from-black to-black via-white/40 mt-[100px] lg:mt-[80px]" />
+                </>
+              ) : null}
               <SectionTitle
                 className="mt-[100px] lg:mt-[100px]"
                 align="center"


### PR DESCRIPTION
## Summary
- Hide the About page investor highlight block behind a feature flag so the section stays in source but does not render.
- Log the visibility change for the About page investors section in `WRITE_HERE/UPDATES`.

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: repository already contains numerous lint violations, e.g. `react/no-unescaped-entities` in existing files.)*
- `pnpm --filter www run build` *(fails: Next.js build re-runs lint and surfaces the same pre-existing violations.)*

## Plan
- Introduce a toggle to guard the About page investor section without removing its data.
- Wrap the JSX block in the toggle to prevent the UI from rendering the investor grid.
- Record the adjustment in the updates log for visibility tracking.


------
https://chatgpt.com/codex/tasks/task_e_68cfa18a50a4832a9fe350862510810f