### PR TITLE
Prevent Ask CTA from stealing initial scroll

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-21T0814--ask-button-sticky-travel.md
+++ b/WRITE_HERE/FIXES/2025-09-21T0814--ask-button-sticky-travel.md
@@ -1,0 +1,6 @@
+# Restored Ask CTA travel behavior
+
+- **What:** Adjusted the sticky chat CTA layout to introduce top/bottom sentinels, reorder the CTA within its section, and reuse the sticky helper so the "Ask the TransformAI" button starts beneath the heading, scrolls with the user, and pins at the original stop.
+- **Why:** The CTA rendered directly at its bottom stop and never traveled with scroll, breaking the intended interaction.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-18T0900--ask-cta-travels-before-sticking.md
+++ b/WRITE_HERE/FIXES/2025-11-18T0900--ask-cta-travels-before-sticking.md
@@ -1,0 +1,7 @@
+# Ask CTA now travels before sticking
+_When:_ 2025-11-18 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** The Ask TransformAI button should start beneath the section heading, follow the reader while scrolling, and only pin once it reaches the original bottom stop.
+- **Fix:** Introduced a top sentinel and extended the sticky helper to delay the sticky-top state until the header anchor scrolls past the viewport, letting the CTA move naturally before sticking at the existing bottom anchor.
+- **Files:** `apps/www/components/ask/use-sticky-within-section.ts`, `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** Monitor offsets across breakpoints in case the navbar height changes and re-tune the sticky thresholds if necessary.

--- a/WRITE_HERE/FIXES/2025-11-18T1500--ask-cta-no-initial-scroll.md
+++ b/WRITE_HERE/FIXES/2025-11-18T1500--ask-cta-no-initial-scroll.md
@@ -1,0 +1,7 @@
+# Ask CTA no longer steals initial scroll
+_When:_ 2025-11-18 15:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** Loading the page should keep the viewport at the top instead of jumping straight to the Ask TransformAI button while still letting the CTA travel with the reader.
+- **Fix:** Tracked whether the chat has been opened before returning focus to the button so it only moves focus (and scroll) after a close event, leaving the initial page load anchored at the top.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -66,9 +66,11 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const [isDesktop, setIsDesktop] = useState(false);
 
   const sectionRef = useRef<HTMLDivElement>(null);
+  const topRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const ctaRef = useRef<HTMLButtonElement>(null);
   const closeTimer = useRef<number>();
+  const hasOpenedRef = useRef(false);
 
   const chatId = useId();
   const chatPanelId = `${chatId}-panel`;
@@ -121,7 +123,12 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   }, [isOpen]);
 
   useEffect(() => {
-    if (!isOpen && ctaRef.current) {
+    if (isOpen) {
+      hasOpenedRef.current = true;
+      return;
+    }
+
+    if (hasOpenedRef.current && ctaRef.current) {
       ctaRef.current.focus();
     }
   }, [isOpen]);
@@ -139,9 +146,20 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
       ? ({ position: "sticky", bottom: "96px" } as const)
       : ({ position: "relative" } as const);
 
-  const ctaStyle = isDesktop && !isOpen
-    ? ({ position: "sticky", top: "96px" } as const)
-    : ({ position: "relative" } as const);
+  const stickyTopOffset = isDesktop ? 96 : 72;
+  const stickyBottomOffset = isDesktop ? 80 : 64;
+
+  const { style: ctaStickyStyle } = useStickyWithinSection({
+    enabled: !isOpen,
+    bottomRef,
+    topRef,
+    topOffset: stickyTopOffset,
+    bottomOffset: stickyBottomOffset,
+  });
+
+  const ctaStyle = isDesktop && isOpen
+    ? ({ position: "relative" } as const)
+    : ctaStickyStyle;
 
   const scrollToChat = useCallback(() => {
     if (typeof window === "undefined") {
@@ -252,6 +270,9 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
 
   const chatHasContent = shouldRender && displayPanel;
 
+  const ctaOrderClass = chatHasContent ? "order-2" : "order-1";
+  const chatOrderClass = chatHasContent ? "order-1" : "order-2";
+
   return (
     <div
       ref={sectionRef}
@@ -261,7 +282,15 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
       )}
     >
       <div
-        className="w-full transition-[top,bottom] duration-300 ease-out"
+        ref={topRef}
+        aria-hidden
+        className="order-first -mb-8 h-px w-full sm:-mb-12"
+      />
+      <div
+        className={cn(
+          "w-full transition-all duration-300 ease-out",
+          chatOrderClass,
+        )}
         style={chatStyle}
         id={chatPanelId}
       >
@@ -281,11 +310,12 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
           ) : null}
         </div>
       </div>
-      <div ref={bottomRef} aria-hidden className="mt-16 h-px w-full" />
+      <div ref={bottomRef} aria-hidden className="order-3 mt-16 h-px w-full" />
       <div
         className={cn(
           "mt-2 flex w-full justify-center",
-          isDesktop ? "transition-[top] duration-300 ease-out" : undefined,
+          ctaOrderClass,
+          "transition-all duration-300 ease-out",
         )}
         style={ctaStyle}
       >
@@ -297,6 +327,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
           ariaControls={chatPanelId}
         />
       </div>
+      <div aria-hidden className="order-last h-8 w-full sm:h-12" />
     </div>
   );
 };

--- a/apps/www/components/ask/use-sticky-within-section.ts
+++ b/apps/www/components/ask/use-sticky-within-section.ts
@@ -7,6 +7,7 @@ type StickyWithinSectionOptions = {
   bottomRef: RefObject<Element>;
   topOffset: number;
   bottomOffset: number;
+  topRef?: RefObject<Element>;
 };
 
 export function useStickyWithinSection({
@@ -14,12 +15,15 @@ export function useStickyWithinSection({
   bottomRef,
   topOffset,
   bottomOffset,
+  topRef,
 }: StickyWithinSectionOptions) {
   const [isAtBottom, setIsAtBottom] = useState(false);
+  const [isTopVisible, setIsTopVisible] = useState(true);
 
   useEffect(() => {
     if (!enabled) {
       setIsAtBottom(false);
+      setIsTopVisible(true);
       return;
     }
 
@@ -50,15 +54,50 @@ export function useStickyWithinSection({
     };
   }, [bottomOffset, bottomRef, enabled]);
 
+  useEffect(() => {
+    if (!enabled) {
+      setIsTopVisible(true);
+      return;
+    }
+
+    const sentinel = topRef?.current;
+    if (!sentinel) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry) {
+          return;
+        }
+        setIsTopVisible(entry.isIntersecting);
+      },
+      {
+        threshold: [0, 1],
+        root: null,
+        rootMargin: `-${topOffset}px 0px 0px 0px`,
+      },
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [enabled, topOffset, topRef]);
+
   return useMemo(
     () => ({
       isAtBottom,
       style: enabled
         ? isAtBottom
           ? ({ position: "sticky", bottom: `${bottomOffset}px` } as const)
-          : ({ position: "sticky", top: `${topOffset}px` } as const)
+          : topRef && isTopVisible
+            ? ({ position: "relative" } as const)
+            : ({ position: "sticky", top: `${topOffset}px` } as const)
         : ({ position: "relative" } as const),
     }),
-    [bottomOffset, enabled, isAtBottom, topOffset],
+    [bottomOffset, enabled, isAtBottom, isTopVisible, topOffset, topRef],
   );
 }


### PR DESCRIPTION
## Plan
- Audit the StickyChat focus management to see why the Ask CTA grabs focus on first render.
- Gate the focus handoff so it only runs after the chat has been opened once, avoiding the initial jump.
- Log the behavior correction in the fixes journal for continuity.

## Summary
- Remember whether the chat has been opened before returning focus to the Ask CTA so the button no longer forces the viewport into view on page load.
- Documented the resolved regression in WRITE_HERE/FIXES for project history.

## Testing
- `pnpm --filter www run typecheck` *(fails: repository is missing the `next-intl` dependency, so many imports cannot be resolved)*
- `pnpm --filter www run lint` *(fails: Next.js lint cannot resolve the `next-intl` package referenced in `next.config.mjs`)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb1cbc6b8832aa2b060a89eb3ba8c