### PR TITLE
Fix Ask CTA sticky travel behavior

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-21T0814--ask-button-sticky-travel.md
+++ b/WRITE_HERE/FIXES/2025-09-21T0814--ask-button-sticky-travel.md
@@ -1,0 +1,6 @@
+# Restored Ask CTA travel behavior
+
+- **What:** Adjusted the sticky chat CTA layout to introduce top/bottom sentinels, reorder the CTA within its section, and reuse the sticky helper so the "Ask the TransformAI" button starts beneath the heading, scrolls with the user, and pins at the original stop.
+- **Why:** The CTA rendered directly at its bottom stop and never traveled with scroll, breaking the intended interaction.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`
+- **Follow-ups:** None.

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -66,6 +66,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const [isDesktop, setIsDesktop] = useState(false);
 
   const sectionRef = useRef<HTMLDivElement>(null);
+  const topRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const ctaRef = useRef<HTMLButtonElement>(null);
   const closeTimer = useRef<number>();
@@ -139,9 +140,19 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
       ? ({ position: "sticky", bottom: "96px" } as const)
       : ({ position: "relative" } as const);
 
-  const ctaStyle = isDesktop && !isOpen
-    ? ({ position: "sticky", top: "96px" } as const)
-    : ({ position: "relative" } as const);
+  const stickyTopOffset = isDesktop ? 96 : 72;
+  const stickyBottomOffset = isDesktop ? 80 : 64;
+
+  const { style: ctaStickyStyle } = useStickyWithinSection({
+    enabled: !isOpen,
+    bottomRef,
+    topOffset: stickyTopOffset,
+    bottomOffset: stickyBottomOffset,
+  });
+
+  const ctaStyle = isDesktop && isOpen
+    ? ({ position: "relative" } as const)
+    : ctaStickyStyle;
 
   const scrollToChat = useCallback(() => {
     if (typeof window === "undefined") {
@@ -252,6 +263,9 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
 
   const chatHasContent = shouldRender && displayPanel;
 
+  const ctaOrderClass = chatHasContent ? "order-2" : "order-1";
+  const chatOrderClass = chatHasContent ? "order-1" : "order-2";
+
   return (
     <div
       ref={sectionRef}
@@ -260,8 +274,12 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
         className,
       )}
     >
+      <div ref={topRef} aria-hidden className="order-first -mb-8 h-0 w-full sm:-mb-12" />
       <div
-        className="w-full transition-[top,bottom] duration-300 ease-out"
+        className={cn(
+          "w-full transition-all duration-300 ease-out",
+          chatOrderClass,
+        )}
         style={chatStyle}
         id={chatPanelId}
       >
@@ -281,11 +299,12 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
           ) : null}
         </div>
       </div>
-      <div ref={bottomRef} aria-hidden className="mt-16 h-px w-full" />
+      <div ref={bottomRef} aria-hidden className="order-3 mt-16 h-px w-full" />
       <div
         className={cn(
           "mt-2 flex w-full justify-center",
-          isDesktop ? "transition-[top] duration-300 ease-out" : undefined,
+          ctaOrderClass,
+          "transition-all duration-300 ease-out",
         )}
         style={ctaStyle}
       >
@@ -297,6 +316,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
           ariaControls={chatPanelId}
         />
       </div>
+      <div aria-hidden className="order-last h-8 w-full sm:h-12" />
     </div>
   );
 };


### PR DESCRIPTION
## Plan
- Inspect the StickyChat layout and identify where to place top/bottom sentinels for the CTA.
- Reuse the sticky helper to control the CTA travel with desktop/mobile offsets.
- Reorder the CTA/chat containers so the CTA starts beneath the heading while keeping the chat panel above when open.
- Add spacer coverage to preserve section height and verify stickiness across breakpoints.

## Summary
- Added a top anchor, spacer, and flex order handling so the Ask CTA begins under the section heading, travels on scroll, and still pins at the existing bottom stop.
- Reused the sticky helper with viewport-aware offsets to keep the CTA sticky while closed and restored relative positioning while the chat is open.
- Logged the behavioral fix in `WRITE_HERE/FIXES`.

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb1cbc6b8832aa2b060a89eb3ba8c