### PR TITLE
Auto-open Ask chat when CTA reaches anchor

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-21T0814--ask-button-sticky-travel.md
+++ b/WRITE_HERE/FIXES/2025-09-21T0814--ask-button-sticky-travel.md
@@ -1,0 +1,6 @@
+# Restored Ask CTA travel behavior
+
+- **What:** Adjusted the sticky chat CTA layout to introduce top/bottom sentinels, reorder the CTA within its section, and reuse the sticky helper so the "Ask the TransformAI" button starts beneath the heading, scrolls with the user, and pins at the original stop.
+- **Why:** The CTA rendered directly at its bottom stop and never traveled with scroll, breaking the intended interaction.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-09-22T0651--anchored-ask-transformai-sticky.md
+++ b/WRITE_HERE/FIXES/2025-09-22T0651--anchored-ask-transformai-sticky.md
@@ -1,0 +1,7 @@
+# Anchored Ask TransformAI sticky header
+_When:_ 2025-09-22 06:51 UTC · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Added a boundary anchor for the Ask TransformAI sticky experience so the chat panel and CTA release above the projects SectionTitle, using layout-based scroll detection to switch the CTA from fixed to in-flow positioning.
+- **Why:** The sticky header previously remained pinned for the entire page, covering content past the "Explore the projects we’ve been part of" section; anchoring preserves the intended spacing above that text.
+- **Files:** `apps/www/app/code-examples.tsx`, `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-18T0900--ask-cta-travels-before-sticking.md
+++ b/WRITE_HERE/FIXES/2025-11-18T0900--ask-cta-travels-before-sticking.md
@@ -1,0 +1,7 @@
+# Ask CTA now travels before sticking
+_When:_ 2025-11-18 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** The Ask TransformAI button should start beneath the section heading, follow the reader while scrolling, and only pin once it reaches the original bottom stop.
+- **Fix:** Introduced a top sentinel and extended the sticky helper to delay the sticky-top state until the header anchor scrolls past the viewport, letting the CTA move naturally before sticking at the existing bottom anchor.
+- **Files:** `apps/www/components/ask/use-sticky-within-section.ts`, `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** Monitor offsets across breakpoints in case the navbar height changes and re-tune the sticky thresholds if necessary.

