### PR TITLE
Make Ask CTA fixed at bottom of homepage

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-19T0900--ask-cta-pins-bottom-of-homepage.md
+++ b/WRITE_HERE/FIXES/2025-11-19T0900--ask-cta-pins-bottom-of-homepage.md
@@ -1,0 +1,7 @@
+# Ask CTA pins to the bottom of the homepage
+_When:_ 2025-11-19 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** Keep the "Ask TransformAI" button visible along the entire homepage and send visitors to the chat section when it is pressed.
+- **Fix:** Replaced the section-based sticky logic with a floating style that fixes the CTA near the viewport bottom until the panel is opened, while retaining the existing scroll-to-chat behaviour when toggled.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -64,10 +64,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [isDesktop, setIsDesktop] = useState(false);
-  const [hasSectionEnteredView, setHasSectionEnteredView] = useState(false);
-
   const sectionRef = useRef<HTMLDivElement>(null);
-  const topRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const ctaRef = useRef<HTMLButtonElement>(null);
   const closeTimer = useRef<number>();
@@ -150,36 +147,23 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const stickyTopOffset = isDesktop ? 96 : 72;
   const stickyBottomOffset = isDesktop ? 80 : 64;
 
-  const { isTopVisible: isSectionTopVisible } = useStickyWithinSection({
-    enabled: !isOpen,
-    bottomRef,
-    topRef,
-    topOffset: stickyTopOffset,
-    bottomOffset: stickyBottomOffset,
-    stickToTop: false,
-  });
+  const floatingBottomOffset = isDesktop ? 72 : 32;
 
-  useEffect(() => {
-    if (isOpen) {
-      return;
-    }
-
-    if (isSectionTopVisible) {
-      setHasSectionEnteredView((previous) => (previous ? previous : true));
-    }
-  }, [isOpen, isSectionTopVisible]);
-
-  const shouldStickCtaToBottom = !isOpen && hasSectionEnteredView && !isSectionTopVisible;
-
-  const restingCtaStyle = shouldStickCtaToBottom
-    ? ({ position: "sticky", bottom: `${stickyBottomOffset}px` } as const)
-    : ({ position: "relative" } as const);
+  const floatingCtaStyle = {
+    position: "fixed",
+    bottom: `${floatingBottomOffset}px`,
+    left: "50%",
+    transform: "translateX(-50%)",
+    zIndex: 60,
+    width: "fit-content",
+    maxWidth: "calc(100% - 32px)",
+  } as const;
 
   const pinnedCtaStyle = isDesktop
     ? ({ position: "sticky", top: `${stickyTopOffset}px` } as const)
     : ({ position: "sticky", bottom: `${stickyBottomOffset}px` } as const);
 
-  const ctaStyle = isOpen ? pinnedCtaStyle : restingCtaStyle;
+  const ctaStyle = isOpen ? pinnedCtaStyle : floatingCtaStyle;
 
   const scrollToChat = useCallback(() => {
     if (typeof window === "undefined") {
@@ -301,11 +285,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
         className,
       )}
     >
-      <div
-        ref={topRef}
-        aria-hidden
-        className="order-first -mb-8 h-px w-full sm:-mb-12"
-      />
+      <div aria-hidden className="order-first -mb-8 h-px w-full sm:-mb-12" />
       <div
         className={cn(
           "w-full transition-all duration-300 ease-out",
@@ -333,7 +313,8 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
       <div ref={bottomRef} aria-hidden className="order-3 mt-16 h-px w-full" />
       <div
         className={cn(
-          "mt-2 flex w-full justify-center",
+          "mt-2 flex justify-center z-50",
+          isOpen ? "w-full" : "w-auto",
           ctaOrderClass,
           "transition-all duration-300 ease-out",
         )}


### PR DESCRIPTION
## Plan
- inspect the Ask CTA positioning logic inside `StickyChat`
- adjust the closed-state styles so the CTA stays fixed to the viewport bottom
- confirm the chat still scrolls into view when the CTA is toggled and document the change

## Summary
- keep the Ask TransformAI CTA fixed near the bottom of the viewport until the chat is opened so it stays visible across the homepage
- retain the existing pinned styling when the chat is expanded and continue scrolling the viewport to the chat panel on toggle
- log the change in `WRITE_HERE/FIXES` for continuity

## Testing
- pnpm --filter www run typecheck
- pnpm --filter www run lint *(fails: existing lint errors in unrelated files)*
- pnpm -w turbo run build --filter=www *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e1fb63a4832aac2d1e46443440f1