### PR TITLE
fix: anchor Ask TransformAI sticky header

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-22T0651--anchored-ask-transformai-sticky.md
+++ b/WRITE_HERE/FIXES/2025-09-22T0651--anchored-ask-transformai-sticky.md
@@ -1,0 +1,7 @@
+# Anchored Ask TransformAI sticky header
+_When:_ 2025-09-22 06:51 UTC · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Added a boundary anchor for the Ask TransformAI sticky experience so the chat panel and CTA release above the projects SectionTitle, using layout-based scroll detection to switch the CTA from fixed to in-flow positioning.
+- **Why:** The sticky header previously remained pinned for the entire page, covering content past the "Explore the projects we’ve been part of" section; anchoring preserves the intended spacing above that text.
+- **Files:** `apps/www/app/code-examples.tsx`, `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -25,6 +25,7 @@ import React, { useEffect } from "react";
 import { useState } from "react";
 const Tabs = TabsPrimitive.Root;
 const ASK_CHAT_TRIGGER_ID = "ask-transformai-assistant-intro";
+const ASK_CHAT_BOUNDARY_ID = "ask-transformai-assistant-boundary";
 
 const editorTheme = {
   plain: {
@@ -608,8 +609,13 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
           <MeteorLines className="ml-16 fade-in-100" delay={2} number={1} />
         </div>
       </SectionTitle>
-      <StickyChat className="mt-16" triggerId={ASK_CHAT_TRIGGER_ID} />
+      <StickyChat
+        className="mt-16"
+        triggerId={ASK_CHAT_TRIGGER_ID}
+        boundaryId={ASK_CHAT_BOUNDARY_ID}
+      />
       <SectionTitle
+        id={ASK_CHAT_BOUNDARY_ID}
         title={t("bottom.title")}
         text={t("bottom.text")}
         align="center"

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -27,9 +27,10 @@ const INTERSECTION_THRESHOLDS = Array.from({ length: 11 }, (_, index) => index /
 type StickyChatProps = {
   className?: string;
   triggerId?: string;
+  boundaryId?: string;
 };
 
-export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) => {
+export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, boundaryId }) => {
   const t = useTranslations("CodeExamples.chat");
   const locale = useMemo<ChatLocale>(
     () => ({
@@ -69,8 +70,10 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [isDesktop, setIsDesktop] = useState(false);
   const [hasReachedTrigger, setHasReachedTrigger] = useState(false);
+  const [hasReachedBoundary, setHasReachedBoundary] = useState(false);
   const sectionRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const chatContainerRef = useRef<HTMLDivElement>(null);
   const ctaRef = useRef<HTMLButtonElement>(null);
   const closeTimer = useRef<number>();
   const hasOpenedRef = useRef(false);
@@ -136,11 +139,15 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
     }
   }, [isOpen]);
 
+  const chatStickyTopOffset = 64;
+  const chatStickyBottomOffset = 80;
+
   const { style: stickyStyle } = useStickyWithinSection({
     enabled: isOpen && isDesktop,
     bottomRef,
-    topOffset: 64,
-    bottomOffset: 80,
+    topOffset: chatStickyTopOffset,
+    bottomOffset: chatStickyBottomOffset,
+    stickToTop: !hasReachedBoundary,
   });
 
   const chatStyle = isDesktop
@@ -148,6 +155,73 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
     : isOpen
       ? ({ position: "sticky", bottom: "96px" } as const)
       : ({ position: "relative" } as const);
+
+  useEffect(() => {
+    if (!boundaryId || typeof window === "undefined" || !isDesktop) {
+      setHasReachedBoundary(false);
+      return;
+    }
+
+    const boundaryElement = document.getElementById(boundaryId);
+    const chatElement = chatContainerRef.current;
+    const sectionElement = sectionRef.current;
+
+    if (!boundaryElement || !chatElement || !sectionElement) {
+      setHasReachedBoundary(false);
+      return;
+    }
+
+    let frame = 0;
+
+    const calculate = () => {
+      const boundaryTop = boundaryElement.getBoundingClientRect().top + window.scrollY;
+      const chatRect = chatElement.getBoundingClientRect();
+      const chatHeight = chatRect.height;
+      const sectionBottom = sectionElement.getBoundingClientRect().bottom + window.scrollY;
+      const defaultGap = Math.max(boundaryTop - sectionBottom, 0);
+      const anchorThreshold = Math.max(
+        boundaryTop - (chatStickyTopOffset + chatHeight + defaultGap),
+        0,
+      );
+      const reached = window.scrollY >= anchorThreshold;
+      setHasReachedBoundary((previous) => (previous === reached ? previous : reached));
+    };
+
+    const handleScroll = () => {
+      if (frame) {
+        return;
+      }
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        calculate();
+      });
+    };
+
+    const handleResize = () => {
+      calculate();
+    };
+
+    calculate();
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleResize);
+
+    let resizeObserver: ResizeObserver | undefined;
+    if (typeof ResizeObserver === "function") {
+      resizeObserver = new ResizeObserver(() => calculate());
+      resizeObserver.observe(chatElement);
+      resizeObserver.observe(sectionElement);
+    }
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleResize);
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+      }
+      resizeObserver?.disconnect();
+    };
+  }, [boundaryId, chatStickyTopOffset, isDesktop]);
 
   const stickyTopOffset = isDesktop ? 96 : 72;
   const stickyBottomOffset = isDesktop ? 80 : 64;
@@ -167,7 +241,18 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
     ? { position: "sticky", top: `${stickyTopOffset}px` }
     : { position: "sticky", bottom: `${stickyBottomOffset}px` };
 
-  const baseCtaStyle = isOpen ? pinnedCtaStyle : floatingCtaStyle;
+  const anchoredCtaStyle: CSSProperties | null =
+    isDesktop && hasReachedBoundary
+      ? {
+          position: "relative",
+          left: "auto",
+          bottom: "auto",
+          transform: "none",
+          zIndex: 60,
+        }
+      : null;
+
+  const baseCtaStyle = anchoredCtaStyle ?? (isOpen ? pinnedCtaStyle : floatingCtaStyle);
   const shouldShowCta = isOpen || hasReachedTrigger;
 
   useEffect(() => {
@@ -355,6 +440,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
           "w-full transition-all duration-300 ease-out",
           chatOrderClass,
         )}
+        ref={chatContainerRef}
         style={chatStyle}
         id={chatPanelId}
       >


### PR DESCRIPTION
## Summary
- add a dedicated boundary anchor for the Ask TransformAI section so the sticky experience respects the projects heading
- teach the sticky chat component to release its sticky positioning and CTA when the boundary is reached while keeping desktop behavior intact
- log the change in WRITE_HERE/FIXES for traceability

## Plan
- identify the “Explore the projects…” SectionTitle as the stop point and expose it via a new ID
- pass the boundary information into the sticky chat component and compute when the chat/CTA should switch from sticky to in-flow
- run lint/typecheck and document results, noting any pre-existing lint failures

## Testing
- pnpm --filter www run lint *(fails: existing repository lint errors unrelated to this change)*
- pnpm --filter www run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d0ee5dfacc832a8598b618ecef131e