### PR TITLE
Gate ask CTA on assistant intro visibility

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-19T0900--ask-cta-pins-bottom-of-homepage.md
+++ b/WRITE_HERE/FIXES/2025-11-19T0900--ask-cta-pins-bottom-of-homepage.md
@@ -1,0 +1,7 @@
+# Ask CTA pins to the bottom of the homepage
+_When:_ 2025-11-19 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** Keep the "Ask TransformAI" button visible along the entire homepage and send visitors to the chat section when it is pressed.
+- **Fix:** Replaced the section-based sticky logic with a floating style that fixes the CTA near the viewport bottom until the panel is opened, while retaining the existing scroll-to-chat behaviour when toggled.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T1100--ask-cta-appears-after-intro-text.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1100--ask-cta-appears-after-intro-text.md
@@ -1,0 +1,7 @@
+# Ask CTA appears after assistant intro text
+_When:_ 2025-11-19 11:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** Only surface the Ask TransformAI button once visitors reach the "Ask questions, schedule a call…" lead-in on the homepage and hide it again when scrolling back above that section.
+- **Fix:** Observed the intro copy via an IntersectionObserver so the CTA floats at the viewport bottom only after the text comes into view (or has been scrolled past) while keeping it pinned when the chat is open.
+- **Files:** `apps/www/app/code-examples.tsx`, `apps/www/components/ask/StickyChat.tsx`, `apps/www/components/section.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -24,6 +24,7 @@ import type { PrismTheme } from "prism-react-renderer";
 import React, { useEffect } from "react";
 import { useState } from "react";
 const Tabs = TabsPrimitive.Root;
+const ASK_CHAT_TRIGGER_ID = "ask-transformai-assistant-intro";
 
 const editorTheme = {
   plain: {
@@ -590,6 +591,7 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
   return (
     <section className={className}>
       <SectionTitle
+        id={ASK_CHAT_TRIGGER_ID}
         title={t("top.title")}
         text={t("top.text")}
         align="center"
@@ -606,7 +608,7 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
           <MeteorLines className="ml-16 fade-in-100" delay={2} number={1} />
         </div>
       </SectionTitle>
-      <StickyChat className="mt-16" />
+      <StickyChat className="mt-16" triggerId={ASK_CHAT_TRIGGER_ID} />
       <SectionTitle
         title={t("bottom.title")}
         text={t("bottom.text")}

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -3,6 +3,7 @@
 import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import {
+  type CSSProperties,
   useCallback,
   useEffect,
   useId,
@@ -23,9 +24,10 @@ const ChatPanel = dynamic(() => import("./ChatPanel").then((mod) => mod.ChatPane
 
 type StickyChatProps = {
   className?: string;
+  triggerId?: string;
 };
 
-export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
+export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) => {
   const t = useTranslations("CodeExamples.chat");
   const locale = useMemo<ChatLocale>(
     () => ({
@@ -64,10 +66,8 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [isDesktop, setIsDesktop] = useState(false);
-  const [hasSectionEnteredView, setHasSectionEnteredView] = useState(false);
-
+  const [hasReachedTrigger, setHasReachedTrigger] = useState(false);
   const sectionRef = useRef<HTMLDivElement>(null);
-  const topRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const ctaRef = useRef<HTMLButtonElement>(null);
   const closeTimer = useRef<number>();
@@ -150,36 +150,69 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const stickyTopOffset = isDesktop ? 96 : 72;
   const stickyBottomOffset = isDesktop ? 80 : 64;
 
-  const { isTopVisible: isSectionTopVisible } = useStickyWithinSection({
-    enabled: !isOpen,
-    bottomRef,
-    topRef,
-    topOffset: stickyTopOffset,
-    bottomOffset: stickyBottomOffset,
-    stickToTop: false,
-  });
+  const floatingBottomOffset = isDesktop ? 72 : 32;
+
+  const floatingCtaStyle: CSSProperties = {
+    position: "fixed",
+    bottom: `${floatingBottomOffset}px`,
+    left: "50%",
+    transform: "translateX(-50%)",
+    zIndex: 60,
+    width: "fit-content",
+    maxWidth: "calc(100% - 32px)",
+  };
+
+  const pinnedCtaStyle: CSSProperties = isDesktop
+    ? { position: "sticky", top: `${stickyTopOffset}px` }
+    : { position: "sticky", bottom: `${stickyBottomOffset}px` };
+
+  const hiddenCtaStyle: CSSProperties = { display: "none" };
+  const baseCtaStyle = isOpen ? pinnedCtaStyle : floatingCtaStyle;
+  const shouldShowCta = isOpen || hasReachedTrigger;
+  const ctaStyle = shouldShowCta ? baseCtaStyle : hiddenCtaStyle;
 
   useEffect(() => {
-    if (isOpen) {
+    if (typeof window === "undefined") {
       return;
     }
 
-    if (isSectionTopVisible) {
-      setHasSectionEnteredView((previous) => (previous ? previous : true));
+    if (!triggerId) {
+      setHasReachedTrigger(true);
+      return;
     }
-  }, [isOpen, isSectionTopVisible]);
 
-  const shouldStickCtaToBottom = !isOpen && hasSectionEnteredView && !isSectionTopVisible;
+    if (typeof window.IntersectionObserver !== "function") {
+      setHasReachedTrigger(true);
+      return;
+    }
 
-  const restingCtaStyle = shouldStickCtaToBottom
-    ? ({ position: "sticky", bottom: `${stickyBottomOffset}px` } as const)
-    : ({ position: "relative" } as const);
+    const section = sectionRef.current;
+    const target = document.getElementById(triggerId) ?? section?.previousElementSibling;
 
-  const pinnedCtaStyle = isDesktop
-    ? ({ position: "sticky", top: `${stickyTopOffset}px` } as const)
-    : ({ position: "sticky", bottom: `${stickyBottomOffset}px` } as const);
+    if (!target) {
+      setHasReachedTrigger(true);
+      return;
+    }
 
-  const ctaStyle = isOpen ? pinnedCtaStyle : restingCtaStyle;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry) {
+          return;
+        }
+
+        const shouldActivate = entry.isIntersecting || entry.boundingClientRect.top < 0;
+        setHasReachedTrigger(shouldActivate);
+      },
+      { threshold: [0, 1] },
+    );
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [triggerId]);
 
   const scrollToChat = useCallback(() => {
     if (typeof window === "undefined") {
@@ -301,11 +334,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
         className,
       )}
     >
-      <div
-        ref={topRef}
-        aria-hidden
-        className="order-first -mb-8 h-px w-full sm:-mb-12"
-      />
+      <div aria-hidden className="order-first -mb-8 h-px w-full sm:-mb-12" />
       <div
         className={cn(
           "w-full transition-all duration-300 ease-out",
@@ -333,11 +362,13 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
       <div ref={bottomRef} aria-hidden className="order-3 mt-16 h-px w-full" />
       <div
         className={cn(
-          "mt-2 flex w-full justify-center",
+          "mt-2 flex justify-center z-50",
+          isOpen ? "w-full" : "w-auto",
           ctaOrderClass,
           "transition-all duration-300 ease-out",
         )}
         style={ctaStyle}
+        aria-hidden={!shouldShowCta}
       >
         <AskCta
           ref={ctaRef}

--- a/apps/www/components/section.tsx
+++ b/apps/www/components/section.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/lib/utils";
 import type { PropsWithChildren } from "react";
 
 type SectionTitleProps = {
+  id?: string;
   label?: string;
   title?: React.ReactNode;
   text?: React.ReactNode;
@@ -11,6 +12,7 @@ type SectionTitleProps = {
 };
 
 export function SectionTitle({
+  id,
   label,
   title,
   text,
@@ -20,6 +22,7 @@ export function SectionTitle({
 }: SectionTitleProps) {
   return (
     <div
+      id={id}
       className={cn(
         "flex flex-col items-center",
         {


### PR DESCRIPTION
## Plan
- add an anchor to the assistant intro SectionTitle that the sticky chat can observe
- update StickyChat to watch the intro text and only float the CTA once visitors reach it
- document the behaviour change in WRITE_HERE/FIXES for continuity

## Summary
- assign a stable id to the Ask TransformAI SectionTitle and pass it into StickyChat as a trigger
- teach StickyChat to track the intro copy with an IntersectionObserver so the CTA appears after the text is visible and hides when scrolling above it while remaining accessible when the chat is open
- log the request and resolution in `WRITE_HERE/FIXES`

## Testing
- pnpm --filter www run typecheck *(fails: repository still missing `next-intl` type declarations)*
- pnpm --filter www run lint *(fails: repository still missing the `next-intl` package referenced in `next.config.mjs`)*
- pnpm -w turbo run build --filter=www *(fails: repository still missing the `next-intl` package referenced in `next.config.mjs`)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e1fb63a4832aac2d1e46443440f1