### PR TITLE
Clamp Ask CTA to pinned height when closed

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-19T1700--ask-cta-stops-at-pinned-position.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1700--ask-cta-stops-at-pinned-position.md
@@ -1,0 +1,7 @@
+# Ask CTA stops at pinned position
+_When:_ 2025-11-19 17:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Updated the sticky anchoring logic so the Ask TransformAI button remains at its pinned position while the chat is open instead of dropping to the bottom of the section when the boundary threshold is reached.
+- **Why:** The CTA was sliding far down the page in its anchored state, causing a noticeable UI glitch; keeping it pinned fulfills the request to stop at the normal button location.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T1800--ask-cta-stops-at-pinned-height-when-closed.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1800--ask-cta-stops-at-pinned-height-when-closed.md
@@ -1,0 +1,7 @@
+# Ask CTA stops at pinned height when closed
+_When:_ 2025-11-19 18:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Adjusted the anchored CTA logic so the Ask TransformAI button pins to the same top offset whether or not the chat is open and keeps rendering after the boundary is reached.
+- **Why:** The sticky CTA slid well past its intended location when closed, causing visible glitches; clamping it to the pinned height fulfills the request that it stop at the open-state position.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -244,7 +244,8 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
   const anchoredCtaStyle: CSSProperties | null =
     isDesktop && hasReachedBoundary
       ? {
-          position: "relative",
+          position: "sticky",
+          top: `${stickyTopOffset}px`,
           left: "auto",
           bottom: "auto",
           transform: "none",
@@ -253,7 +254,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
       : null;
 
   const baseCtaStyle = anchoredCtaStyle ?? (isOpen ? pinnedCtaStyle : floatingCtaStyle);
-  const shouldShowCta = isOpen || (hasReachedTrigger && !hasReachedBoundary);
+  const shouldShowCta = isOpen || hasReachedTrigger;
 
   useEffect(() => {
     if (typeof window === "undefined") {


### PR DESCRIPTION
## Summary
- keep the Ask TransformAI CTA pinned to the desktop sticky top offset even when the chat is closed so it stops exactly at the open-state position
- ensure the CTA continues rendering after the boundary is reached instead of fading out while anchored
- document the adjustment in WRITE_HERE/FIXES for future reference

## Plan
- inspect the sticky CTA anchoring logic for the closed chat state on desktop
- update the anchored style and visibility gating so the button clamps to the pinned height once it reaches the boundary
- record the resolved issue in WRITE_HERE/FIXES with context on the change
- run the www workspace lint and typecheck commands and report any pre-existing failures

## Testing
- pnpm --filter www run typecheck *(fails: missing next-intl module declarations — existing issue)*
- pnpm --filter www run lint *(fails: missing next-intl package while loading next.config.mjs — existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f9a63ea4832aa520b45751dd7700