### PR TITLE
Add pricing assistant chat

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-20T1800--pricing-assistant-chat.md
+++ b/WRITE_HERE/UPDATES/2025-11-20T1800--pricing-assistant-chat.md
@@ -1,0 +1,7 @@
+# Added pricing page TransformAI assistant
+_When:_ 2025-11-20 18:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Added a floating Ask TransformAI button and pricing-focused chat assistant on the pricing page, reusing the existing chat panel styling with a new layout tailored for the right-hand corner.
+- **Why:** To help visitors compare packages and select the right offering without leaving the pricing context.
+- **Files:** `apps/www/app/[locale]/(site)/pricing/page.tsx`, `apps/www/components/ask/PricingChat.tsx`, `apps/www/components/ask/index.ts`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Replace the proxy endpoint with the production assistant backend once ready and evaluate adding analytics for chat engagement.

--- a/apps/www/app/[locale]/(site)/pricing/page.tsx
+++ b/apps/www/app/[locale]/(site)/pricing/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { PricingChat } from "@/components/ask";
 import { CTA } from "@/components/cta";
 import { Particles } from "@/components/particles";
 import { PricingCompareTable } from "@/components/pricing/pricing-compare-table";
@@ -34,6 +35,7 @@ export default function PricingPage() {
   const enterpriseContactHref = "mailto:support@unkey.dev?subject=TransformAI%20Enterprise%20Solutions";
   return (
     <div className="px-4 mx-auto lg:px-0 pt-[64px]">
+      <PricingChat />
       <TopRightShiningLight />
       <TopLeftShiningLight />
       <div

--- a/apps/www/components/ask/PricingChat.tsx
+++ b/apps/www/components/ask/PricingChat.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+import { AskCta } from "./AskCta";
+import type { ChatLocale, ChatMessage } from "./types";
+
+const ChatPanel = dynamic(() => import("./ChatPanel").then((mod) => mod.ChatPanel), {
+  ssr: false,
+});
+
+type PricingChatProps = {
+  className?: string;
+};
+
+export const PricingChat: React.FC<PricingChatProps> = ({ className }) => {
+  const t = useTranslations("Pricing.Chat");
+  const locale = useMemo<ChatLocale>(
+    () => ({
+      ctaLabel: t("cta.label"),
+      headerTitle: t("header.title"),
+      headerStatus: t("header.status"),
+      headerStatusA11y: t("header.statusA11y"),
+      closeLabel: t("header.close"),
+      inputPlaceholder: t("input.placeholder"),
+      inputTooltip: t("input.tooltip"),
+      inputSend: t("input.send"),
+      emptyTitle: t("empty.title"),
+      emptyPrompts: [
+        t("empty.prompts.0"),
+        t("empty.prompts.1"),
+        t("empty.prompts.2"),
+        t("empty.prompts.3"),
+      ],
+      emptyAction: t("empty.action"),
+      assistantLabel: t("messages.assistant"),
+      userLabel: t("messages.user"),
+      typingLabel: t("messages.typing"),
+      transcriptLabel: t("messages.transcriptLabel"),
+      errorTitle: t("errors.title"),
+      errorBody: t("errors.body"),
+      retryLabel: t("errors.retry"),
+    }),
+    [t],
+  );
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [shouldRenderPanel, setShouldRenderPanel] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const hasOpenedRef = useRef(false);
+
+  const id = useId();
+  const panelId = `${id}-pricing-chat`;
+
+  useEffect(() => {
+    if (isOpen) {
+      return;
+    }
+
+    if (!shouldRenderPanel) {
+      return;
+    }
+
+    let timer: number | undefined;
+    if (typeof window !== "undefined") {
+      timer = window.setTimeout(() => setShouldRenderPanel(false), 220);
+    }
+
+    return () => {
+      if (timer) {
+        window.clearTimeout(timer);
+      }
+    };
+  }, [isOpen, shouldRenderPanel]);
+
+  useEffect(() => {
+    if (isOpen) {
+      hasOpenedRef.current = true;
+      return;
+    }
+
+    if (hasOpenedRef.current && buttonRef.current) {
+      buttonRef.current.focus();
+    }
+  }, [isOpen]);
+
+  const sendToAssistant = useCallback(
+    async (conversation: ChatMessage[], prompt: string | null) => {
+      setIsLoading(true);
+      setErrorMessage(null);
+      setPendingPrompt((prev) => prompt ?? prev);
+
+      try {
+        const response = await fetch("/api/assistant", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            messages: conversation.map(({ role, content }) => ({ role, content })),
+          }),
+        });
+
+        if (!response.ok) {
+          const error = await response.json().catch(() => null);
+          const message = typeof error?.error === "string" ? error.error : response.statusText;
+          throw new Error(message);
+        }
+
+        const data = (await response.json().catch(() => ({}))) as { message?: string };
+        const assistantText = typeof data.message === "string" ? data.message.trim() : "";
+
+        if (!assistantText) {
+          throw new Error("Empty assistant response");
+        }
+
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: crypto.randomUUID(),
+            role: "assistant",
+            content: assistantText,
+          },
+        ]);
+        setPendingPrompt(null);
+      } catch (error) {
+        console.error("Assistant request failed", error);
+        setErrorMessage(locale.errorBody);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [locale.errorBody],
+  );
+
+  const openChat = useCallback(() => {
+    setShouldRenderPanel(true);
+    setIsOpen(true);
+  }, []);
+
+  const closeChat = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const handleToggle = useCallback(() => {
+    if (isOpen) {
+      closeChat();
+      return;
+    }
+    openChat();
+  }, [closeChat, isOpen, openChat]);
+
+  const handleSend = useCallback(
+    (value: string) => {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return;
+      }
+
+      const userMessage: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: "user",
+        content: trimmed,
+      };
+
+      setMessages((prev) => {
+        const next = [...prev, userMessage];
+        void sendToAssistant(next, trimmed);
+        return next;
+      });
+    },
+    [sendToAssistant],
+  );
+
+  const handleRetry = useCallback(() => {
+    if (!pendingPrompt) {
+      return;
+    }
+    void sendToAssistant([...messages], pendingPrompt);
+  }, [messages, pendingPrompt, sendToAssistant]);
+
+  const handlePrompt = useCallback(
+    (prompt: string) => {
+      handleSend(prompt);
+    },
+    [handleSend],
+  );
+
+  const showPanel = shouldRenderPanel;
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-none fixed bottom-5 right-4 z-[80] flex flex-col items-end gap-4 sm:bottom-6 sm:right-6 md:bottom-8 md:right-10",
+        "motion-reduce:translate-y-0 motion-reduce:transition-none",
+        className,
+      )}
+    >
+      <div
+        id={panelId}
+        aria-hidden={!isOpen}
+        className={cn(
+          "pointer-events-auto w-[min(420px,calc(100vw-32px))] transition-all duration-300 ease-out",
+          "sm:w-[min(440px,calc(100vw-48px))]",
+          isOpen ? "translate-y-0 opacity-100" : "translate-y-3 opacity-0 pointer-events-none",
+          "motion-reduce:translate-y-0 motion-reduce:opacity-100 motion-reduce:transition-none",
+        )}
+      >
+        {showPanel ? (
+          <ChatPanel
+            messages={messages}
+            isOpen={isOpen}
+            isLoading={isLoading}
+            locale={locale}
+            onClose={closeChat}
+            onSend={handleSend}
+            onUsePrompt={handlePrompt}
+            errorMessage={errorMessage}
+            onRetry={handleRetry}
+          />
+        ) : null}
+      </div>
+      <div className="pointer-events-auto">
+        <AskCta
+          ref={buttonRef}
+          label={locale.ctaLabel}
+          pressed={isOpen}
+          onToggle={handleToggle}
+          ariaControls={panelId}
+          tabIndex={0}
+        />
+      </div>
+    </div>
+  );
+};

