### PR TITLE
Fix Ask CTA scroll anchoring

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-18T1700--ask-cta-scrolls-with-section.md
+++ b/WRITE_HERE/FIXES/2025-11-18T1700--ask-cta-scrolls-with-section.md
@@ -1,0 +1,7 @@
+# Ask CTA scrolls naturally before sticking
+_When:_ 2025-11-18 17:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** Make the Ask TransformAI button travel with the section instead of appearing pinned from the start while still stopping at the existing bottom anchor.
+- **Fix:** Let the sticky helper expose scroll state so the CTA only sticks once the top sentinel leaves view, keep it flowing otherwise, and pin it while the chat is open so the panel stays stable.
+- **Files:** `apps/www/components/ask/use-sticky-within-section.ts`, `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -149,17 +149,26 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const stickyTopOffset = isDesktop ? 96 : 72;
   const stickyBottomOffset = isDesktop ? 80 : 64;
 
-  const { style: ctaStickyStyle } = useStickyWithinSection({
+  const { isAtBottom: isCtaAtBottom, isTopVisible: isSectionTopVisible } = useStickyWithinSection({
     enabled: !isOpen,
     bottomRef,
     topRef,
     topOffset: stickyTopOffset,
     bottomOffset: stickyBottomOffset,
+    stickToTop: false,
   });
 
-  const ctaStyle = isDesktop && isOpen
-    ? ({ position: "relative" } as const)
-    : ctaStickyStyle;
+  const shouldStickCtaToBottom = isCtaAtBottom && !isSectionTopVisible;
+
+  const restingCtaStyle = shouldStickCtaToBottom
+    ? ({ position: "sticky", bottom: `${stickyBottomOffset}px` } as const)
+    : ({ position: "relative" } as const);
+
+  const pinnedCtaStyle = isDesktop
+    ? ({ position: "sticky", top: `${stickyTopOffset}px` } as const)
+    : ({ position: "sticky", bottom: `${stickyBottomOffset}px` } as const);
+
+  const ctaStyle = isOpen ? pinnedCtaStyle : restingCtaStyle;
 
   const scrollToChat = useCallback(() => {
     if (typeof window === "undefined") {

--- a/apps/www/components/ask/use-sticky-within-section.ts
+++ b/apps/www/components/ask/use-sticky-within-section.ts
@@ -8,6 +8,7 @@ type StickyWithinSectionOptions = {
   topOffset: number;
   bottomOffset: number;
   topRef?: RefObject<Element>;
+  stickToTop?: boolean;
 };
 
 export function useStickyWithinSection({
@@ -16,6 +17,7 @@ export function useStickyWithinSection({
   topOffset,
   bottomOffset,
   topRef,
+  stickToTop = true,
 }: StickyWithinSectionOptions) {
   const [isAtBottom, setIsAtBottom] = useState(false);
   const [isTopVisible, setIsTopVisible] = useState(true);
@@ -87,17 +89,34 @@ export function useStickyWithinSection({
     };
   }, [enabled, topOffset, topRef]);
 
+  const style = useMemo(() => {
+    if (!enabled) {
+      return { position: "relative" } as const;
+    }
+
+    if (isAtBottom) {
+      return { position: "sticky", bottom: `${bottomOffset}px` } as const;
+    }
+
+    if (!stickToTop) {
+      return { position: "relative" } as const;
+    }
+
+    if (!topRef) {
+      return { position: "sticky", top: `${topOffset}px` } as const;
+    }
+
+    return isTopVisible
+      ? ({ position: "relative" } as const)
+      : ({ position: "sticky", top: `${topOffset}px` } as const);
+  }, [bottomOffset, enabled, isAtBottom, isTopVisible, stickToTop, topOffset, topRef]);
+
   return useMemo(
     () => ({
       isAtBottom,
-      style: enabled
-        ? isAtBottom
-          ? ({ position: "sticky", bottom: `${bottomOffset}px` } as const)
-          : topRef && isTopVisible
-            ? ({ position: "relative" } as const)
-            : ({ position: "sticky", top: `${topOffset}px` } as const)
-        : ({ position: "relative" } as const),
+      isTopVisible,
+      style,
     }),
-    [bottomOffset, enabled, isAtBottom, isTopVisible, topOffset, topRef],
+    [isAtBottom, isTopVisible, style],
   );
 }


### PR DESCRIPTION
## Summary
- expose sticky helper scroll state and configurability so consumers can detect when the section top is visible
- update the Ask CTA styling to flow with the section, stick only at the bottom anchor, and pin while the chat panel is open
- log the behavior fix for the Ask TransformAI section in WRITE_HERE/FIXES

## Plan
- review the Ask TransformAI sticky helpers and identify where the CTA gets pinned immediately
- adjust the sticky hook plus CTA container styling to respect scroll position and the bottom anchor stop
- record the regression fix and rerun lint/typecheck (noting lint baseline failures)

## Testing
- pnpm --filter www run typecheck
- pnpm --filter www run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d054071150832a90c78503b2f97812