### PR TITLE
Add Ask TransformAI assistant chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables for the mini chat
+TRANSFORMAI_ASSISTANT_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 # Local env files
 .env
 .env.local
+.env.*.local
 .env.development.local
 .env.test.local
 .env.production.local

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This repository is for the Unkey marketing materials and resources, it includes 
 
 Follow our [contributing guide](https://engineering.unkey.com/contributing)
 
+## Getting Started
+
+Copy `.env.example` to `.env.local` and set `TRANSFORMAI_ASSISTANT_KEY` before working with the assistant chat experience.
+
 ## Running locally
 
 You can find the instructions for each project in their respective directories.

--- a/WRITE_HERE/UPDATES/2025-11-17T0900--added-homepage-assistant-chat.md
+++ b/WRITE_HERE/UPDATES/2025-11-17T0900--added-homepage-assistant-chat.md
@@ -1,0 +1,7 @@
+# Added homepage assistant chat experience
+_When:_ 2025-11-17 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Introduced the “Ask the TransformAI” CTA with a lazy-loaded sticky chat surface, localized UI strings, focus management, and a basic proxy API with rate limiting.
+- **Why:** Delivers the requested mini chat experience directly below the existing assistant section while keeping interactions on-brand and accessible.
+- **Files:** `.env.example`, `.gitignore`, `README.md`, `apps/www/app/api/assistant/route.ts`, `apps/www/app/code-examples.tsx`, `apps/www/app/globals.css`, `apps/www/components/ask/*`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Replace the stubbed reply logic in the API route with the actual model integration once available.

--- a/apps/www/app/api/assistant/route.ts
+++ b/apps/www/app/api/assistant/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest } from "next/server";
+
+type ChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 8;
+
+const tokenBuckets = new Map<string, { tokens: number; updatedAt: number }>();
+
+export async function POST(request: NextRequest) {
+  if (!process.env.TRANSFORMAI_ASSISTANT_KEY) {
+    console.error("[assistant] Missing TRANSFORMAI_ASSISTANT_KEY environment variable.");
+    return jsonResponse({ error: "unauthorized" }, 401);
+  }
+
+  const identifier = getClientIdentifier(request);
+
+  if (!takeToken(identifier)) {
+    return jsonResponse({ error: "rate_limited" }, 429);
+  }
+
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({ error: "invalid_request" }, 400);
+  }
+
+  const messages = Array.isArray((body as { messages?: unknown }).messages)
+    ? ((body as { messages: ChatMessage[] }).messages ?? [])
+    : [];
+
+  const sanitizedMessages = messages
+    .filter((message): message is ChatMessage => {
+      return Boolean(message) && typeof message.content === "string";
+    })
+    .map((message) => ({
+      role: message.role === "assistant" ? "assistant" : "user",
+      content: message.content.slice(0, 4000),
+    }));
+
+  const lastUserMessage = [...sanitizedMessages]
+    .reverse()
+    .find((message) => message.role === "user");
+
+  const reply = buildReply(lastUserMessage?.content);
+
+  return jsonResponse({ message: reply }, 200);
+}
+
+function jsonResponse(payload: unknown, status: number) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store",
+    },
+  });
+}
+
+function getClientIdentifier(request: NextRequest) {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    return forwardedFor.split(",").at(0)?.trim() ?? "anonymous";
+  }
+
+  if (request.ip) {
+    return request.ip;
+  }
+
+  return "anonymous";
+}
+
+function takeToken(identifier: string) {
+  const now = Date.now();
+  const bucket = tokenBuckets.get(identifier);
+
+  if (!bucket) {
+    tokenBuckets.set(identifier, {
+      tokens: RATE_LIMIT_MAX_REQUESTS - 1,
+      updatedAt: now,
+    });
+    return true;
+  }
+
+  const elapsed = now - bucket.updatedAt;
+  const tokensToAdd = (elapsed / RATE_LIMIT_WINDOW_MS) * RATE_LIMIT_MAX_REQUESTS;
+  const refreshedTokens = Math.min(RATE_LIMIT_MAX_REQUESTS, bucket.tokens + tokensToAdd);
+
+  if (refreshedTokens < 1) {
+    bucket.tokens = refreshedTokens;
+    bucket.updatedAt = now;
+    tokenBuckets.set(identifier, bucket);
+    return false;
+  }
+
+  bucket.tokens = refreshedTokens - 1;
+  bucket.updatedAt = now;
+  tokenBuckets.set(identifier, bucket);
+  return true;
+}
+
+function buildReply(input?: string) {
+  const normalized = input?.toLowerCase() ?? "";
+  const response: string[] = [];
+
+  response.push("Thanks for reaching out to TransformAI! Here's how we can help next:");
+
+  if (normalized.includes("price") || normalized.includes("cost") || normalized.includes("prijs")) {
+    response.push(
+      "- **Transparent pricing:** Our introduction package is €5,000 (one-time) and the education program starts at €6,000. Enterprise solutions are tailored with a dedicated proposal.",
+    );
+  }
+
+  if (normalized.includes("call") || normalized.includes("meeting") || normalized.includes("intro")) {
+    response.push(
+      "- **Book an intro call:** Share a couple of time slots or request one via hello@transformai.nl — we usually reply within one business day.",
+    );
+  }
+
+  if (
+    normalized.includes("compliance") ||
+    normalized.includes("governance") ||
+    normalized.includes("regulated") ||
+    normalized.includes("risk")
+  ) {
+    response.push(
+      "- **Governance & compliance:** We embed legal, security, and change-management checkpoints so AI can launch safely in regulated environments.",
+    );
+  }
+
+  response.push(
+    "- **What you receive:** We map high-impact workflows, coach your teams on responsible AI adoption, and build the first automations together.",
+  );
+  response.push(
+    "Let me know if you’d like case studies, a proposal draft, or a workshop agenda — happy to send resources tailored to your question.",
+  );
+
+  return response.join("\n");
+}

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { AskCta } from "@/components/ask/AskCta";
+import type { StickyChatProps } from "@/components/ask/StickyChat";
 import { PrimaryButton, SecondaryButton } from "@/components/button";
 import { SectionTitle } from "@/components/section";
 import type { LangIconProps } from "@/components/svg/lang-icons";