--- a/WRITE_HERE/FIXES/2025-11-18T1500--ask-cta-no-initial-scroll.md
+++ b/WRITE_HERE/FIXES/2025-11-18T1500--ask-cta-no-initial-scroll.md
@@ -1,0 +1,7 @@
+# Ask CTA no longer steals initial scroll
+_When:_ 2025-11-18 15:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** Loading the page should keep the viewport at the top instead of jumping straight to the Ask TransformAI button while still letting the CTA travel with the reader.
+- **Fix:** Tracked whether the chat has been opened before returning focus to the button so it only moves focus (and scroll) after a close event, leaving the initial page load anchored at the top.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-18T1700--ask-cta-scrolls-with-section.md
+++ b/WRITE_HERE/FIXES/2025-11-18T1700--ask-cta-scrolls-with-section.md
@@ -1,0 +1,7 @@
+# Ask CTA scrolls naturally before sticking
+_When:_ 2025-11-18 17:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** Make the Ask TransformAI button travel with the section instead of appearing pinned from the start while still stopping at the existing bottom anchor.
+- **Fix:** Let the sticky helper expose scroll state so the CTA only sticks once the top sentinel leaves view, keep it flowing otherwise, and pin it while the chat is open so the panel stays stable.
+- **Files:** `apps/www/components/ask/use-sticky-within-section.ts`, `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-18T2000--ask-cta-floats-with-section-scroll.md
+++ b/WRITE_HERE/FIXES/2025-11-18T2000--ask-cta-floats-with-section-scroll.md
@@ -1,0 +1,7 @@
+# Ask CTA floats with section scroll before anchoring
+_When:_ 2025-11-18 20:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** Make the Ask TransformAI button travel with the section, floating alongside the viewport during scroll until it reaches the bottom anchor, similar to the referenced OpenAI Codex upgrades page.
+- **Fix:** Track when the section heading enters view and switch the CTA container to a sticky-bottom position after the reader passes the top sentinel so it rides the viewport until the section's bottom stop while still pinning when the chat panel is open.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T0900--ask-cta-pins-bottom-of-homepage.md
+++ b/WRITE_HERE/FIXES/2025-11-19T0900--ask-cta-pins-bottom-of-homepage.md
@@ -1,0 +1,7 @@
+# Ask CTA pins to the bottom of the homepage
+_When:_ 2025-11-19 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** Keep the "Ask TransformAI" button visible along the entire homepage and send visitors to the chat section when it is pressed.
+- **Fix:** Replaced the section-based sticky logic with a floating style that fixes the CTA near the viewport bottom until the panel is opened, while retaining the existing scroll-to-chat behaviour when toggled.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T1100--ask-cta-appears-after-intro-text.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1100--ask-cta-appears-after-intro-text.md
@@ -1,0 +1,7 @@
+# Ask CTA appears after assistant intro text
+_When:_ 2025-11-19 11:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **Request:** Only surface the Ask TransformAI button once visitors reach the "Ask questions, schedule a call…" lead-in on the homepage and hide it again when scrolling back above that section.
+- **Fix:** Observed the intro copy via an IntersectionObserver so the CTA floats at the viewport bottom only after the text comes into view (or has been scrolled past) while keeping it pinned when the chat is open.
+- **Files:** `apps/www/app/code-examples.tsx`, `apps/www/components/ask/StickyChat.tsx`, `apps/www/components/section.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T1200--ask-cta-fades-in-when-space-allows.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1200--ask-cta-fades-in-when-space-allows.md
@@ -1,0 +1,7 @@
+# Ask CTA fades in when intro has room
+_When:_ 2025-11-19 12:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Adjusted the Ask TransformAI sticky CTA so it measures its height, waits until the intro copy has enough viewport space before appearing, and fades in/out with a subtle translate while staying keyboard-accessible only when visible.
+- **Why:** The user wanted the button to surface only once there was sufficient distance between the intro text and the bottom of the viewport, with a smooth fade animation instead of an abrupt toggle.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`, `apps/www/components/ask/AskCta.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T1330--ask-cta-reveals-with-intro-visibility.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1330--ask-cta-reveals-with-intro-visibility.md
@@ -1,0 +1,6 @@
+# Ask CTA reveals with intro visibility
+
+- **What:** Updated the StickyChat intersection logic so the Ask TransformAI button appears as soon as the intro SectionTitle enters the viewport with a small cushion, keeping the CTA sticky afterward and fading it when the chat closes.
+- **Why:** The previous reveal waited for extra space beneath the intro text, so the CTA surfaced too late compared to the moment users first saw the copy.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T1500--ask-cta-releases-before-projects.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1500--ask-cta-releases-before-projects.md
@@ -1,0 +1,7 @@
+# Ask CTA releases before projects heading
+_When:_ 2025-11-19 15:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Adjusted the Ask TransformAI sticky logic so the panel stops sticking roughly 100px sooner, hiding the CTA once it crosses the projects heading boundary.
+- **Why:** The previous anchoring held the CTA too long near the projects section and produced glitchy behavior; releasing a bit earlier keeps the scroll experience smooth.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T1600--ask-cta-anchors-at-button-position.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1600--ask-cta-anchors-at-button-position.md
@@ -1,0 +1,7 @@
+# Ask CTA anchors at button position
+_When:_ 2025-11-19 16:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Removed the extra 100px scroll buffer from the Ask TransformAI sticky calculation so the chat and CTA release exactly at the button’s natural anchor point.
+- **Why:** The CTA was stopping short of its intended anchor after the prior buffer tweak; aligning the threshold with the button’s resting position meets the user’s request.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T1700--ask-cta-stops-at-pinned-position.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1700--ask-cta-stops-at-pinned-position.md
@@ -1,0 +1,7 @@
+# Ask CTA stops at pinned position
+_When:_ 2025-11-19 17:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Updated the sticky anchoring logic so the Ask TransformAI button remains at its pinned position while the chat is open instead of dropping to the bottom of the section when the boundary threshold is reached.
+- **Why:** The CTA was sliding far down the page in its anchored state, causing a noticeable UI glitch; keeping it pinned fulfills the request to stop at the normal button location.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-19T1800--ask-cta-stops-at-pinned-height-when-closed.md
+++ b/WRITE_HERE/FIXES/2025-11-19T1800--ask-cta-stops-at-pinned-height-when-closed.md
@@ -1,0 +1,7 @@
+# Ask CTA stops at pinned height when closed
+_When:_ 2025-11-19 18:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Adjusted the anchored CTA logic so the Ask TransformAI button pins to the same top offset whether or not the chat is open and keeps rendering after the boundary is reached.
+- **Why:** The sticky CTA slid well past its intended location when closed, causing visible glitches; clamping it to the pinned height fulfills the request that it stop at the open-state position.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-20T0900--clamped-ask-cta-to-open-anchor.md
+++ b/WRITE_HERE/FIXES/2025-11-20T0900--clamped-ask-cta-to-open-anchor.md
@@ -1,0 +1,7 @@
+# Clamped Ask CTA to open-state anchor
+_When:_ 2025-11-20 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Introduced an anchor sentinel and scroll listener so the floating Ask TransformAI CTA transitions into the same sticky position it occupies when the chat is open, including on resize. Latched the scroll detection so once the anchor is reached the CTA remains pinned there until the user scrolls back above the threshold, eliminating the upward jump.
+- **Why:** The button could drift past its intended stop and overlap the following section whenever the chat was closed; clamping it to the measured open-state anchor keeps it aligned.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-20T1300--auto-open-ask-chat-at-anchor.md
+++ b/WRITE_HERE/FIXES/2025-11-20T1300--auto-open-ask-chat-at-anchor.md
@@ -1,0 +1,7 @@
+# Auto-open Ask chat once anchor reached
+_When:_ 2025-11-20 13:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Trigger the Ask TransformAI chat panel to open automatically whenever the floating CTA reaches its measured anchor position, keeping it visible until the visitor explicitly closes it while tracking dismissals so the button stays closed until the anchor is released.
+- **Why:** Users noticed the CTA remained closed after settling at the anchor, forcing an extra click; auto-opening the chat at that point removes the sticky overlap and surfaces the conversation immediately.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -25,6 +25,7 @@ import React, { useEffect } from "react";
 import { useState } from "react";
 const Tabs = TabsPrimitive.Root;
 const ASK_CHAT_TRIGGER_ID = "ask-transformai-assistant-intro";
