### PR TITLE
Keep Ask CTA pinned when anchored

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-19T1700--ask-cta-stops-at-pinned-position.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1700--ask-cta-stops-at-pinned-position.md
@@ -1,0 +1,7 @@
+# Ask CTA stops at pinned position
+_When:_ 2025-11-19 17:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Updated the sticky anchoring logic so the Ask TransformAI button remains at its pinned position while the chat is open instead of dropping to the bottom of the section when the boundary threshold is reached.
+- **Why:** The CTA was sliding far down the page in its anchored state, causing a noticeable UI glitch; keeping it pinned fulfills the request to stop at the normal button location.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -243,13 +243,22 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
 
   const anchoredCtaStyle: CSSProperties | null =
     isDesktop && hasReachedBoundary
-      ? {
-          position: "relative",
-          left: "auto",
-          bottom: "auto",
-          transform: "none",
-          zIndex: 60,
-        }
+      ? isOpen
+        ? {
+            position: "sticky",
+            top: `${stickyTopOffset}px`,
+            left: "auto",
+            bottom: "auto",
+            transform: "none",
+            zIndex: 60,
+          }
+        : {
+            position: "relative",
+            left: "auto",
+            bottom: "auto",
+            transform: "none",
+            zIndex: 60,
+          }
       : null;
 
   const baseCtaStyle = anchoredCtaStyle ?? (isOpen ? pinnedCtaStyle : floatingCtaStyle);


### PR DESCRIPTION
## Summary
- keep the Ask TransformAI CTA fixed to its pinned position when the sticky chat reaches the boundary on desktop
- retain the relative fallback only for the hidden/floating state so the button no longer slides down the page
- log the bug fix in WRITE_HERE/FIXES for future reference

## Plan
- review the current anchored CTA positioning in `StickyChat`
- update the boundary handling to preserve the sticky top alignment while the chat is open
- document the change in a new FIXES entry
- run lint/typecheck for www and note any pre-existing failures

## Testing
- pnpm --filter www run lint *(fails: existing lint violations in unrelated files)*
- pnpm --filter www run typecheck


------
https://chatgpt.com/codex/tasks/task_e_68d0f9a63ea4832aa520b45751dd7700