@@ -20,8 +22,7 @@ import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import type { PrismTheme } from "prism-react-renderer";
-import React, { useEffect } from "react";
-import { useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 const Tabs = TabsPrimitive.Root;
 
 const editorTheme = {
@@ -555,9 +556,105 @@ LanguageTrigger.displayName = TabsPrimitive.Trigger.displayName;
 export const CodeExamples: React.FC<Props> = ({ className }) => {
   const t = useTranslations("CodeExamples");
   const cta = useTranslations("CTA");
+  const ask = useTranslations("AskAssistant");
+  const [isChatOpen, setIsChatOpen] = useState(false);
+  const [isChatLoading, setIsChatLoading] = useState(false);
+  const [ChatSurface, setChatSurface] = useState<React.ComponentType<StickyChatProps> | null>(null);
+  const ctaRef = useRef<HTMLButtonElement>(null);
+  const isMountedRef = useRef(true);
   const [language, setLanguage] = useState<Language>("Typescript");
   const [framework, setFramework] = useState<FrameworkName>("Typescript");
   const [languageHover, setLanguageHover] = useState("Typescript");
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const askStrings = useMemo(
+    () => ({
+      title: ask("panel.title"),
+      status: ask("panel.status"),
+      close: ask("panel.close"),
+      assistantLabel: ask("panel.assistantLabel"),
+      userLabel: ask("panel.userLabel"),
+      placeholder: ask("panel.placeholder"),
+      send: ask("panel.send"),
+      sendTooltip: ask("panel.sendTooltip"),
+      typing: ask("panel.typing"),
+      emptyTitle: ask("panel.emptyTitle"),
+      emptyDescription: ask("panel.emptyDescription"),
+      suggestions: [
+        ask("panel.suggestions.0"),
+        ask("panel.suggestions.1"),
+        ask("panel.suggestions.2"),
+        ask("panel.suggestions.3"),
+      ],
+      error: ask("panel.error"),
+      rateLimited: ask("panel.rateLimited"),
+      unauthorized: ask("panel.unauthorized"),
+      retry: ask("panel.retry"),
+      transcriptLabel: ask("panel.transcriptLabel"),
+      intro: ask("panel.intro"),
+    }),
+    [ask],
+  );
+
+  const askCtaLabel = ask("cta.label");
+
+  const ensureChatLoaded = useCallback(async () => {
+    if (ChatSurface) {
+      return ChatSurface;
+    }
+    setIsChatLoading(true);
+    try {
+      const module = await import("@/components/ask/StickyChat");
+      if (isMountedRef.current) {
+        setChatSurface(() => module.StickyChat);
+      }
+      return module.StickyChat;
+    } catch (error) {
+      console.error(error);
+      throw error;
+    } finally {
+      if (isMountedRef.current) {
+        setIsChatLoading(false);
+      }
+    }
+  }, [ChatSurface]);
+
+  const handleChatToggle = useCallback(async () => {
+    if (!ChatSurface) {
+      try {
+        await ensureChatLoaded();
+        if (isMountedRef.current) {
+          setIsChatOpen(true);
+        }
+      } catch (error) {
+        console.error(error);
+      }
+      return;
+    }
+
+    setIsChatOpen((previous) => !previous);
+  }, [ChatSurface, ensureChatLoaded]);
+
+  const handleChatClose = useCallback(() => {
+    setIsChatOpen(false);
+  }, []);
+
+  const handleAskToggle = useCallback(() => {
+    void handleChatToggle();
+  }, [handleChatToggle]);
+
+  const prefetchChat = useCallback(() => {
+    if (!ChatSurface) {
+      void ensureChatLoaded().catch((error) => {
+        console.error(error);
+      });
+    }
+  }, [ChatSurface, ensureChatLoaded]);
   function getLanguage({
     language,
     framework,
@@ -605,6 +702,37 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
           <MeteorLines className="ml-16 fade-in-100" delay={2} number={1} />
         </div>
       </SectionTitle>
+      <div className="relative mt-14 flex flex-col items-center sm:mt-16">
+        <div aria-hidden className="h-10 sm:h-12" />
+        <div className="flex w-full justify-center">
+          {ChatSurface ? (
+            <ChatSurface
+              isOpen={isChatOpen}
+              onClose={handleChatClose}
+              focusReturnRef={ctaRef}
+              strings={askStrings}
+            />
+          ) : (
+            <div
+              className="relative w-full max-w-[760px] min-h-[26rem] sm:min-h-[28rem]"
+              aria-hidden
+            />
+          )}
+        </div>
+        <div aria-hidden className="h-8 sm:h-10" />
+        <div className="flex w-full justify-center">
+          <AskCta
+            ref={ctaRef}
+            label={askCtaLabel}
+            pressed={isChatOpen}
+            onToggle={handleAskToggle}
+            loading={isChatLoading}
+            onMouseEnter={prefetchChat}
+            onFocus={prefetchChat}
+          />
+        </div>
+        <div aria-hidden className="h-12 sm:h-14" />
+      </div>
       <SectionTitle
         title={t("bottom.title")}
         text={t("bottom.text")}

--- a/apps/www/app/globals.css
+++ b/apps/www/app/globals.css
@@ -268,6 +268,56 @@ li > p {
   animation: slideGradient 1.5s linear forwards;
 }
 
+.ask-typing-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, rgba(2, 252, 241, 0.8), rgba(2, 57, 252, 0.8));
+  animation: askTyping 1.2s ease-in-out infinite;
+}
+
+.ask-plane {
+  animation: askPlane 0.45s ease-out;
+}
+
+@keyframes askTyping {
+  0%,
+  80%,
+  100% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+
+  40% {
+    opacity: 1;
+    transform: translateY(-2px);
+  }
+}
+
+@keyframes askPlane {
+  0% {
+    transform: translateX(0) translateY(0) rotate(0deg);
+  }
+
+  50% {
+    transform: translateX(6px) translateY(-3px) rotate(8deg);
+  }
+
+  100% {
+    transform: translateX(0) translateY(0) rotate(0deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ask-typing-dot {
+    animation: none;
+  }
+
+  .ask-plane {
+    animation: none;
+  }
+}
+
 @keyframes slideGradient {
   from {
     left: -50%;

--- a/apps/www/components/ask/AskCta.tsx
+++ b/apps/www/components/ask/AskCta.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Sparkles } from "lucide-react";
+import { forwardRef, type FocusEventHandler, type MouseEventHandler } from "react";
+
+type AskCtaProps = {
+  label: string;
+  pressed: boolean;
+  onToggle: () => void;
+  className?: string;
+  loading?: boolean;
+  onMouseEnter?: MouseEventHandler<HTMLButtonElement>;
+  onFocus?: FocusEventHandler<HTMLButtonElement>;
+};
+
+export const AskCta = forwardRef<HTMLButtonElement, AskCtaProps>(
+  (
+    { label, pressed, onToggle, className, loading = false, onMouseEnter, onFocus },
+    ref,
+  ) => {
+    return (
+      <button
+        type="button"
+        ref={ref}
+        aria-pressed={pressed}
+        onClick={onToggle}
+        disabled={loading}
+        onMouseEnter={onMouseEnter}
+        onFocus={onFocus}
+        className={cn(
+          "group relative inline-flex items-center justify-center rounded-full transition-transform duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black motion-safe:active:scale-[0.98]",
+          "hero-hiring-gradient p-[1.5px]",
+          "aria-[pressed=true]:ring-1 aria-[pressed=true]:ring-white/40",
+          loading ? "cursor-wait" : "",
+          className,
+        )}
+      >
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-[1.5px] rounded-full bg-white/10 opacity-0 transition-opacity duration-300 group-hover:opacity-20 group-active:opacity-25"
+        />
+        <span
+          className={cn(
+            "relative flex items-center gap-2 rounded-full px-6 py-3 text-sm font-medium text-white sm:px-8",
+            "bg-black/60 backdrop-blur-xl",
+            "shadow-[0_18px_40px_rgba(15,23,42,0.45)]",
+          )}
+        >
+          {loading ? (
+            <span
+              className="inline-flex h-4 w-4 items-center justify-center"
+              aria-hidden
+            >
+              <span className="h-3.5 w-3.5 rounded-full border border-white/50 border-t-transparent motion-safe:animate-spin" />
+            </span>
+          ) : (
+            <Sparkles className="h-4 w-4 text-white/80" aria-hidden />
+          )}
+          <span>{label}</span>
+        </span>
+      </button>
+    );
+  },
+);
+
+AskCta.displayName = "AskCta";

--- a/apps/www/components/ask/ChatPanel.tsx
+++ b/apps/www/components/ask/ChatPanel.tsx
@@ -1,0 +1,480 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Send, Sparkles, User, X } from "lucide-react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import type { ChatMessage } from "./types";
+
+type ChatPanelStrings = {
+  title: string;
+  status: string;
+  close: string;
+  assistantLabel: string;
+  userLabel: string;
+  placeholder: string;
+  send: string;
+  sendTooltip: string;
+  typing: string;
+  emptyTitle: string;
+  emptyDescription: string;
+  suggestions: string[];
+  error: string;
+  rateLimited: string;
+  unauthorized: string;
+  retry: string;
+  transcriptLabel: string;
+  intro: string;
+};
+
+type ChatPanelProps = {
+  isOpen: boolean;
+  messages: ChatMessage[];
+  onSend: (value: string, options?: { retry?: boolean }) => Promise<void> | void;
+  onRetry: () => Promise<void> | void;
+  onClose: () => void;
+  isTyping: boolean;
+  error: string | null;
+  strings: ChatPanelStrings;
+};
+
+const focusableSelector =
+  "a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex='-1'])";
+
+export const ChatPanel: React.FC<ChatPanelProps> = ({
+  isOpen,
+  messages,
+  onSend,
+  onRetry,
+  onClose,
+  isTyping,
+  error,
+  strings,
+}) => {
+  const [value, setValue] = useState("");
+  const [planeActive, setPlaneActive] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const focusScopeRef = useRef<HTMLDivElement>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  const hasMessages = messages.length > 0;
+
+  const resetTextareaHeight = useCallback(() => {
+    const textarea = inputRef.current;
+    if (!textarea) return;
+    textarea.style.height = "auto";
+    textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      inputRef.current?.focus({ preventScroll: true });
+      resetTextareaHeight();
+    }, 80);
+
+    return () => window.clearTimeout(timeout);
+  }, [isOpen, resetTextareaHeight]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const scope = focusScopeRef.current;
+    if (!scope) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const focusable = Array.from(
+        scope.querySelectorAll<HTMLElement>(focusableSelector),
+      ).filter((element) => element.offsetParent !== null || element === document.activeElement);
+
+      if (focusable.length === 0) {
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    const scrollArea = scrollRef.current;
+    if (!scrollArea) {
+      return;
+    }
+
+    const scrollBehavior: ScrollBehavior = prefersReducedMotion ? "auto" : "smooth";
+    scrollArea.scrollTo({ top: scrollArea.scrollHeight, behavior: scrollBehavior });
+  }, [messages, isTyping, prefersReducedMotion]);
+
+  useEffect(() => {
+    if (!planeActive) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setPlaneActive(false);
+    }, 420);
+
+    return () => window.clearTimeout(timeout);
+  }, [planeActive]);
+
+  const handleSubmit = useCallback(async () => {
+    const trimmed = value.trim();
+    if (!trimmed || isTyping) {
+      return;
+    }
+
+    try {
+      setPlaneActive(true);
+      await onSend(trimmed);
+      setValue("");
+      resetTextareaHeight();
+    } catch (error) {
+      console.error(error);
+    }
+  }, [isTyping, onSend, resetTextareaHeight, value]);
+
+  const handleFormSubmit = useCallback<React.FormEventHandler<HTMLFormElement>>(
+    (event) => {
+      event.preventDefault();
+      void handleSubmit();
+    },
+    [handleSubmit],
+  );
+
+  const handleKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = (event) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      void handleSubmit();
+    }
+  };
+
+  const handleInput: React.ChangeEventHandler<HTMLTextAreaElement> = (event) => {
+    setValue(event.target.value);
+    window.requestAnimationFrame(resetTextareaHeight);
+  };
+
+  const handleSuggestion = (suggestion: string) => {
+    setValue(suggestion);
+    window.requestAnimationFrame(resetTextareaHeight);
+    inputRef.current?.focus({ preventScroll: true });
+  };
+
+  const disableSend = !value.trim() || isTyping;
+
+  const transcriptId = useIdWithPrefix("ask-transcript");
+
+  return (
+    <div
+      ref={focusScopeRef}
+      className={cn(
+        "relative flex w-full max-w-[760px] flex-col gap-4 rounded-3xl border border-white/10 bg-neutral-950/90 p-4 text-sm text-white shadow-[0_40px_120px_rgba(15,23,42,0.45)] backdrop-blur-xl transition-all duration-300 sm:p-6",
+        "data-[open=false]:pointer-events-none data-[open=false]:opacity-0 data-[open=false]:scale-[0.98]",
+        "data-[open=true]:opacity-100 data-[open=true]:scale-100",
+        "motion-reduce:transition-none motion-reduce:data-[open=false]:scale-100",
+      )}
+      data-open={isOpen}
+      role="dialog"
+      aria-modal={isOpen}
+      aria-hidden={!isOpen}
+      aria-labelledby={`${transcriptId}-title`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-white/70" aria-hidden />
+          <div className="flex flex-col">
+            <span id={`${transcriptId}-title`} className="text-sm font-semibold">
+              {strings.title}
+            </span>
+            <span className="flex items-center gap-2 text-xs text-emerald-400">
+              <span className="inline-flex h-2 w-2 rounded-full bg-emerald-400 motion-safe:animate-pulse" aria-hidden />
+              {strings.status}
+            </span>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex h-9 w-9 items-center justify-center rounded-full border border-white/10 text-white/60 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          aria-label={strings.close}
+        >
+          <X className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+
+      <div
+        ref={scrollRef}
+        className="relative flex min-h-[220px] flex-1 flex-col gap-4 overflow-y-auto rounded-2xl border border-white/5 bg-black/60 px-4 py-5"
+        role="log"
+        aria-live="polite"
+        aria-label={strings.transcriptLabel}
+      >
+        {hasMessages ? (
+          <ul className="flex flex-col gap-4" aria-live="off">
+            {messages.map((message) => (
+              <li key={message.id} className="flex flex-col gap-2">
+                <RoleLabel role={message.role} strings={strings} />
+                <MessageBubble role={message.role} content={message.content} />
+              </li>
+            ))}
+            {isTyping ? (
+              <li className="flex flex-col gap-2">
+                <RoleLabel role="assistant" strings={strings} />
+                <TypingIndicator label={strings.typing} />
+              </li>
+            ) : null}
+          </ul>
+        ) : (
+          <EmptyState strings={strings} onSuggestion={handleSuggestion} />
+        )}
+      </div>
+
+      <form
+        onSubmit={handleFormSubmit}
+        className="flex flex-col gap-3"
+        noValidate
+      >
+        {error ? (
+          <div className="flex items-center justify-between rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+            <span>{error}</span>
+            <button
+              type="button"
+              onClick={() => {
+                void onRetry();
+              }}
+              className="rounded-full border border-white/20 px-3 py-1 text-xs font-medium text-white/80 transition hover:text-white"
+            >
+              {strings.retry}
+            </button>
+          </div>
+        ) : null}
+        <div className="flex items-end gap-3 rounded-2xl border border-white/10 bg-black/70 px-4 py-3">
+          <label htmlFor={`${transcriptId}-input`} className="sr-only">
+            {strings.placeholder}
+          </label>
+          <textarea
+            id={`${transcriptId}-input`}
+            ref={inputRef}
+            className="min-h-[44px] flex-1 resize-none bg-transparent text-sm leading-relaxed text-white placeholder:text-white/40 focus-visible:outline-none"
+            placeholder={strings.placeholder}
+            value={value}
+            onKeyDown={handleKeyDown}
+            onChange={handleInput}
+            rows={1}
+          />
+          <button
+            type="submit"
+            disabled={disableSend}
+            className={cn(
+              "relative flex h-11 w-11 items-center justify-center rounded-full border border-white/10 bg-white/10 text-white/80 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black",
+              disableSend ? "cursor-not-allowed opacity-60" : "",
+            )}
+            title={strings.sendTooltip}
+            aria-label={strings.send}
+          >
+            <Send
+              aria-hidden
+              className={cn(
+                "h-4 w-4 transition-transform duration-300",
+                planeActive && !prefersReducedMotion ? "ask-plane" : "",
+              )}
+            />
+          </button>
+        </div>
+        {hasMessages ? null : (
+          <SuggestionList
+            suggestions={strings.suggestions}
+            onSuggestion={handleSuggestion}
+          />
+        )}
+      </form>
+    </div>
+  );
+};
+
+type RoleLabelProps = {
+  role: ChatMessage["role"];
+  strings: Pick<ChatPanelStrings, "assistantLabel" | "userLabel">;
+};
+
+const RoleLabel: React.FC<RoleLabelProps> = ({ role, strings }) => {
+  const isAssistant = role === "assistant";
+  return (
+    <span
+      className={cn(
+        "flex w-fit items-center gap-2 rounded-full border px-3 py-1 text-2xs font-medium uppercase tracking-[0.08em]",
+        isAssistant
+          ? "border-white/15 bg-white/5 text-white/80"
+          : "border-white/10 bg-white/10 text-white",
+      )}
+    >
+      {isAssistant ? (
+        <Sparkles className="h-3 w-3" aria-hidden />
+      ) : (
+        <User className="h-3 w-3" aria-hidden />
+      )}
+      {isAssistant ? strings.assistantLabel : strings.userLabel}
+    </span>
+  );
+};
+
+type MessageBubbleProps = {
+  role: ChatMessage["role"];
+  content: string;
+};
+
+const MessageBubble: React.FC<MessageBubbleProps> = ({ role, content }) => {
+  const isUser = role === "user";
+  return (
+    <div
+      className={cn(
+        "max-w-[90%] rounded-3xl text-sm leading-relaxed",
+        isUser
+          ? "ml-auto hero-hiring-gradient p-[1.5px]"
+          : "border border-white/10 bg-neutral-900/70 p-[1.5px]",
+      )}
+    >
+      <div
+        className={cn(
+          "rounded-[inherit] px-4 py-3 text-sm",
+          isUser
+            ? "bg-gradient-to-r from-sky-500/30 via-blue-500/25 to-indigo-500/30 text-white shadow-[0_20px_40px_rgba(32,56,123,0.45)]"
+            : "bg-black/70 text-white/85 shadow-[0_16px_40px_rgba(2,10,38,0.45)]",
+        )}
+      >
+        <p className="whitespace-pre-wrap text-sm leading-relaxed text-white/90">{content}</p>
+      </div>
+    </div>
+  );
+};
+
+type EmptyStateProps = {
+  strings: Pick<
+    ChatPanelStrings,
+    "emptyTitle" | "emptyDescription" | "suggestions" | "intro" | "assistantLabel"
+  >;
+  onSuggestion: (suggestion: string) => void;
+};
+
+const EmptyState: React.FC<EmptyStateProps> = ({ strings, onSuggestion }) => {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-6 text-center">
+      <div className="max-w-[420px] space-y-3">
+        <span className="mx-auto flex items-center justify-center gap-2 rounded-full border border-white/15 bg-white/5 px-3 py-1 text-2xs font-medium uppercase tracking-[0.08em] text-white/80">
+          <Sparkles className="h-3 w-3" aria-hidden />
+          {strings.assistantLabel}
+        </span>
+        <p className="text-base font-semibold text-white">{strings.emptyTitle}</p>
+        <p className="text-sm text-white/70">{strings.emptyDescription}</p>
+        <p className="text-sm text-white/80">{strings.intro}</p>
+      </div>
+      <SuggestionList suggestions={strings.suggestions} onSuggestion={onSuggestion} />
+    </div>
+  );
+};
+
+type SuggestionListProps = {
+  suggestions: string[];
+  onSuggestion: (suggestion: string) => void;
+};
+
+const SuggestionList: React.FC<SuggestionListProps> = ({ suggestions, onSuggestion }) => {
+  const items = useMemo(() => suggestions.slice(0, 4), [suggestions]);
+  return (
+    <div className="flex flex-wrap justify-center gap-2">
+      {items.map((suggestion) => (
+        <button
+          key={suggestion}
+          type="button"
+          onClick={() => onSuggestion(suggestion)}
+          className="hero-hiring-gradient p-[1.5px] transition-transform duration-200 hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+        >
+          <span className="flex items-center gap-2 rounded-full bg-black/70 px-4 py-2 text-xs font-medium text-white/90 backdrop-blur">
+            <Sparkles className="h-3 w-3 text-white/70" aria-hidden />
+            {suggestion}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+};
+
+type TypingIndicatorProps = {
+  label: string;
+};
+
+const TypingIndicator: React.FC<TypingIndicatorProps> = ({ label }) => {
+  return (
+    <div className="flex w-fit items-center gap-3 rounded-full border border-white/10 bg-black/70 px-3 py-2">
+      <span className="hero-hiring-gradient flex h-9 w-9 items-center justify-center rounded-full p-[1.5px]">
+        <span className="flex h-full w-full items-center justify-center gap-1 rounded-full bg-black/80 px-2">
+          <span className="ask-typing-dot" aria-hidden />
+          <span className="ask-typing-dot" aria-hidden style={{ animationDelay: "0.12s" }} />
+          <span className="ask-typing-dot" aria-hidden style={{ animationDelay: "0.24s" }} />
+        </span>
+      </span>
+      <span className="text-xs text-white/70">{label}</span>
+    </div>
+  );
+};
+
+function useIdWithPrefix(prefix: string) {
+  const id = useId();
+  return `${prefix}-${id}`;
+}
+
+function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handleChange = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    handleChange();
+
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+export type { ChatPanelStrings };

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { nanoid } from "nanoid";
+import { ChatPanel, type ChatPanelStrings } from "./ChatPanel";
+import { useStickyWithinSection } from "./useStickyWithinSection";
+import type { ChatMessage } from "./types";
+
+type StickyChatProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  focusReturnRef: RefObject<HTMLButtonElement>;
+  strings: ChatPanelStrings;
+};
+
+export const StickyChat: React.FC<StickyChatProps> = ({
+  isOpen,
+  onClose,
+  focusReturnRef,
+  strings,
+}) => {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isTyping, setIsTyping] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const topSentinelRef = useRef<HTMLDivElement>(null);
+  const bottomSentinelRef = useRef<HTMLDivElement>(null);
+  const messagesRef = useRef<ChatMessage[]>(messages);
+  const pendingRequestRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+
+  useEffect(() => {
+    return () => {
+      pendingRequestRef.current?.abort();
+    };
+  }, []);
+
+  const stickyState = useStickyWithinSection(
+    { topRef: topSentinelRef, bottomRef: bottomSentinelRef },
+    { topOffset: 96 },
+  );
+
+  const sendMessage = useCallback(
+    async (content: string, { retry = false }: { retry?: boolean } = {}) => {
+      const trimmed = content.trim();
+      if (!trimmed) {
+        return;
+      }
+
+      setError(null);
+
+      let nextMessages = messagesRef.current;
+
+      if (!retry) {
+        const userMessage: ChatMessage = {
+          id: nanoid(),
+          role: "user",
+          content: trimmed,
+        };
+        nextMessages = [...messagesRef.current, userMessage];
+        messagesRef.current = nextMessages;
+        setMessages(nextMessages);
+      } else if (!nextMessages.some((message) => message.role === "user")) {
+        return;
+      }
+
+      setIsTyping(true);
+
+      const controller = new AbortController();
+      pendingRequestRef.current?.abort();
+      pendingRequestRef.current = controller;
+
+      try {
+        const response = await fetch("/api/assistant", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            messages: nextMessages.map(({ role, content }) => ({ role, content })),
+          }),
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          if (response.status === 429) {
+            setError(strings.rateLimited);
+          } else if (response.status === 401) {
+            setError(strings.unauthorized);
+          } else {
+            setError(strings.error);
+          }
+          return;
+        }
+
+        const data = (await response.json()) as { message?: string };
+        const assistantText = data.message?.trim();
+
+        if (assistantText) {
+          const assistantMessage: ChatMessage = {
+            id: nanoid(),
+            role: "assistant",
+            content: assistantText,
+          };
+          setMessages((previousMessages) => {
+            const updated = [...previousMessages, assistantMessage];
+            messagesRef.current = updated;
+            return updated;
+          });
+        }
+      } catch (error) {
+        if ((error as Error).name === "AbortError") {
+          return;
+        }
+        console.error(error);
+        setError(strings.error);
+      } finally {
+        if (pendingRequestRef.current === controller) {
+          pendingRequestRef.current = null;
+        }
+        setIsTyping(false);
+      }
+    },
+    [strings.error, strings.rateLimited, strings.unauthorized],
+  );
+
+  const handleRetry = useCallback(async () => {
+    const lastUserMessage = [...messagesRef.current]
+      .reverse()
+      .find((message) => message.role === "user");
+
+    if (!lastUserMessage) {
+      return;
+    }
+
+    await sendMessage(lastUserMessage.content, { retry: true });
+  }, [sendMessage]);
+
+  const handleClose = useCallback(() => {
+    onClose();
+    focusReturnRef.current?.focus({ preventScroll: true });
+  }, [focusReturnRef, onClose]);
+
+  return (
+    <div className="relative w-full">
+      <div ref={topSentinelRef} aria-hidden className="pointer-events-none absolute inset-x-0 top-0 h-px" />
+      <div
+        className="relative w-full min-h-[26rem] sm:min-h-[28rem] pt-2 sm:pt-4 pb-12 sm:pb-16"
+        aria-hidden={false}
+      >
+        <div className="transition-transform duration-300 sm:sticky sm:top-24"
+          data-bottom={stickyState.isAtBottom}
+          data-sticky={stickyState.isSticky}
+        >
+          <ChatPanel
+            isOpen={isOpen}
+            messages={messages}
+            onSend={(value) => sendMessage(value)}
+            onRetry={handleRetry}
+            onClose={handleClose}
+            isTyping={isTyping}
+            error={error}
+            strings={strings}
+          />
+        </div>
+      </div>
+      <div ref={bottomSentinelRef} aria-hidden className="pointer-events-none absolute inset-x-0 bottom-0 h-px" />
+    </div>
+  );
+};
+
+export type { StickyChatProps };

