### PR TITLE
Localize About blog teaser

### DIFF
--- a/WRITE_HERE/UPDATES/2025-09-21T0719--localized-about-blog-teaser.md
+++ b/WRITE_HERE/UPDATES/2025-09-21T0719--localized-about-blog-teaser.md
@@ -1,0 +1,6 @@
+# Localized About blog teaser
+
+- **What:** Routed the About page blog teaser copy through the i18n system and added English/Dutch strings.
+- **Why:** Ensure localized messaging while keeping English as the fallback when translations are missing.
+- **Files:** apps/www/app/[locale]/(site)/about/page.tsx; apps/www/messages/en.json; apps/www/messages/nl.json.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -189,6 +189,8 @@ export default async function Page({ params }: PageProps) {
 
   const valuesIntroTitle = t("ValuesIntro.title");
   const valuesIntroBody = t("ValuesIntro.body");
+  const blogTitle = t("Blog.title");
+  const blogBody = t("Blog.body");
 
   const posts = allPosts.filter((post) => SELECTED_POSTS.includes(post.slug));
   return (
@@ -409,8 +411,8 @@ export default async function Page({ params }: PageProps) {
               <SectionTitle
                 className="mt-[100px] lg:mt-[100px]"
                 align="center"
-                title="From our blog"
-                text="Explore insights, tips, and updates directly from our team members"
+                title={blogTitle}
+                text={blogBody}
               />
               <div className="flex flex-row w-full mx-auto gap-6 mt-[96px] flex-wrap lg:flex-nowrap">
                 {posts.map((post) => {

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -199,6 +199,10 @@
         "title": "Partnership, not just Service",
         "body": "We don’t deliver and leave. We collaborate deeply, co-creating workflows and strategy so AI becomes a lasting advantage."
       }
+    },
+    "Blog": {
+      "title": "From our blog",
+      "body": "Explore insights, tips, and updates directly from our team members"
     }
   },
   "LogoCloud": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -199,6 +199,10 @@
         "title": "Partnerschap, geen Dienstverlening",
         "body": "We leveren niet en vertrekken. We werken nauw samen en co-creëren workflows en strategie zodat AI een blijvend voordeel wordt."
       }
+    },
+    "Blog": {
+      "title": "Uit onze blog",
+      "body": "Ontdek inzichten, tips en updates rechtstreeks van ons team"
     }
   },
   "LogoCloud": {


### PR DESCRIPTION
## Summary
- route the About page blog teaser heading and description through the About namespace translations
- add English and Dutch strings for the blog teaser copy so Dutch users see localized messaging
- log the change in WRITE_HERE updates for project history

## Plan
- review the About page implementation to locate the blog teaser section
- introduce translation lookups for the blog teaser title and description while preserving layout
- add the required English and Dutch strings to the About namespace and verify locale handling

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: existing lint violations in unrelated startup/yc components)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa6c6f4f0832a895a1cc59499f5aa