### PR TITLE
fix: align ask chat anchor with button position

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-22T0651--anchored-ask-transformai-sticky.md
+++ b/WRITE_HERE/FIXES/2025-09-22T0651--anchored-ask-transformai-sticky.md
@@ -1,0 +1,7 @@
+# Anchored Ask TransformAI sticky header
+_When:_ 2025-09-22 06:51 UTC · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Added a boundary anchor for the Ask TransformAI sticky experience so the chat panel and CTA release above the projects SectionTitle, using layout-based scroll detection to switch the CTA from fixed to in-flow positioning.
+- **Why:** The sticky header previously remained pinned for the entire page, covering content past the "Explore the projects we’ve been part of" section; anchoring preserves the intended spacing above that text.
+- **Files:** `apps/www/app/code-examples.tsx`, `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T1500--ask-cta-releases-before-projects.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1500--ask-cta-releases-before-projects.md
@@ -1,0 +1,7 @@
+# Ask CTA releases before projects heading
+_When:_ 2025-11-19 15:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Adjusted the Ask TransformAI sticky logic so the panel stops sticking roughly 100px sooner, hiding the CTA once it crosses the projects heading boundary.
+- **Why:** The previous anchoring held the CTA too long near the projects section and produced glitchy behavior; releasing a bit earlier keeps the scroll experience smooth.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T1600--ask-cta-anchors-at-button-position.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1600--ask-cta-anchors-at-button-position.md
@@ -1,0 +1,7 @@
+# Ask CTA anchors at button position
+_When:_ 2025-11-19 16:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Removed the extra 100px scroll buffer from the Ask TransformAI sticky calculation so the chat and CTA release exactly at the button’s natural anchor point.
+- **Why:** The CTA was stopping short of its intended anchor after the prior buffer tweak; aligning the threshold with the button’s resting position meets the user’s request.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -25,6 +25,7 @@ import React, { useEffect } from "react";
 import { useState } from "react";
 const Tabs = TabsPrimitive.Root;
 const ASK_CHAT_TRIGGER_ID = "ask-transformai-assistant-intro";
+const ASK_CHAT_BOUNDARY_ID = "ask-transformai-assistant-boundary";
 
 const editorTheme = {
   plain: {
@@ -608,8 +609,13 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
           <MeteorLines className="ml-16 fade-in-100" delay={2} number={1} />
         </div>
       </SectionTitle>
-      <StickyChat className="mt-16" triggerId={ASK_CHAT_TRIGGER_ID} />
+      <StickyChat
+        className="mt-16"
+        triggerId={ASK_CHAT_TRIGGER_ID}
+        boundaryId={ASK_CHAT_BOUNDARY_ID}
+      />
       <SectionTitle
+        id={ASK_CHAT_BOUNDARY_ID}
         title={t("bottom.title")}
         text={t("bottom.text")}
         align="center"

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -27,9 +27,10 @@ const INTERSECTION_THRESHOLDS = Array.from({ length: 11 }, (_, index) => index /
 type StickyChatProps = {
   className?: string;
   triggerId?: string;
+  boundaryId?: string;
 };
 
-export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) => {
+export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, boundaryId }) => {
   const t = useTranslations("CodeExamples.chat");
   const locale = useMemo<ChatLocale>(
     () => ({
@@ -69,8 +70,10 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [isDesktop, setIsDesktop] = useState(false);
   const [hasReachedTrigger, setHasReachedTrigger] = useState(false);
+  const [hasReachedBoundary, setHasReachedBoundary] = useState(false);
   const sectionRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const chatContainerRef = useRef<HTMLDivElement>(null);
   const ctaRef = useRef<HTMLButtonElement>(null);
   const closeTimer = useRef<number>();
   const hasOpenedRef = useRef(false);
@@ -136,11 +139,15 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
     }
   }, [isOpen]);
 
+  const chatStickyTopOffset = 64;
+  const chatStickyBottomOffset = 80;
+
   const { style: stickyStyle } = useStickyWithinSection({
     enabled: isOpen && isDesktop,
     bottomRef,
-    topOffset: 64,
-    bottomOffset: 80,
+    topOffset: chatStickyTopOffset,
+    bottomOffset: chatStickyBottomOffset,
+    stickToTop: !hasReachedBoundary,
   });
 
   const chatStyle = isDesktop
@@ -148,6 +155,73 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
     : isOpen
       ? ({ position: "sticky", bottom: "96px" } as const)
       : ({ position: "relative" } as const);
+
+  useEffect(() => {
+    if (!boundaryId || typeof window === "undefined" || !isDesktop) {
+      setHasReachedBoundary(false);
+      return;
+    }
+
+    const boundaryElement = document.getElementById(boundaryId);
+    const chatElement = chatContainerRef.current;
+    const sectionElement = sectionRef.current;
+
+    if (!boundaryElement || !chatElement || !sectionElement) {
+      setHasReachedBoundary(false);
+      return;
+    }
+
+    let frame = 0;
+
+    const calculate = () => {
+      const boundaryTop = boundaryElement.getBoundingClientRect().top + window.scrollY;
+      const chatRect = chatElement.getBoundingClientRect();
+      const chatHeight = chatRect.height;
+      const sectionBottom = sectionElement.getBoundingClientRect().bottom + window.scrollY;
+      const defaultGap = Math.max(boundaryTop - sectionBottom, 0);
+      const anchorThreshold = Math.max(
+        boundaryTop - (chatStickyTopOffset + chatHeight + defaultGap),
+        0,
+      );
+      const reached = window.scrollY >= anchorThreshold;
+      setHasReachedBoundary((previous) => (previous === reached ? previous : reached));
+    };
+
+    const handleScroll = () => {
+      if (frame) {
+        return;
+      }
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        calculate();
+      });
+    };
+
+    const handleResize = () => {
+      calculate();
+    };
+
+    calculate();
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleResize);
+
+    let resizeObserver: ResizeObserver | undefined;
+    if (typeof ResizeObserver === "function") {
+      resizeObserver = new ResizeObserver(() => calculate());
+      resizeObserver.observe(chatElement);
+      resizeObserver.observe(sectionElement);
+    }
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleResize);
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+      }
+      resizeObserver?.disconnect();
+    };
+  }, [boundaryId, chatStickyTopOffset, isDesktop]);
 
   const stickyTopOffset = isDesktop ? 96 : 72;
   const stickyBottomOffset = isDesktop ? 80 : 64;
@@ -167,8 +241,19 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
     ? { position: "sticky", top: `${stickyTopOffset}px` }
     : { position: "sticky", bottom: `${stickyBottomOffset}px` };
 
-  const baseCtaStyle = isOpen ? pinnedCtaStyle : floatingCtaStyle;
-  const shouldShowCta = isOpen || hasReachedTrigger;
+  const anchoredCtaStyle: CSSProperties | null =
+    isDesktop && hasReachedBoundary
+      ? {
+          position: "relative",
+          left: "auto",
+          bottom: "auto",
+          transform: "none",
+          zIndex: 60,
+        }
+      : null;
+
+  const baseCtaStyle = anchoredCtaStyle ?? (isOpen ? pinnedCtaStyle : floatingCtaStyle);
+  const shouldShowCta = isOpen || (hasReachedTrigger && !hasReachedBoundary);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -355,6 +440,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
           "w-full transition-all duration-300 ease-out",
           chatOrderClass,
         )}
+        ref={chatContainerRef}
         style={chatStyle}
         id={chatPanelId}
       >


### PR DESCRIPTION
## Summary
- remove the extra 100px buffer from the Ask TransformAI sticky threshold so the chat releases exactly at the button’s anchor
- log the adjustment in WRITE_HERE/FIXES for continuity with earlier sticky chat tweaks

## Plan
- adjust the boundary calculation to stop using the manual release offset
- verify the Ask CTA sticks until its natural anchor point without overshooting
- record the change in the FIXES log and run the usual www checks

## Testing
- pnpm --filter www run typecheck *(fails: workspace still missing `next-intl` packages/types; pre-existing)*
- pnpm --filter www run lint *(fails: workspace still missing `next-intl` package; pre-existing)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ee5dfacc832a8598b618ecef131e