--- a/apps/www/components/ask/types.ts
+++ b/apps/www/components/ask/types.ts
@@ -1,0 +1,7 @@
+export type ChatRole = "user" | "assistant";
+
+export type ChatMessage = {
+  id: string;
+  role: ChatRole;
+  content: string;
+};

--- a/apps/www/components/ask/useStickyWithinSection.ts
+++ b/apps/www/components/ask/useStickyWithinSection.ts
@@ -1,0 +1,67 @@
+import { type RefObject, useEffect, useState } from "react";
+
+type StickyOptions = {
+  topOffset?: number;
+};
+
+type StickySentinels = {
+  topRef: RefObject<Element>;
+  bottomRef: RefObject<Element>;
+};
+
+export type StickyState = {
+  isSticky: boolean;
+  isAtBottom: boolean;
+};
+
+export function useStickyWithinSection(
+  { topRef, bottomRef }: StickySentinels,
+  { topOffset = 96 }: StickyOptions = {},
+): StickyState {
+  const [state, setState] = useState<StickyState>({ isSticky: false, isAtBottom: false });
+
+  useEffect(() => {
+    const top = topRef.current;
+    const bottom = bottomRef.current;
+
+    if (!top || !bottom || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+
+    let frame: number | null = null;
+
+    const topObserver = new IntersectionObserver(
+      ([entry]) => {
+        if (frame !== null) {
+          cancelAnimationFrame(frame);
+        }
+        frame = requestAnimationFrame(() => {
+          setState((prev) => ({ ...prev, isSticky: entry.intersectionRatio < 1 }));
+        });
+      },
+      { threshold: [1], rootMargin: `-${topOffset}px 0px 0px 0px` },
+    );
+
+    const bottomObserver = new IntersectionObserver(([entry]) => {
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+      frame = requestAnimationFrame(() => {
+        setState((prev) => ({ ...prev, isAtBottom: entry.isIntersecting }));
+      });
+    });
+
+    topObserver.observe(top);
+    bottomObserver.observe(bottom);
+
+    return () => {
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+      topObserver.disconnect();
+      bottomObserver.disconnect();
+    };
+  }, [topRef, bottomRef, topOffset]);
+
+  return state;
+}

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -214,6 +214,36 @@
       "text": "Click through the interface below to explore sample projects."
     }
   },