--- a/apps/www/components/ask/index.ts
+++ b/apps/www/components/ask/index.ts
@@ -1,3 +1,4 @@
 export { AskCta } from "./AskCta";
 export { StickyChat } from "./StickyChat";
+export { PricingChat } from "./PricingChat";
 export type { ChatLocale, ChatMessage } from "./types";

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -137,6 +137,43 @@
         "chooseTier2": "Explore the Introduction Package",
         "chooseTier3": "Talk to Enterprise Solutions"
       }
+    },
+    "Chat": {
+      "cta": {
+        "label": "Ask our TransformAI"
+      },
+      "header": {
+        "title": "TransformAI Pricing Assistant",
+        "status": "Online",
+        "statusA11y": "Assistant status: online",
+        "close": "Hide the pricing assistant"
+      },
+      "input": {
+        "placeholder": "Ask about packages, ROI, or the best fit for your team…",
+        "tooltip": "Send message",
+        "send": "Send"
+      },
+      "empty": {
+        "title": "Popular pricing questions",
+        "prompts": [
+          "Which package is best for onboarding our whole team?",
+          "Can you compare the Education and Introduction packages?",
+          "Do you support staged rollouts before committing to Enterprise?",
+          "What does a typical Enterprise proposal include?"
+        ],
+        "action": "Ask this question"
+      },
+      "messages": {
+        "assistant": "TransformAI Pricing Assistant",
+        "user": "You",
+        "typing": "TransformAI Pricing Assistant is typing…",
+        "transcriptLabel": "Conversation about pricing with the assistant"
+      },
+      "errors": {
+        "title": "Unable to reach the assistant",
+        "body": "Please try again in a few moments.",
+        "retry": "Retry"
+      }
     }
   },
   "Hero": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -137,6 +137,43 @@
         "chooseTier2": "Bekijk het introductiepakket",
         "chooseTier3": "Neem contact op voor enterprise"
       }
