### PR TITLE
feat: replace rust code example with project image

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-17T1530--added-project-image-slot.md
+++ b/WRITE_HERE/UPDATES/2025-11-17T1530--added-project-image-slot.md
@@ -1,0 +1,5 @@
+# Added image placeholder for code examples Rust tab
+- **What:** Reworked the Rust tab in the homepage code examples to support non-code media, wiring up a project image container and adding a dedicated public/projects directory with a Platform placeholder asset.
+- **Why:** To begin showcasing TransformAI projects within the interactive carousel as requested by the user.
+- **Files:** `apps/www/app/code-examples.tsx`, `apps/www/public/projects/platform.png`.
+- **Follow-ups:** Swap in the final Platform artwork and extend the pattern to other language tabs as additional project visuals become available.

--- a/WRITE_HERE/UPDATES/2025-11-17T1600--remove-platform-placeholder-asset.md
+++ b/WRITE_HERE/UPDATES/2025-11-17T1600--remove-platform-placeholder-asset.md
@@ -1,0 +1,5 @@
+# Removed temporary Platform placeholder asset
+- **What:** Deleted the binary Platform preview added for the homepage carousel and replaced it with documentation in `apps/www/public/projects/README.md` so the folder stays tracked without bundling binaries.
+- **Why:** Repository guidelines forbid committing binary assets; the user will supply the final image separately.
+- **Files:** `apps/www/public/projects/README.md`.
+- **Follow-ups:** Upload the real Platform showcase image (named `platform.png`) into `apps/www/public/projects/` once available.

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -18,6 +18,7 @@ import { MeteorLines } from "@/components/ui/meteorLines";
 import { cn } from "@/lib/utils";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { ChevronRight } from "lucide-react";
+import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import type { PrismTheme } from "prism-react-renderer";
@@ -383,8 +384,14 @@ public class APIController {
 type Framework = {
   name: string;
   Icon: React.FC<LangIconProps>;
-  codeBlock: string;
-  editorLanguage: string;
+  codeBlock?: string;
+  editorLanguage?: string;
+  image?: {
+    src: string;
+    alt: string;
+    width: number;
+    height: number;
+  };
 };
 
 const languagesList = {
@@ -472,10 +479,14 @@ const languagesList = {
   ],
   Rust: [
     {
-      name: "Verify key",
+      name: "Platform",
       Icon: RustIcon,
-      codeBlock: rustCodeBlock,
-      editorLanguage: "rust",
+      image: {
+        src: "/projects/platform.png",
+        alt: "Platform project preview",
+        width: 1200,
+        height: 800,
+      },
     },
   ],
   Curl: [
@@ -561,33 +572,19 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
   const [language, setLanguage] = useState<Language>("Typescript");
   const [framework, setFramework] = useState<FrameworkName>("Typescript");
   const [languageHover, setLanguageHover] = useState("Typescript");
-  function getLanguage({
-    language,
-    framework,
-  }: {
-    language: Language;
-    framework: FrameworkName;
-  }) {
-    const frameworks = languagesList[language];
-    const currentFramework = frameworks.find((f) => f.name === framework);
-    return currentFramework?.editorLanguage || "tsx";
-  }
+  const frameworksForLanguage: Framework[] = languagesList[language];
+  const currentFrameworkData: Framework | undefined =
+    frameworksForLanguage.find((f) => f.name === framework) ??
+    frameworksForLanguage[0];
+  const activeCodeBlock = currentFrameworkData?.codeBlock ?? "";
+  const activeEditorLanguage = currentFrameworkData?.editorLanguage ?? "tsx";
 
   useEffect(() => {
-    setFramework(languagesList[language].at(0)!.name);
+    const [firstFramework] = languagesList[language];
+    if (firstFramework) {
+      setFramework(firstFramework.name);
+    }
   }, [language]);
-
-  function getCodeBlock({
-    language,
-    framework,
-  }: {
-    language: Language;
-    framework: FrameworkName;
-  }) {
-    const frameworks = languagesList[language];
-    const currentFramework = frameworks.find((f) => f.name === framework);
-    return currentFramework?.codeBlock || "";
-  }
 
   return (
     <section className={className}>
@@ -647,20 +644,41 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
         </Tabs>
         <div className="flex flex-col sm:flex-row overflow-x-auto scrollbar-hidden sm:h-[520px]">
           <FrameworkSwitcher
-            frameworks={languagesList[language]}
+            frameworks={frameworksForLanguage}
             currentFramework={framework}
             setFramework={setFramework}
           />
-          <div className="relative flex w-full pt-4 pb-8 pl-8 font-mono text-xs text-white sm:text-sm">
-            <CodeEditor
-              language={getLanguage({ language, framework })}
-              theme={editorTheme}
-              codeBlock={getCodeBlock({ language, framework })}
-            />
-            <CopyCodeSnippetButton
-              textToCopy={getCodeBlock({ language, framework })}
-              className="absolute hidden cursor-pointer top-5 right-5 lg:flex"
-            />
+          <div
+            className={cn(
+              "relative flex w-full pt-4 pb-8 pl-8 text-white",
+              currentFrameworkData?.image
+                ? "items-center justify-center pr-8"
+                : "font-mono text-xs sm:text-sm",
+            )}
+          >
+            {currentFrameworkData?.image ? (
+              <Image
+                src={currentFrameworkData.image.src}
+                alt={currentFrameworkData.image.alt}
+                width={currentFrameworkData.image.width}
+                height={currentFrameworkData.image.height}
+                className="object-contain w-full h-auto max-h-[420px] rounded-2xl border border-white/10 bg-white/5"
+                sizes="(min-width: 1280px) 720px, (min-width: 640px) 75vw, 90vw"
+                priority={language === "Rust"}
+              />
+            ) : (
+              <>
+                <CodeEditor
+                  language={activeEditorLanguage}
+                  theme={editorTheme}
+                  codeBlock={activeCodeBlock}
+                />
+                <CopyCodeSnippetButton
+                  textToCopy={activeCodeBlock}
+                  className="absolute hidden cursor-pointer top-5 right-5 lg:flex"
+                />
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/apps/www/public/projects/README.md
+++ b/apps/www/public/projects/README.md
@@ -1,0 +1,3 @@
+# Project image assets
+
+Add project showcase images (e.g., `platform.png`) to this directory. Keep filenames lowercase and prefer optimized PNG/WebP assets sized for the homepage code examples carousel.


### PR DESCRIPTION
## Summary
- allow language frameworks to render either code or an image in the homepage code examples carousel
- reserve the Rust tab for the Platform project image while replacing the committed placeholder binary with instructions in the new public/projects directory
- log the asset change for future reference

## Plan
- inspect CodeExamples component and identify how frameworks are rendered
- extend framework typing/rendering to support an image payload alongside code blocks
- reserve a placeholder project image slot in a dedicated public/projects folder and document how to add the asset
- verify type safety, linting/build, and document the content change

## Testing
- pnpm --filter www run typecheck *(fails: repository lacks next-intl typings in this environment)*
- pnpm --filter www run lint *(fails: next lint cannot resolve next-intl in this environment)*
- pnpm -w turbo run build --filter=www *(fails: build step cannot resolve next-intl in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d10b396024832abb51ae116210d136