+const ASK_CHAT_BOUNDARY_ID = "ask-transformai-assistant-boundary";
 
 const editorTheme = {
   plain: {
@@ -608,8 +609,13 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
           <MeteorLines className="ml-16 fade-in-100" delay={2} number={1} />
         </div>
       </SectionTitle>
-      <StickyChat className="mt-16" triggerId={ASK_CHAT_TRIGGER_ID} />
+      <StickyChat
+        className="mt-16"
+        triggerId={ASK_CHAT_TRIGGER_ID}
+        boundaryId={ASK_CHAT_BOUNDARY_ID}
+      />
       <SectionTitle
+        id={ASK_CHAT_BOUNDARY_ID}
         title={t("bottom.title")}
         text={t("bottom.text")}
         align="center"

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -24,6 +24,7 @@ import type { PrismTheme } from "prism-react-renderer";
 import React, { useEffect } from "react";
 import { useState } from "react";
 const Tabs = TabsPrimitive.Root;
+const ASK_CHAT_TRIGGER_ID = "ask-transformai-assistant-intro";
 
 const editorTheme = {
   plain: {
@@ -590,6 +591,7 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
   return (
     <section className={className}>
       <SectionTitle
+        id={ASK_CHAT_TRIGGER_ID}
         title={t("top.title")}
         text={t("top.text")}
         align="center"
@@ -606,7 +608,7 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
           <MeteorLines className="ml-16 fade-in-100" delay={2} number={1} />
         </div>
       </SectionTitle>
-      <StickyChat className="mt-16" />
+      <StickyChat className="mt-16" triggerId={ASK_CHAT_TRIGGER_ID} />
       <SectionTitle
         title={t("bottom.title")}
         text={t("bottom.text")}

--- a/apps/www/components/ask/AskCta.tsx
+++ b/apps/www/components/ask/AskCta.tsx
@@ -10,10 +10,11 @@ type AskCtaProps = {
   onToggle: () => void;
   ariaControls?: string;
   className?: string;
+  tabIndex?: number;
 };
 
 export const AskCta = forwardRef<HTMLButtonElement, AskCtaProps>(
-  ({ label, pressed, onToggle, ariaControls, className }, ref) => {
+  ({ label, pressed, onToggle, ariaControls, className, tabIndex }, ref) => {
     return (
       <button
         ref={ref}
@@ -21,6 +22,7 @@ export const AskCta = forwardRef<HTMLButtonElement, AskCtaProps>(
         onClick={onToggle}
         aria-pressed={pressed}
         aria-controls={ariaControls}
+        tabIndex={tabIndex}
         data-state={pressed ? "open" : "closed"}
         className={cn(
           "group relative inline-flex items-center justify-center rounded-full p-[1px] text-sm font-semibold text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70 focus-visible:ring-offset-2 focus-visible:ring-offset-black",

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -64,6 +64,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [isDesktop, setIsDesktop] = useState(false);
+  const [hasSectionEnteredView, setHasSectionEnteredView] = useState(false);
 
   const sectionRef = useRef<HTMLDivElement>(null);
   const topRef = useRef<HTMLDivElement>(null);
@@ -149,17 +150,36 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const stickyTopOffset = isDesktop ? 96 : 72;
   const stickyBottomOffset = isDesktop ? 80 : 64;
 
-  const { style: ctaStickyStyle } = useStickyWithinSection({
+  const { isTopVisible: isSectionTopVisible } = useStickyWithinSection({
     enabled: !isOpen,
     bottomRef,
     topRef,
     topOffset: stickyTopOffset,
     bottomOffset: stickyBottomOffset,
+    stickToTop: false,
   });
 
-  const ctaStyle = isDesktop && isOpen
-    ? ({ position: "relative" } as const)
-    : ctaStickyStyle;
+  useEffect(() => {
+    if (isOpen) {
+      return;
+    }
+
+    if (isSectionTopVisible) {
+      setHasSectionEnteredView((previous) => (previous ? previous : true));
+    }
+  }, [isOpen, isSectionTopVisible]);
+
+  const shouldStickCtaToBottom = !isOpen && hasSectionEnteredView && !isSectionTopVisible;
+
+  const restingCtaStyle = shouldStickCtaToBottom
+    ? ({ position: "sticky", bottom: `${stickyBottomOffset}px` } as const)
+    : ({ position: "relative" } as const);
+
+  const pinnedCtaStyle = isDesktop
+    ? ({ position: "sticky", top: `${stickyTopOffset}px` } as const)
+    : ({ position: "sticky", bottom: `${stickyBottomOffset}px` } as const);
+
+  const ctaStyle = isOpen ? pinnedCtaStyle : restingCtaStyle;
 
   const scrollToChat = useCallback(() => {
     if (typeof window === "undefined") {

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -66,9 +66,11 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const [isDesktop, setIsDesktop] = useState(false);
 
   const sectionRef = useRef<HTMLDivElement>(null);
+  const topRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const ctaRef = useRef<HTMLButtonElement>(null);
   const closeTimer = useRef<number>();
+  const hasOpenedRef = useRef(false);
 
   const chatId = useId();
   const chatPanelId = `${chatId}-panel`;
@@ -121,7 +123,12 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   }, [isOpen]);
 
   useEffect(() => {
-    if (!isOpen && ctaRef.current) {
+    if (isOpen) {
+      hasOpenedRef.current = true;
+      return;
+    }
+
+    if (hasOpenedRef.current && ctaRef.current) {
       ctaRef.current.focus();
     }
   }, [isOpen]);
@@ -139,9 +146,20 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
       ? ({ position: "sticky", bottom: "96px" } as const)
       : ({ position: "relative" } as const);
 
-  const ctaStyle = isDesktop && !isOpen
-    ? ({ position: "sticky", top: "96px" } as const)
-    : ({ position: "relative" } as const);
+  const stickyTopOffset = isDesktop ? 96 : 72;
+  const stickyBottomOffset = isDesktop ? 80 : 64;
+
+  const { style: ctaStickyStyle } = useStickyWithinSection({
+    enabled: !isOpen,
+    bottomRef,
+    topRef,
+    topOffset: stickyTopOffset,
+    bottomOffset: stickyBottomOffset,
+  });
+
+  const ctaStyle = isDesktop && isOpen
+    ? ({ position: "relative" } as const)
+    : ctaStickyStyle;
 
   const scrollToChat = useCallback(() => {
     if (typeof window === "undefined") {
@@ -252,6 +270,9 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
 
   const chatHasContent = shouldRender && displayPanel;
 
+  const ctaOrderClass = chatHasContent ? "order-2" : "order-1";
+  const chatOrderClass = chatHasContent ? "order-1" : "order-2";
+
   return (
     <div
       ref={sectionRef}
@@ -261,7 +282,15 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
       )}
     >
       <div
-        className="w-full transition-[top,bottom] duration-300 ease-out"
+        ref={topRef}
+        aria-hidden
+        className="order-first -mb-8 h-px w-full sm:-mb-12"
+      />
+      <div
+        className={cn(
+          "w-full transition-all duration-300 ease-out",
+          chatOrderClass,
+        )}
         style={chatStyle}
         id={chatPanelId}
       >
@@ -281,11 +310,12 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
           ) : null}
         </div>
       </div>
-      <div ref={bottomRef} aria-hidden className="mt-16 h-px w-full" />
+      <div ref={bottomRef} aria-hidden className="order-3 mt-16 h-px w-full" />
       <div
         className={cn(
           "mt-2 flex w-full justify-center",
-          isDesktop ? "transition-[top] duration-300 ease-out" : undefined,
+          ctaOrderClass,
+          "transition-all duration-300 ease-out",
         )}
         style={ctaStyle}
       >
@@ -297,6 +327,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
           ariaControls={chatPanelId}
         />
       </div>
+      <div aria-hidden className="order-last h-8 w-full sm:h-12" />
     </div>
   );
 };

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -27,9 +27,10 @@ const INTERSECTION_THRESHOLDS = Array.from({ length: 11 }, (_, index) => index /
 type StickyChatProps = {
   className?: string;
   triggerId?: string;
+  boundaryId?: string;
 };
 
-export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) => {
+export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, boundaryId }) => {
   const t = useTranslations("CodeExamples.chat");
   const locale = useMemo<ChatLocale>(
     () => ({
@@ -69,8 +70,10 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [isDesktop, setIsDesktop] = useState(false);
   const [hasReachedTrigger, setHasReachedTrigger] = useState(false);
+  const [hasReachedBoundary, setHasReachedBoundary] = useState(false);
   const sectionRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const chatContainerRef = useRef<HTMLDivElement>(null);
   const ctaRef = useRef<HTMLButtonElement>(null);
   const closeTimer = useRef<number>();
   const hasOpenedRef = useRef(false);
@@ -136,11 +139,15 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
     }
   }, [isOpen]);
 
+  const chatStickyTopOffset = 64;
+  const chatStickyBottomOffset = 80;
+
   const { style: stickyStyle } = useStickyWithinSection({
     enabled: isOpen && isDesktop,
     bottomRef,
-    topOffset: 64,
-    bottomOffset: 80,
+    topOffset: chatStickyTopOffset,
+    bottomOffset: chatStickyBottomOffset,
+    stickToTop: !hasReachedBoundary,
   });
 
   const chatStyle = isDesktop
@@ -148,6 +155,73 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
     : isOpen
       ? ({ position: "sticky", bottom: "96px" } as const)
       : ({ position: "relative" } as const);
+
+  useEffect(() => {
+    if (!boundaryId || typeof window === "undefined" || !isDesktop) {
+      setHasReachedBoundary(false);
+      return;
+    }
+
+    const boundaryElement = document.getElementById(boundaryId);
+    const chatElement = chatContainerRef.current;
+    const sectionElement = sectionRef.current;
+
+    if (!boundaryElement || !chatElement || !sectionElement) {
+      setHasReachedBoundary(false);
+      return;
+    }
+
+    let frame = 0;
+
+    const calculate = () => {
+      const boundaryTop = boundaryElement.getBoundingClientRect().top + window.scrollY;
+      const chatRect = chatElement.getBoundingClientRect();
+      const chatHeight = chatRect.height;
+      const sectionBottom = sectionElement.getBoundingClientRect().bottom + window.scrollY;
+      const defaultGap = Math.max(boundaryTop - sectionBottom, 0);
+      const anchorThreshold = Math.max(
+        boundaryTop - (chatStickyTopOffset + chatHeight + defaultGap),
+        0,
+      );
+      const reached = window.scrollY >= anchorThreshold;
+      setHasReachedBoundary((previous) => (previous === reached ? previous : reached));
+    };
+
+    const handleScroll = () => {
+      if (frame) {
+        return;
+      }
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        calculate();
+      });
+    };
+
+    const handleResize = () => {
+      calculate();
+    };
+
+    calculate();
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleResize);
+
+    let resizeObserver: ResizeObserver | undefined;
+    if (typeof ResizeObserver === "function") {
+      resizeObserver = new ResizeObserver(() => calculate());
+      resizeObserver.observe(chatElement);
+      resizeObserver.observe(sectionElement);
+    }
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleResize);
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+      }
+      resizeObserver?.disconnect();
+    };
+  }, [boundaryId, chatStickyTopOffset, isDesktop]);
 
   const stickyTopOffset = isDesktop ? 96 : 72;
   const stickyBottomOffset = isDesktop ? 80 : 64;
@@ -167,8 +241,19 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
     ? { position: "sticky", top: `${stickyTopOffset}px` }
     : { position: "sticky", bottom: `${stickyBottomOffset}px` };
 
-  const baseCtaStyle = isOpen ? pinnedCtaStyle : floatingCtaStyle;
-  const shouldShowCta = isOpen || hasReachedTrigger;
+  const anchoredCtaStyle: CSSProperties | null =
+    isDesktop && hasReachedBoundary
+      ? {
+          position: "relative",
+          left: "auto",
+          bottom: "auto",
+          transform: "none",
+          zIndex: 60,
+        }
+      : null;
+
+  const baseCtaStyle = anchoredCtaStyle ?? (isOpen ? pinnedCtaStyle : floatingCtaStyle);
+  const shouldShowCta = isOpen || (hasReachedTrigger && !hasReachedBoundary);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -355,6 +440,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) 
           "w-full transition-all duration-300 ease-out",
           chatOrderClass,
         )}
+        ref={chatContainerRef}
         style={chatStyle}
         id={chatPanelId}
       >

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -244,7 +244,8 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
   const anchoredCtaStyle: CSSProperties | null =
     isDesktop && hasReachedBoundary
       ? {
-          position: "relative",
+          position: "sticky",
+          top: `${stickyTopOffset}px`,
           left: "auto",
           bottom: "auto",
           transform: "none",
@@ -253,7 +254,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
       : null;
 
   const baseCtaStyle = anchoredCtaStyle ?? (isOpen ? pinnedCtaStyle : floatingCtaStyle);
-  const shouldShowCta = isOpen || (hasReachedTrigger && !hasReachedBoundary);
+  const shouldShowCta = isOpen || hasReachedTrigger;
 
   useEffect(() => {
     if (typeof window === "undefined") {

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -71,12 +71,16 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
   const [isDesktop, setIsDesktop] = useState(false);
   const [hasReachedTrigger, setHasReachedTrigger] = useState(false);
   const [hasReachedBoundary, setHasReachedBoundary] = useState(false);
+  const [hasReachedAnchor, setHasReachedAnchor] = useState(false);
   const sectionRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const ctaRef = useRef<HTMLButtonElement>(null);
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const lastScrollYRef = useRef(0);
   const closeTimer = useRef<number>();
   const hasOpenedRef = useRef(false);
+  const anchorDismissedRef = useRef(false);
 
   const chatId = useId();
   const chatPanelId = `${chatId}-panel`;
@@ -241,20 +245,137 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
     ? { position: "sticky", top: `${stickyTopOffset}px` }
     : { position: "sticky", bottom: `${stickyBottomOffset}px` };
 
+  const shouldAnchorCta = hasReachedAnchor || (isDesktop && hasReachedBoundary);
+
+  useEffect(() => {
+    if (shouldAnchorCta) {
+      if (!isOpen && !anchorDismissedRef.current) {
+        setIsOpen(true);
+      }
+      return;
+    }
+
+    anchorDismissedRef.current = false;
+  }, [isOpen, shouldAnchorCta]);
+
   const anchoredCtaStyle: CSSProperties | null =
-    isDesktop && hasReachedBoundary
-      ? {
-          position: "sticky",
-          top: `${stickyTopOffset}px`,
-          left: "auto",
-          bottom: "auto",
-          transform: "none",
-          zIndex: 60,
-        }
+    !isOpen && shouldAnchorCta
+      ? isDesktop
+        ? {
+            position: "sticky",
+            top: `${stickyTopOffset}px`,
+            left: "auto",
+            right: "auto",
+            bottom: "auto",
+            transform: "none",
+            zIndex: 60,
+          }
+        : {
+            position: "sticky",
+            bottom: `${stickyBottomOffset}px`,
+            left: "auto",
+            right: "auto",
+            top: "auto",
+            transform: "none",
+            zIndex: 60,
+          }
       : null;
 
-  const baseCtaStyle = anchoredCtaStyle ?? (isOpen ? pinnedCtaStyle : floatingCtaStyle);
+  const baseCtaStyle = isOpen ? pinnedCtaStyle : anchoredCtaStyle ?? floatingCtaStyle;
   const shouldShowCta = isOpen || hasReachedTrigger;
+  const chatHasContent = shouldRender && displayPanel;
+  const ctaOrderClass = chatHasContent ? "order-2" : "order-1";
+  const chatOrderClass = chatHasContent ? "order-1" : "order-2";
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const anchorElement = anchorRef.current;
+    if (!anchorElement) {
+      setHasReachedAnchor(false);
+      return;
+    }
+
+    let frame = 0;
+    lastScrollYRef.current = window.scrollY;
+
+    const calculate = () => {
+      const element = anchorRef.current;
+      if (!element) {
+        setHasReachedAnchor(false);
+        return;
+      }
+
+      const rect = element.getBoundingClientRect();
+      const viewportHeight = window.innerHeight || 0;
+      const referencePosition = isDesktop ? rect.top : rect.bottom;
+      const anchorLimit = isDesktop
+        ? stickyTopOffset
+        : viewportHeight - stickyBottomOffset;
+      const scrollY = window.scrollY;
+      const isScrollingDown = scrollY >= lastScrollYRef.current;
+      const reached = referencePosition <= anchorLimit;
+      const releaseThreshold = anchorLimit + 8;
+
+      setHasReachedAnchor((previous) => {
+        if (reached) {
+          return true;
+        }
+
+        if (!previous) {
+          return false;
+        }
+
+        if (!isScrollingDown && referencePosition > releaseThreshold) {
+          return false;
+        }
+
+        return previous;
+      });
+
+      lastScrollYRef.current = scrollY;
+    };
+
+    calculate();
+
+    const handleScroll = () => {
+      if (frame) {
+        return;
+      }
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        calculate();
+      });
+    };
+
+    const handleResize = () => {
+      calculate();
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleResize);
+
+    let resizeObserver: ResizeObserver | undefined;
+    if (typeof ResizeObserver === "function") {
+      resizeObserver = new ResizeObserver(() => calculate());
+      resizeObserver.observe(anchorElement);
+      const sectionElement = sectionRef.current;
+      if (sectionElement && sectionElement !== anchorElement) {
+        resizeObserver.observe(sectionElement);
+      }
+    }
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleResize);
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+      }
+      resizeObserver?.disconnect();
+    };
+  }, [chatHasContent, isDesktop, isOpen, stickyBottomOffset, stickyTopOffset]);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -407,13 +528,23 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
     void sendToAssistant([...messages], pendingPrompt);
   }, [messages, pendingPrompt, sendToAssistant]);
 