+  "AskAssistant": {
+    "cta": {
+      "label": "Ask the TransformAI"
+    },
+    "panel": {
+      "title": "TransformAI Assistant",
+      "status": "Online",
+      "close": "Close chat",
+      "assistantLabel": "Assistant",
+      "userLabel": "You",
+      "placeholder": "Ask anything about our solutions, pricing, or a free intro call…",
+      "send": "Send",
+      "sendTooltip": "Send message",
+      "typing": "TransformAI assistant is typing",
+      "emptyTitle": "How we can help…",
+      "emptyDescription": "Pick a prompt below or ask your own question to start the conversation.",
+      "suggestions": [
+        "Show me how TransformAI guides enterprise AI adoption",
+        "What does the introduction package include?",
+        "Can we book a free intro call next week?",
+        "How do you ensure compliant AI usage in regulated industries?"
+      ],
+      "error": "We couldn’t send that. Please try again.",
+      "rateLimited": "You’ve reached the question limit for the moment. Please wait a few seconds and try again.",
+      "unauthorized": "The assistant is unavailable right now. Please try again later.",
+      "retry": "Retry",
+      "transcriptLabel": "TransformAI assistant conversation",
+      "intro": "Hi! I'm the TransformAI assistant. Ask me about our services, pricing, or how we guide AI transformation."
+    }
+  },
   "CTA": {
     "getStarted": "Get Started",
     "exploreProjects": "Explore All projects"

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -214,6 +214,36 @@
       "text": "Klik door de interface hieronder om enkele projecten te ontdekken."
     }
   },
