### PR TITLE
Fine-tune Ask CTA reveal timing

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-19T0900--ask-cta-pins-bottom-of-homepage.md
+++ b/WRITE_HERE/FIXES/2025-11-19T0900--ask-cta-pins-bottom-of-homepage.md
@@ -1,0 +1,7 @@
+# Ask CTA pins to the bottom of the homepage
+_When:_ 2025-11-19 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** Keep the "Ask TransformAI" button visible along the entire homepage and send visitors to the chat section when it is pressed.
+- **Fix:** Replaced the section-based sticky logic with a floating style that fixes the CTA near the viewport bottom until the panel is opened, while retaining the existing scroll-to-chat behaviour when toggled.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T1100--ask-cta-appears-after-intro-text.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1100--ask-cta-appears-after-intro-text.md
@@ -1,0 +1,7 @@
+# Ask CTA appears after assistant intro text
+_When:_ 2025-11-19 11:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** Only surface the Ask TransformAI button once visitors reach the "Ask questions, schedule a call…" lead-in on the homepage and hide it again when scrolling back above that section.
+- **Fix:** Observed the intro copy via an IntersectionObserver so the CTA floats at the viewport bottom only after the text comes into view (or has been scrolled past) while keeping it pinned when the chat is open.
+- **Files:** `apps/www/app/code-examples.tsx`, `apps/www/components/ask/StickyChat.tsx`, `apps/www/components/section.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T1200--ask-cta-fades-in-when-space-allows.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1200--ask-cta-fades-in-when-space-allows.md
@@ -1,0 +1,7 @@
+# Ask CTA fades in when intro has room
+_When:_ 2025-11-19 12:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Adjusted the Ask TransformAI sticky CTA so it measures its height, waits until the intro copy has enough viewport space before appearing, and fades in/out with a subtle translate while staying keyboard-accessible only when visible.
+- **Why:** The user wanted the button to surface only once there was sufficient distance between the intro text and the bottom of the viewport, with a smooth fade animation instead of an abrupt toggle.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`, `apps/www/components/ask/AskCta.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T1330--ask-cta-reveals-with-intro-visibility.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1330--ask-cta-reveals-with-intro-visibility.md
@@ -1,0 +1,6 @@
+# Ask CTA reveals with intro visibility
+
+- **What:** Updated the StickyChat intersection logic so the Ask TransformAI button appears as soon as the intro SectionTitle enters the viewport with a small cushion, keeping the CTA sticky afterward and fading it when the chat closes.
+- **Why:** The previous reveal waited for extra space beneath the intro text, so the CTA surfaced too late compared to the moment users first saw the copy.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -24,6 +24,7 @@ import type { PrismTheme } from "prism-react-renderer";
 import React, { useEffect } from "react";
 import { useState } from "react";
 const Tabs = TabsPrimitive.Root;
+const ASK_CHAT_TRIGGER_ID = "ask-transformai-assistant-intro";
 
 const editorTheme = {
   plain: {
@@ -590,6 +591,7 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
   return (
     <section className={className}>
       <SectionTitle
+        id={ASK_CHAT_TRIGGER_ID}
         title={t("top.title")}
         text={t("top.text")}
         align="center"
@@ -606,7 +608,7 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
           <MeteorLines className="ml-16 fade-in-100" delay={2} number={1} />
         </div>
       </SectionTitle>
-      <StickyChat className="mt-16" />
+      <StickyChat className="mt-16" triggerId={ASK_CHAT_TRIGGER_ID} />
       <SectionTitle
         title={t("bottom.title")}
         text={t("bottom.text")}

--- a/apps/www/components/ask/AskCta.tsx
+++ b/apps/www/components/ask/AskCta.tsx
@@ -10,10 +10,11 @@ type AskCtaProps = {
   onToggle: () => void;
   ariaControls?: string;
   className?: string;
+  tabIndex?: number;
 };
 
 export const AskCta = forwardRef<HTMLButtonElement, AskCtaProps>(
-  ({ label, pressed, onToggle, ariaControls, className }, ref) => {
+  ({ label, pressed, onToggle, ariaControls, className, tabIndex }, ref) => {
     return (
       <button
         ref={ref}
@@ -21,6 +22,7 @@ export const AskCta = forwardRef<HTMLButtonElement, AskCtaProps>(
         onClick={onToggle}
         aria-pressed={pressed}
         aria-controls={ariaControls}
+        tabIndex={tabIndex}
         data-state={pressed ? "open" : "closed"}
         className={cn(
           "group relative inline-flex items-center justify-center rounded-full p-[1px] text-sm font-semibold text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70 focus-visible:ring-offset-2 focus-visible:ring-offset-black",

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -3,6 +3,7 @@
 import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import {
+  type CSSProperties,
   useCallback,
   useEffect,
   useId,
@@ -21,11 +22,14 @@ const ChatPanel = dynamic(() => import("./ChatPanel").then((mod) => mod.ChatPane
   ssr: false,
 });
 
+const INTERSECTION_THRESHOLDS = Array.from({ length: 11 }, (_, index) => index / 10);
+
 type StickyChatProps = {
   className?: string;
+  triggerId?: string;
 };
 
-export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
+export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) => {
   const t = useTranslations("CodeExamples.chat");
   const locale = useMemo<ChatLocale>(
     () => ({
@@ -64,10 +68,8 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [isDesktop, setIsDesktop] = useState(false);
-  const [hasSectionEnteredView, setHasSectionEnteredView] = useState(false);
-
+  const [hasReachedTrigger, setHasReachedTrigger] = useState(false);
   const sectionRef = useRef<HTMLDivElement>(null);
-  const topRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const ctaRef = useRef<HTMLButtonElement>(null);
   const closeTimer = useRef<number>();
@@ -150,36 +152,82 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const stickyTopOffset = isDesktop ? 96 : 72;
   const stickyBottomOffset = isDesktop ? 80 : 64;
 
-  const { isTopVisible: isSectionTopVisible } = useStickyWithinSection({
-    enabled: !isOpen,
-    bottomRef,
-    topRef,
-    topOffset: stickyTopOffset,
-    bottomOffset: stickyBottomOffset,
-    stickToTop: false,
-  });
+  const floatingBottomOffset = isDesktop ? 72 : 32;
+  const floatingCtaStyle: CSSProperties = {
+    position: "fixed",
+    bottom: `${floatingBottomOffset}px`,
+    left: "50%",
+    transform: "translateX(-50%)",
+    zIndex: 60,
+    width: "fit-content",
+    maxWidth: "calc(100% - 32px)",
+  };
+
+  const pinnedCtaStyle: CSSProperties = isDesktop
+    ? { position: "sticky", top: `${stickyTopOffset}px` }
+    : { position: "sticky", bottom: `${stickyBottomOffset}px` };
+
+  const baseCtaStyle = isOpen ? pinnedCtaStyle : floatingCtaStyle;
+  const shouldShowCta = isOpen || hasReachedTrigger;
 
   useEffect(() => {
-    if (isOpen) {
+    if (typeof window === "undefined") {
       return;
     }
 
-    if (isSectionTopVisible) {
-      setHasSectionEnteredView((previous) => (previous ? previous : true));
+    if (!triggerId) {
+      setHasReachedTrigger(true);
+      return;
     }
-  }, [isOpen, isSectionTopVisible]);
 
-  const shouldStickCtaToBottom = !isOpen && hasSectionEnteredView && !isSectionTopVisible;
+    if (typeof window.IntersectionObserver !== "function") {
+      setHasReachedTrigger(true);
+      return;
+    }
 
-  const restingCtaStyle = shouldStickCtaToBottom
-    ? ({ position: "sticky", bottom: `${stickyBottomOffset}px` } as const)
-    : ({ position: "relative" } as const);
+    const section = sectionRef.current;
+    const target = (document.getElementById(triggerId) ?? section?.previousElementSibling) as
+      | HTMLElement
+      | null;
 
-  const pinnedCtaStyle = isDesktop
-    ? ({ position: "sticky", top: `${stickyTopOffset}px` } as const)
-    : ({ position: "sticky", bottom: `${stickyBottomOffset}px` } as const);
+    if (!target) {
+      setHasReachedTrigger(true);
+      return;
+    }
 
-  const ctaStyle = isOpen ? pinnedCtaStyle : restingCtaStyle;
+    const computeShouldActivate = (rect: DOMRect | DOMRectReadOnly) => {
+      const viewportHeight = window.innerHeight || 0;
+      const visibilityOffset = Math.max(Math.min(viewportHeight, 16), 0);
+      const threshold = viewportHeight - visibilityOffset;
+      return rect.top <= threshold;
+    };
+
+    const evaluate = () => {
+      const rect = target.getBoundingClientRect();
+      setHasReachedTrigger(computeShouldActivate(rect));
+    };
+
+    evaluate();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry) {
+          return;
+        }
+
+        const rect = entry.boundingClientRect;
+        setHasReachedTrigger(entry.isIntersecting || computeShouldActivate(rect));
+      },
+      { threshold: INTERSECTION_THRESHOLDS },
+    );
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [triggerId]);
 
   const scrollToChat = useCallback(() => {
     if (typeof window === "undefined") {
@@ -301,11 +349,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
         className,
       )}
     >
-      <div
-        ref={topRef}
-        aria-hidden
-        className="order-first -mb-8 h-px w-full sm:-mb-12"
-      />
+      <div aria-hidden className="order-first -mb-8 h-px w-full sm:-mb-12" />
       <div
         className={cn(
           "w-full transition-all duration-300 ease-out",
@@ -333,11 +377,17 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
       <div ref={bottomRef} aria-hidden className="order-3 mt-16 h-px w-full" />
       <div
         className={cn(
-          "mt-2 flex w-full justify-center",
+          "mt-2 flex justify-center z-50",
+          isOpen ? "w-full" : "w-auto",
           ctaOrderClass,
-          "transition-all duration-300 ease-out",
+          "transition-opacity transition-transform duration-300 ease-out",
+          "motion-reduce:transition-none motion-reduce:transform-none",
+          shouldShowCta
+            ? "pointer-events-auto opacity-100 translate-y-0 motion-reduce:translate-y-0"
+            : "pointer-events-none opacity-0 translate-y-2 motion-reduce:translate-y-0",
         )}
-        style={ctaStyle}
+        style={baseCtaStyle}
+        aria-hidden={!shouldShowCta}
       >
         <AskCta
           ref={ctaRef}
@@ -345,6 +395,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
           pressed={isOpen}
           onToggle={handleToggle}
           ariaControls={chatPanelId}
+          tabIndex={shouldShowCta ? 0 : -1}
         />
       </div>
       <div aria-hidden className="order-last h-8 w-full sm:h-12" />

--- a/apps/www/components/section.tsx
+++ b/apps/www/components/section.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/lib/utils";
 import type { PropsWithChildren } from "react";
 
 type SectionTitleProps = {
+  id?: string;
   label?: string;
   title?: React.ReactNode;
   text?: React.ReactNode;
@@ -11,6 +12,7 @@ type SectionTitleProps = {
 };
 
 export function SectionTitle({
+  id,
   label,
   title,
   text,
@@ -20,6 +22,7 @@ export function SectionTitle({
 }: SectionTitleProps) {
   return (
     <div
+      id={id}
       className={cn(
         "flex flex-col items-center",
         {


### PR DESCRIPTION
## Plan
- Remove the CTA height-based reveal gap so the observer can react directly to the intro text visibility.
- Adjust the StickyChat intersection logic to activate once the SectionTitle enters the viewport with a small buffer.
- Log the behavioural tweak in the FIXES journal for continuity.

## Summary
- Simplified StickyChat by dropping the CTA height measurement and recalibrating the observer to flag the intro section as soon as its top crosses a small viewport buffer so the button appears promptly. 
- Ensured the IntersectionObserver fallback still shows the CTA after the intro has been scrolled past and documented the change in a new FIXES entry.

## Testing
- pnpm --filter www run typecheck *(fails: repo is missing the `next-intl` dependency and type declarations required by existing imports)*
- pnpm --filter www run lint *(fails: Next.js lint config can’t resolve the absent `next-intl` package)*
- pnpm -w turbo run build --filter=www *(fails: build step hits the missing `next-intl` package when loading `next.config.mjs`)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e1fb63a4832aac2d1e46443440f1