-  const handleToggle = useCallback(() => {
-    const next = !isOpen;
-    setIsOpen(next);
-    if (next) {
-      scrollToChat();
+  const closeChat = useCallback(() => {
+    setIsOpen(false);
+    if (shouldAnchorCta) {
+      anchorDismissedRef.current = true;
     }
-  }, [isOpen, scrollToChat]);
+  }, [shouldAnchorCta]);
+
+  const handleToggle = useCallback(() => {
+    if (isOpen) {
+      closeChat();
+      return;
+    }
+
+    anchorDismissedRef.current = false;
+    setIsOpen(true);
+    scrollToChat();
+  }, [closeChat, isOpen, scrollToChat]);
 
   const handlePrompt = useCallback(
     (prompt: string) => {
@@ -421,11 +552,6 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
     },
     [handleSend],
   );
-
-  const chatHasContent = shouldRender && displayPanel;
-
-  const ctaOrderClass = chatHasContent ? "order-2" : "order-1";
-  const chatOrderClass = chatHasContent ? "order-1" : "order-2";
 
   return (
     <div
@@ -452,7 +578,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
               isOpen={isOpen}
               isLoading={isLoading}
               locale={locale}
-              onClose={() => setIsOpen(false)}
+              onClose={closeChat}
               onSend={handleSend}
               onUsePrompt={handlePrompt}
               errorMessage={errorMessage}
@@ -463,8 +589,13 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
       </div>
       <div ref={bottomRef} aria-hidden className="order-3 mt-16 h-px w-full" />
       <div
+        ref={anchorRef}
+        aria-hidden
+        className={cn("pointer-events-none mt-2 h-0 w-full", ctaOrderClass)}
+      />
+      <div
         className={cn(
-          "mt-2 flex justify-center z-50",
+          "flex justify-center z-50",
           isOpen ? "w-full" : "w-auto",
           ctaOrderClass,
           "transition-opacity transition-transform duration-300 ease-out",

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -3,6 +3,7 @@
 import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import {
+  type CSSProperties,
   useCallback,
   useEffect,
   useId,
@@ -21,11 +22,14 @@ const ChatPanel = dynamic(() => import("./ChatPanel").then((mod) => mod.ChatPane
   ssr: false,
 });
 
+const INTERSECTION_THRESHOLDS = Array.from({ length: 11 }, (_, index) => index / 10);
+
 type StickyChatProps = {
   className?: string;
+  triggerId?: string;
 };
 
-export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
+export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId }) => {
   const t = useTranslations("CodeExamples.chat");
   const locale = useMemo<ChatLocale>(
     () => ({
@@ -64,10 +68,8 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [isDesktop, setIsDesktop] = useState(false);
-  const [hasSectionEnteredView, setHasSectionEnteredView] = useState(false);
-
+  const [hasReachedTrigger, setHasReachedTrigger] = useState(false);
   const sectionRef = useRef<HTMLDivElement>(null);
-  const topRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const ctaRef = useRef<HTMLButtonElement>(null);
   const closeTimer = useRef<number>();
@@ -150,36 +152,82 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
   const stickyTopOffset = isDesktop ? 96 : 72;
   const stickyBottomOffset = isDesktop ? 80 : 64;
 
-  const { isTopVisible: isSectionTopVisible } = useStickyWithinSection({
-    enabled: !isOpen,
-    bottomRef,
-    topRef,
-    topOffset: stickyTopOffset,
-    bottomOffset: stickyBottomOffset,
-    stickToTop: false,
-  });
+  const floatingBottomOffset = isDesktop ? 72 : 32;
+  const floatingCtaStyle: CSSProperties = {
+    position: "fixed",
+    bottom: `${floatingBottomOffset}px`,
+    left: "50%",
+    transform: "translateX(-50%)",
+    zIndex: 60,
+    width: "fit-content",
+    maxWidth: "calc(100% - 32px)",
+  };
+
+  const pinnedCtaStyle: CSSProperties = isDesktop
+    ? { position: "sticky", top: `${stickyTopOffset}px` }
+    : { position: "sticky", bottom: `${stickyBottomOffset}px` };
+
+  const baseCtaStyle = isOpen ? pinnedCtaStyle : floatingCtaStyle;
+  const shouldShowCta = isOpen || hasReachedTrigger;
 
   useEffect(() => {
-    if (isOpen) {
+    if (typeof window === "undefined") {
       return;
     }
 
-    if (isSectionTopVisible) {
-      setHasSectionEnteredView((previous) => (previous ? previous : true));
+    if (!triggerId) {
+      setHasReachedTrigger(true);
+      return;
     }
-  }, [isOpen, isSectionTopVisible]);
 
-  const shouldStickCtaToBottom = !isOpen && hasSectionEnteredView && !isSectionTopVisible;
+    if (typeof window.IntersectionObserver !== "function") {
+      setHasReachedTrigger(true);
+      return;
+    }
 
-  const restingCtaStyle = shouldStickCtaToBottom
-    ? ({ position: "sticky", bottom: `${stickyBottomOffset}px` } as const)
-    : ({ position: "relative" } as const);
+    const section = sectionRef.current;
+    const target = (document.getElementById(triggerId) ?? section?.previousElementSibling) as
+      | HTMLElement
+      | null;
 
-  const pinnedCtaStyle = isDesktop
-    ? ({ position: "sticky", top: `${stickyTopOffset}px` } as const)
-    : ({ position: "sticky", bottom: `${stickyBottomOffset}px` } as const);
+    if (!target) {
+      setHasReachedTrigger(true);
+      return;
+    }
 
-  const ctaStyle = isOpen ? pinnedCtaStyle : restingCtaStyle;
+    const computeShouldActivate = (rect: DOMRect | DOMRectReadOnly) => {
+      const viewportHeight = window.innerHeight || 0;
+      const visibilityOffset = Math.max(Math.min(viewportHeight, 16), 0);
+      const threshold = viewportHeight - visibilityOffset;
+      return rect.top <= threshold;
+    };
+
+    const evaluate = () => {
+      const rect = target.getBoundingClientRect();
+      setHasReachedTrigger(computeShouldActivate(rect));
+    };
+
+    evaluate();
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry) {
+          return;
+        }
+
+        const rect = entry.boundingClientRect;
+        setHasReachedTrigger(entry.isIntersecting || computeShouldActivate(rect));
+      },
+      { threshold: INTERSECTION_THRESHOLDS },
+    );
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [triggerId]);
 
   const scrollToChat = useCallback(() => {
     if (typeof window === "undefined") {
@@ -301,11 +349,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
         className,
       )}
     >
-      <div
-        ref={topRef}
-        aria-hidden
-        className="order-first -mb-8 h-px w-full sm:-mb-12"
-      />
+      <div aria-hidden className="order-first -mb-8 h-px w-full sm:-mb-12" />
       <div
         className={cn(
           "w-full transition-all duration-300 ease-out",
@@ -333,11 +377,17 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
       <div ref={bottomRef} aria-hidden className="order-3 mt-16 h-px w-full" />
       <div
         className={cn(
-          "mt-2 flex w-full justify-center",
+          "mt-2 flex justify-center z-50",
+          isOpen ? "w-full" : "w-auto",
           ctaOrderClass,
-          "transition-all duration-300 ease-out",
+          "transition-opacity transition-transform duration-300 ease-out",
+          "motion-reduce:transition-none motion-reduce:transform-none",
+          shouldShowCta
+            ? "pointer-events-auto opacity-100 translate-y-0 motion-reduce:translate-y-0"
+            : "pointer-events-none opacity-0 translate-y-2 motion-reduce:translate-y-0",
         )}
-        style={ctaStyle}
+        style={baseCtaStyle}
+        aria-hidden={!shouldShowCta}
       >
         <AskCta
           ref={ctaRef}
@@ -345,6 +395,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className }) => {
           pressed={isOpen}
           onToggle={handleToggle}
           ariaControls={chatPanelId}
+          tabIndex={shouldShowCta ? 0 : -1}
         />
       </div>
       <div aria-hidden className="order-last h-8 w-full sm:h-12" />

--- a/apps/www/components/ask/use-sticky-within-section.ts
+++ b/apps/www/components/ask/use-sticky-within-section.ts
@@ -8,6 +8,7 @@ type StickyWithinSectionOptions = {
   topOffset: number;
   bottomOffset: number;
   topRef?: RefObject<Element>;
+  stickToTop?: boolean;
 };
 
 export function useStickyWithinSection({
@@ -16,6 +17,7 @@ export function useStickyWithinSection({
   topOffset,
   bottomOffset,
   topRef,
+  stickToTop = true,
 }: StickyWithinSectionOptions) {
   const [isAtBottom, setIsAtBottom] = useState(false);
   const [isTopVisible, setIsTopVisible] = useState(true);
@@ -87,17 +89,34 @@ export function useStickyWithinSection({
     };
   }, [enabled, topOffset, topRef]);
 
+  const style = useMemo(() => {
+    if (!enabled) {
+      return { position: "relative" } as const;
+    }
+
+    if (isAtBottom) {
+      return { position: "sticky", bottom: `${bottomOffset}px` } as const;
+    }
+
+    if (!stickToTop) {
+      return { position: "relative" } as const;
+    }
+
+    if (!topRef) {
+      return { position: "sticky", top: `${topOffset}px` } as const;
+    }
+
+    return isTopVisible
+      ? ({ position: "relative" } as const)
+      : ({ position: "sticky", top: `${topOffset}px` } as const);
+  }, [bottomOffset, enabled, isAtBottom, isTopVisible, stickToTop, topOffset, topRef]);
+
   return useMemo(
     () => ({
       isAtBottom,
-      style: enabled
-        ? isAtBottom
-          ? ({ position: "sticky", bottom: `${bottomOffset}px` } as const)
-          : topRef && isTopVisible
-            ? ({ position: "relative" } as const)
-            : ({ position: "sticky", top: `${topOffset}px` } as const)
-        : ({ position: "relative" } as const),
+      isTopVisible,
+      style,
     }),
-    [bottomOffset, enabled, isAtBottom, isTopVisible, topOffset, topRef],
+    [isAtBottom, isTopVisible, style],
   );
 }

--- a/apps/www/components/ask/use-sticky-within-section.ts
+++ b/apps/www/components/ask/use-sticky-within-section.ts
@@ -7,6 +7,7 @@ type StickyWithinSectionOptions = {
   bottomRef: RefObject<Element>;
   topOffset: number;
   bottomOffset: number;
+  topRef?: RefObject<Element>;
 };
 
 export function useStickyWithinSection({
@@ -14,12 +15,15 @@ export function useStickyWithinSection({
   bottomRef,
   topOffset,
   bottomOffset,
+  topRef,
 }: StickyWithinSectionOptions) {
   const [isAtBottom, setIsAtBottom] = useState(false);
+  const [isTopVisible, setIsTopVisible] = useState(true);
 
   useEffect(() => {
     if (!enabled) {
       setIsAtBottom(false);
+      setIsTopVisible(true);
       return;
     }
 
@@ -50,15 +54,50 @@ export function useStickyWithinSection({
     };
   }, [bottomOffset, bottomRef, enabled]);
 
+  useEffect(() => {
+    if (!enabled) {
+      setIsTopVisible(true);
+      return;
+    }
+
+    const sentinel = topRef?.current;
+    if (!sentinel) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry) {
+          return;
+        }
+        setIsTopVisible(entry.isIntersecting);
+      },
+      {
+        threshold: [0, 1],
+        root: null,
+        rootMargin: `-${topOffset}px 0px 0px 0px`,
+      },
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [enabled, topOffset, topRef]);
+
   return useMemo(
     () => ({
       isAtBottom,
       style: enabled
         ? isAtBottom
           ? ({ position: "sticky", bottom: `${bottomOffset}px` } as const)
-          : ({ position: "sticky", top: `${topOffset}px` } as const)
+          : topRef && isTopVisible
+            ? ({ position: "relative" } as const)
+            : ({ position: "sticky", top: `${topOffset}px` } as const)
         : ({ position: "relative" } as const),
     }),
-    [bottomOffset, enabled, isAtBottom, topOffset],
+    [bottomOffset, enabled, isAtBottom, isTopVisible, topOffset, topRef],
   );
 }

--- a/apps/www/components/section.tsx
+++ b/apps/www/components/section.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/lib/utils";
 import type { PropsWithChildren } from "react";
 
 type SectionTitleProps = {
+  id?: string;
   label?: string;
   title?: React.ReactNode;
   text?: React.ReactNode;
@@ -11,6 +12,7 @@ type SectionTitleProps = {
 };
 
 export function SectionTitle({
+  id,
   label,
   title,
   text,
@@ -20,6 +22,7 @@ export function SectionTitle({
 }: SectionTitleProps) {
   return (
     <div
+      id={id}
       className={cn(
         "flex flex-col items-center",
         {


### PR DESCRIPTION
## Summary
- Auto-open the Ask CTA panel as soon as the scroll observer reports the anchor has been reached while remembering dismissals so the panel stays closed until the user scrolls away.
- Centralize chat closing so manual dismissals set the anchor dismissal flag and wire the ChatPanel close action through the helper.
- Document the behavioral change in WRITE_HERE/FIXES for continuity.

## Plan
- Review the Ask CTA anchor detection and sticky state logic.
- Add auto-open logic plus dismissal tracking tied to the anchor observer.
- Update the chat close handlers and capture the change in the FIXES log.

## Testing
- `pnpm --filter www run typecheck` *(fails: workspace still missing the next-intl dependency referenced throughout the site)*
- `pnpm --filter www run lint` *(fails: same missing next-intl package)*
- `pnpm -w turbo run build --filter=www` *(fails: same missing next-intl package)*

------
https://chatgpt.com/codex/tasks/task_e_68d100e97080832a8484c6b519868aab