### PR TITLE
Add price range tooltips to pricing availability

### DIFF
--- a/WRITE_HERE/UPDATES/2025-09-23T0600--added-price-tooltips-for-availability-icons.md
+++ b/WRITE_HERE/UPDATES/2025-09-23T0600--added-price-tooltips-for-availability-icons.md
@@ -1,0 +1,5 @@
+# Added price range tooltips to availability icons
+- **What:** Added localized price range tooltips to availability indicators in the pricing comparison table and wired ranges into tier data.
+- **Why:** Give visitors an immediate sense of expected investment when hovering over available services, as requested.
+- **Files:** `apps/www/components/pricing/pricing-compare-table.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Replace placeholder ranges with live pricing data when finalized with stakeholders.

--- a/apps/www/components/pricing/pricing-compare-table.tsx
+++ b/apps/www/components/pricing/pricing-compare-table.tsx
@@ -27,15 +27,33 @@ type PricingTableCategory = {
 };
 
 type PricingTableData = {
-  tiers: Array<{ id: TierId; labelKey: string; priceKey: string; anchor: string }>;
+  tiers: Array<{ id: TierId; labelKey: string; priceKey: string; anchor: string; priceRangeKey: string }>;
   categories: PricingTableCategory[];
 };
 
 const TABLE_DATA: PricingTableData = {
   tiers: [
-    { id: "t1", labelKey: "tiers.t1", priceKey: "tiers.price.t1", anchor: "#pricing-tier-1" },
-    { id: "t2", labelKey: "tiers.t2", priceKey: "tiers.price.t2", anchor: "#pricing-tier-2" },
-    { id: "t3", labelKey: "tiers.t3", priceKey: "tiers.price.t3", anchor: "#pricing-tier-3" },
+    {
+      id: "t1",
+      labelKey: "tiers.t1",
+      priceKey: "tiers.price.t1",
+      anchor: "#pricing-tier-1",
+      priceRangeKey: "priceRanges.t1",
+    },
+    {
+      id: "t2",
+      labelKey: "tiers.t2",
+      priceKey: "tiers.price.t2",
+      anchor: "#pricing-tier-2",
+      priceRangeKey: "priceRanges.t2",
+    },
+    {
+      id: "t3",
+      labelKey: "tiers.t3",
+      priceKey: "tiers.price.t3",
+      anchor: "#pricing-tier-3",
+      priceRangeKey: "priceRanges.t3",
+    },
   ],
   categories: [
     {
@@ -153,6 +171,7 @@ type AvailabilityIndicatorProps = {
   value: Availability;
   label: string;
   note?: string;
+  priceRange?: string;
   size?: "md" | "sm";
 };
 
@@ -161,23 +180,46 @@ const sizeMap = {
   sm: "h-8 w-8 text-sm",
 } satisfies Record<NonNullable<AvailabilityIndicatorProps["size"]>, string>;
 
-function AvailabilityIndicator({ value, label, note, size = "md" }: AvailabilityIndicatorProps) {
+function AvailabilityIndicator({ value, label, note, priceRange, size = "md" }: AvailabilityIndicatorProps) {
   const meta = AVAILABILITY_META[value];
   const Icon = meta.icon;
 
+  const indicatorClasses = cn(
+    "inline-flex items-center justify-center rounded-full border bg-opacity-20 font-medium transition-colors",
+    sizeMap[size],
+    meta.className,
+  );
+
+  const iconElement = <Icon className={cn(size === "md" ? "h-4 w-4" : "h-3.5 w-3.5")} />;
+
+  const shouldShowPriceTooltip = value === "yes" && Boolean(priceRange);
+
   return (
     <div className="flex items-center justify-center gap-2">
-      <span
-        aria-hidden
-        className={cn(
-          "inline-flex items-center justify-center rounded-full border bg-opacity-20 font-medium transition-colors",
-          sizeMap[size],
-          meta.className,
-        )}
-      >
-        <Icon className={cn(size === "md" ? "h-4 w-4" : "h-3.5 w-3.5")} />
-      </span>
-      <span className="sr-only">{label}</span>
+      {shouldShowPriceTooltip ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                indicatorClasses,
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900",
+              )}
+              aria-label={`${label}. ${priceRange}`}
+            >
+              {iconElement}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="max-w-xs text-left text-white">
+            <p>{priceRange}</p>
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <span aria-hidden className={indicatorClasses}>
+          {iconElement}
+        </span>
+      )}
+      {shouldShowPriceTooltip ? null : <span className="sr-only">{label}</span>}
       {value === "partial" && note ? (
         <Tooltip>
           <TooltipTrigger asChild>
@@ -280,6 +322,11 @@ export function PricingCompareTable() {
                               value={row.availability[tier.id]}
                               label={availabilityLabels[row.availability[tier.id]]}
                               note={row.noteKey ? t(row.noteKey) : undefined}
+                              priceRange={
+                                row.availability[tier.id] === "yes"
+                                  ? t(tier.priceRangeKey)
+                                  : undefined
+                              }
                             />
                           </td>
                         ))}
@@ -313,6 +360,11 @@ export function PricingCompareTable() {
                                     value={row.availability[tier.id]}
                                     label={availabilityLabels[row.availability[tier.id]]}
                                     note={row.noteKey ? t(row.noteKey) : undefined}
+                                    priceRange={
+                                      row.availability[tier.id] === "yes"
+                                        ? t(tier.priceRangeKey)
+                                        : undefined
+                                    }
                                     size="sm"
                                   />
                                   <span className="text-[11px] text-muted-foreground">{t(tier.priceKey)}</span>

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -126,6 +126,11 @@
         "consulting": "Dedicated consulting",
         "continuousSupport": "Continuous support"
       },
+      "priceRanges": {
+        "t1": "Estimated investment per included service: €450 – €1,200",
+        "t2": "Estimated investment per included service: €900 – €2,500",
+        "t3": "Custom engagements typically range from €2,500 – €8,500"
+      },
       "legend": {
         "included": "Included",
         "notIncluded": "Not included",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -126,6 +126,11 @@
         "consulting": "Toegewijde consulting",
         "continuousSupport": "Doorlopende ondersteuning"
       },
+      "priceRanges": {
+        "t1": "Geschatte investering per inbegrepen service: €450 – €1.200",
+        "t2": "Geschatte investering per inbegrepen service: €900 – €2.500",
+        "t3": "Maatwerktrajecten variëren doorgaans van €2.500 – €8.500"
+      },
       "legend": {
         "included": "Inbegrepen",
         "notIncluded": "Niet inbegrepen",


### PR DESCRIPTION
## Summary
- add per-tier price range metadata to the pricing comparison table and surface it through localized copy
- enhance the availability indicator to show a tooltip with the price range when an offering is included
- log the change in WRITE_HERE updates for project continuity

## Testing
- ✅ `pnpm --filter www run typecheck`
- ❌ `pnpm --filter www run lint` *(fails with pre-existing lint violations in careers/startups/yc pages and shared components)*

------
https://chatgpt.com/codex/tasks/task_e_68d236af864c832ab776e47ae55ee176