+    },
+    "Chat": {
+      "cta": {
+        "label": "Vraag het aan onze TransformAI"
+      },
+      "header": {
+        "title": "TransformAI Prijsassistent",
+        "status": "Online",
+        "statusA11y": "Assistentstatus: online",
+        "close": "Sluit de prijsassistent"
+      },
+      "input": {
+        "placeholder": "Stel vragen over pakketten, ROI of maatwerk voor jouw team…",
+        "tooltip": "Verstuur bericht",
+        "send": "Versturen"
+      },
+      "empty": {
+        "title": "Veelgestelde prijsvragen",
+        "prompts": [
+          "Welk pakket past het beste bij het onboarden van ons hele team?",
+          "Kun je het educatie- en introductiepakket vergelijken?",
+          "Ondersteunen jullie gefaseerde uitrol voordat we voor Enterprise kiezen?",
+          "Wat zit er meestal in een Enterprise-voorstel?"
+        ],
+        "action": "Stel deze vraag"
+      },
+      "messages": {
+        "assistant": "TransformAI Prijsassistent",
+        "user": "Jij",
+        "typing": "TransformAI Prijsassistent is aan het typen…",
+        "transcriptLabel": "Gesprek over prijzen met de assistent"
+      },
+      "errors": {
+        "title": "Assistent niet bereikbaar",
+        "body": "Probeer het over een moment opnieuw.",
+        "retry": "Opnieuw proberen"
+      }
     }
   },
   "Hero": {


### PR DESCRIPTION
## Plan
- Create a floating Ask TransformAI experience dedicated to the pricing page using existing chat primitives.
- Integrate the assistant entry point into the pricing layout without disturbing existing content sections.
- Add locale strings and documentation to support the new assistant copy.

## Summary
- Added a pricing-specific `PricingChat` client component that wraps the shared chat panel, handles toggling, and anchors the assistant button to the bottom-right corner. 
- Wired the floating assistant into the pricing page so it is available across the entire package comparison experience.
- Expanded English and Dutch pricing message catalogs and logged the change in WRITE_HERE updates.

## Testing
- pnpm --filter www run lint *(fails: longstanding lint violations in untouched routes)*
- pnpm --filter www run typecheck


------
https://chatgpt.com/codex/tasks/task_e_68d2341fa148832a8ae4b0169c240e86