### PR TITLE
Clamp Ask CTA to measured anchor

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-20T0900--clamped-ask-cta-to-open-anchor.md
+++ b/WRITE_HERE/FIXES/2025-11-20T0900--clamped-ask-cta-to-open-anchor.md
@@ -1,0 +1,7 @@
+# Clamped Ask CTA to open-state anchor
+_When:_ 2025-11-20 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Introduced an anchor sentinel and scroll listener so the floating Ask TransformAI CTA transitions into the same sticky position it occupies when the chat is open, including on resize.
+- **Why:** The button could drift past its intended stop and overlap the following section whenever the chat was closed; clamping it to the measured open-state anchor keeps it aligned.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -71,10 +71,12 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
   const [isDesktop, setIsDesktop] = useState(false);
   const [hasReachedTrigger, setHasReachedTrigger] = useState(false);
   const [hasReachedBoundary, setHasReachedBoundary] = useState(false);
+  const [hasReachedAnchor, setHasReachedAnchor] = useState(false);
   const sectionRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const ctaRef = useRef<HTMLButtonElement>(null);
+  const anchorRef = useRef<HTMLDivElement>(null);
   const closeTimer = useRef<number>();
   const hasOpenedRef = useRef(false);
 
@@ -241,20 +243,105 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
     ? { position: "sticky", top: `${stickyTopOffset}px` }
     : { position: "sticky", bottom: `${stickyBottomOffset}px` };
 
+  const shouldAnchorCta = hasReachedAnchor || (isDesktop && hasReachedBoundary);
+
   const anchoredCtaStyle: CSSProperties | null =
-    isDesktop && hasReachedBoundary
-      ? {
-          position: "sticky",
-          top: `${stickyTopOffset}px`,
-          left: "auto",
-          bottom: "auto",
-          transform: "none",
-          zIndex: 60,
-        }
+    !isOpen && shouldAnchorCta
+      ? isDesktop
+        ? {
+            position: "sticky",
+            top: `${stickyTopOffset}px`,
+            left: "auto",
+            right: "auto",
+            bottom: "auto",
+            transform: "none",
+            zIndex: 60,
+          }
+        : {
+            position: "sticky",
+            bottom: `${stickyBottomOffset}px`,
+            left: "auto",
+            right: "auto",
+            top: "auto",
+            transform: "none",
+            zIndex: 60,
+          }
       : null;
 
-  const baseCtaStyle = anchoredCtaStyle ?? (isOpen ? pinnedCtaStyle : floatingCtaStyle);
+  const baseCtaStyle = isOpen ? pinnedCtaStyle : anchoredCtaStyle ?? floatingCtaStyle;
   const shouldShowCta = isOpen || hasReachedTrigger;
+  const chatHasContent = shouldRender && displayPanel;
+  const ctaOrderClass = chatHasContent ? "order-2" : "order-1";
+  const chatOrderClass = chatHasContent ? "order-1" : "order-2";
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const anchorElement = anchorRef.current;
+    if (!anchorElement) {
+      setHasReachedAnchor(false);
+      return;
+    }
+
+    let frame = 0;
+
+    const calculate = () => {
+      const element = anchorRef.current;
+      if (!element) {
+        setHasReachedAnchor(false);
+        return;
+      }
+
+      const rect = element.getBoundingClientRect();
+      const viewportHeight = window.innerHeight || 0;
+      const referencePosition = isDesktop ? rect.top : rect.bottom;
+      const anchorLimit = isDesktop
+        ? stickyTopOffset
+        : viewportHeight - stickyBottomOffset;
+      const reached = referencePosition <= anchorLimit;
+      setHasReachedAnchor((previous) => (previous === reached ? previous : reached));
+    };
+
+    calculate();
+
+    const handleScroll = () => {
+      if (frame) {
+        return;
+      }
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        calculate();
+      });
+    };
+
+    const handleResize = () => {
+      calculate();
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleResize);
+
+    let resizeObserver: ResizeObserver | undefined;
+    if (typeof ResizeObserver === "function") {
+      resizeObserver = new ResizeObserver(() => calculate());
+      resizeObserver.observe(anchorElement);
+      const sectionElement = sectionRef.current;
+      if (sectionElement && sectionElement !== anchorElement) {
+        resizeObserver.observe(sectionElement);
+      }
+    }
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleResize);
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+      }
+      resizeObserver?.disconnect();
+    };
+  }, [chatHasContent, isDesktop, isOpen, stickyBottomOffset, stickyTopOffset]);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -422,11 +509,6 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
     [handleSend],
   );
 
-  const chatHasContent = shouldRender && displayPanel;
-
-  const ctaOrderClass = chatHasContent ? "order-2" : "order-1";
-  const chatOrderClass = chatHasContent ? "order-1" : "order-2";
-
   return (
     <div
       ref={sectionRef}
@@ -463,8 +545,13 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
       </div>
       <div ref={bottomRef} aria-hidden className="order-3 mt-16 h-px w-full" />
       <div
+        ref={anchorRef}
+        aria-hidden
+        className={cn("pointer-events-none mt-2 h-0 w-full", ctaOrderClass)}
+      />
+      <div
         className={cn(
-          "mt-2 flex justify-center z-50",
+          "flex justify-center z-50",
           isOpen ? "w-full" : "w-auto",
           ctaOrderClass,
           "transition-opacity transition-transform duration-300 ease-out",


### PR DESCRIPTION
## Summary
- Clamp the floating Ask TransformAI CTA to the chat anchor so it stops exactly where the chat opens instead of drifting past the next section.
- Add a sentinel element and scroll/resize measurement to reuse the open-state sticky position while keeping the CTA layout order intact.
- Record the fix in the WRITE_HERE log for continuity.

## Plan
- Inspect the StickyChat CTA logic to determine how to capture the open-state anchor position.
- Add a sentinel plus scroll/resize observers that switch the CTA from floating to sticky once the anchor is reached.
- Validate the behavior across viewport changes and document the change for future reference.

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: existing lint violations in unrelated files)*
- `pnpm -w turbo run build --filter=www` *(fails: same lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d100e97080832a8484c6b519868aab