### PR TITLE
Make Ask CTA float with section before anchoring

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-18T1700--ask-cta-scrolls-with-section.md
+++ b/WRITE_HERE/FIXES/2025-11-18T1700--ask-cta-scrolls-with-section.md
@@ -1,0 +1,7 @@
+# Ask CTA scrolls naturally before sticking
+_When:_ 2025-11-18 17:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** Make the Ask TransformAI button travel with the section instead of appearing pinned from the start while still stopping at the existing bottom anchor.
+- **Fix:** Let the sticky helper expose scroll state so the CTA only sticks once the top sentinel leaves view, keep it flowing otherwise, and pin it while the chat is open so the panel stays stable.
+- **Files:** `apps/www/components/ask/use-sticky-within-section.ts`, `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-18T2000--ask-cta-floats-with-section-scroll.md
+++ b/WRITE_HERE/FIXES/2025-11-18T2000--ask-cta-floats-with-section-scroll.md
@@ -1,0 +1,7 @@
+# Ask CTA floats with section scroll before anchoring
+_When:_ 2025-11-18 20:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** Make the Ask TransformAI button travel with the section, floating alongside the viewport during scroll until it reaches the bottom anchor, similar to the referenced OpenAI Codex upgrades page.
+- **Fix:** Track when the section heading enters view and switch the CTA container to a sticky-bottom position after the reader passes the top sentinel so it rides the viewport until the section's bottom stop while still pinning when the chat panel is open.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -64,6 +64,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [isDesktop, setIsDesktop] = useState(false);
+  const [hasSectionEnteredView, setHasSectionEnteredView] = useState(false);
 
   const sectionRef = useRef<HTMLDivElement>(null);
   const topRef = useRef<HTMLDivElement>(null);
@@ -149,17 +150,36 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const stickyTopOffset = isDesktop ? 96 : 72;
   const stickyBottomOffset = isDesktop ? 80 : 64;
 
-  const { style: ctaStickyStyle } = useStickyWithinSection({
+  const { isTopVisible: isSectionTopVisible } = useStickyWithinSection({
     enabled: !isOpen,
     bottomRef,
     topRef,
     topOffset: stickyTopOffset,
     bottomOffset: stickyBottomOffset,
+    stickToTop: false,
   });
 
-  const ctaStyle = isDesktop && isOpen
-    ? ({ position: "relative" } as const)
-    : ctaStickyStyle;
+  useEffect(() => {
+    if (isOpen) {
+      return;
+    }
+
+    if (isSectionTopVisible) {
+      setHasSectionEnteredView((previous) => (previous ? previous : true));
+    }
+  }, [isOpen, isSectionTopVisible]);
+
+  const shouldStickCtaToBottom = !isOpen && hasSectionEnteredView && !isSectionTopVisible;
+
+  const restingCtaStyle = shouldStickCtaToBottom
+    ? ({ position: "sticky", bottom: `${stickyBottomOffset}px` } as const)
+    : ({ position: "relative" } as const);
+
+  const pinnedCtaStyle = isDesktop
+    ? ({ position: "sticky", top: `${stickyTopOffset}px` } as const)
+    : ({ position: "sticky", bottom: `${stickyBottomOffset}px` } as const);
+
+  const ctaStyle = isOpen ? pinnedCtaStyle : restingCtaStyle;
 
   const scrollToChat = useCallback(() => {
     if (typeof window === "undefined") {

--- a/apps/www/components/ask/use-sticky-within-section.ts
+++ b/apps/www/components/ask/use-sticky-within-section.ts
@@ -8,6 +8,7 @@ type StickyWithinSectionOptions = {
   topOffset: number;
   bottomOffset: number;
   topRef?: RefObject<Element>;
+  stickToTop?: boolean;
 };
 
 export function useStickyWithinSection({
@@ -16,6 +17,7 @@ export function useStickyWithinSection({
   topOffset,
   bottomOffset,
   topRef,
+  stickToTop = true,
 }: StickyWithinSectionOptions) {
   const [isAtBottom, setIsAtBottom] = useState(false);
   const [isTopVisible, setIsTopVisible] = useState(true);
@@ -87,17 +89,34 @@ export function useStickyWithinSection({
     };
   }, [enabled, topOffset, topRef]);
 
+  const style = useMemo(() => {
+    if (!enabled) {
+      return { position: "relative" } as const;
+    }
+
+    if (isAtBottom) {
+      return { position: "sticky", bottom: `${bottomOffset}px` } as const;
+    }
+
+    if (!stickToTop) {
+      return { position: "relative" } as const;
+    }
+
+    if (!topRef) {
+      return { position: "sticky", top: `${topOffset}px` } as const;
+    }
+
+    return isTopVisible
+      ? ({ position: "relative" } as const)
+      : ({ position: "sticky", top: `${topOffset}px` } as const);
+  }, [bottomOffset, enabled, isAtBottom, isTopVisible, stickToTop, topOffset, topRef]);
+
   return useMemo(
     () => ({
       isAtBottom,
-      style: enabled
-        ? isAtBottom
-          ? ({ position: "sticky", bottom: `${bottomOffset}px` } as const)
-          : topRef && isTopVisible
-            ? ({ position: "relative" } as const)
-            : ({ position: "sticky", top: `${topOffset}px` } as const)
-        : ({ position: "relative" } as const),
+      isTopVisible,
+      style,
     }),
-    [bottomOffset, enabled, isAtBottom, isTopVisible, topOffset, topRef],
+    [isAtBottom, isTopVisible, style],
   );
 }


### PR DESCRIPTION
## Summary
- gate the Ask CTA sticky-bottom state on the section entering view so it floats with the viewport before reaching the anchor
- ensure the CTA only applies the sticky style while closed, keeping the chat-open pin behavior intact
- log the behavioral change for future reference in WRITE_HERE/FIXES

## Plan
- detect when the section's top sentinel has entered the viewport before enabling the sticky CTA state
- fall back to the prior pinned styles when the chat panel is open so the layout stays stable
- document the fix in the repository log and rerun the workspace checks

## Testing
- pnpm --filter www run typecheck *(fails: repository missing next-intl packages)*
- pnpm --filter www run lint *(fails: repository missing next-intl packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d054071150832a90c78503b2f97812