+  "AskAssistant": {
+    "cta": {
+      "label": "Stel je vraag aan TransformAI"
+    },
+    "panel": {
+      "title": "TransformAI-assistent",
+      "status": "Online",
+      "close": "Sluit chat",
+      "assistantLabel": "Assistent",
+      "userLabel": "Jij",
+      "placeholder": "Stel een vraag over onze oplossingen, prijzen of een gratis introductiegesprek…",
+      "send": "Verstuur",
+      "sendTooltip": "Verstuur bericht",
+      "typing": "TransformAI-assistent is aan het typen",
+      "emptyTitle": "Hoe we kunnen helpen…",
+      "emptyDescription": "Kies een suggestie hieronder of stel je eigen vraag om te beginnen.",
+      "suggestions": [
+        "Hoe begeleidt TransformAI ondernemingen bij AI-adoptie?",
+        "Wat zit er in het introductiepakket?",
+        "Kunnen we volgende week een gratis introductiecall plannen?",
+        "Hoe zorgen jullie voor compliant AI-gebruik in gereguleerde sectoren?"
+      ],
+      "error": "Het bericht kon niet worden verzonden. Probeer het opnieuw.",
+      "rateLimited": "Je hebt kort achter elkaar te veel vragen gesteld. Wacht even en probeer het nogmaals.",
+      "unauthorized": "De assistent is nu even niet beschikbaar. Probeer het later opnieuw.",
+      "retry": "Opnieuw",
+      "transcriptLabel": "TransformAI-assistentgesprek",
+      "intro": "Hoi! Ik ben de TransformAI-assistent. Stel me vragen over onze diensten, prijzen of hoe we AI-transformatie begeleiden."
+    }
+  },
   "CTA": {
     "getStarted": "Begin Nu",
     "exploreProjects": "Ontdek alle projecten"


### PR DESCRIPTION
## Summary
- add Ask the TransformAI CTA, chat panel, sticky orchestration, and supporting hook for the new assistant experience
- wire the assistant entry into the homepage section with lazy loading, localization, and reserved layout spacing
- introduce an API proxy stub with rate limiting, chat styling tweaks, environment docs, and update log entry

## Plan
- Build dedicated CTA, chat panel, sticky container, and hook components that meet the requested UX and a11y details
- Integrate the chat bundle below the existing assistant copy with dynamic loading, translations, and styling updates
- Provide a server route stub, environment scaffolding, and documentation/update notes for the new assistant feature

## Testing
- `pnpm --filter www run lint` *(fails: existing lint issues in unrelated files)*
- `pnpm --filter www run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68cfa614c5a4832a8bf74316b17ffc5d