### PR TITLE
Slide pricing content when chat opens

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-20T1500--pricing-chat-clears-overlap.md
+++ b/WRITE_HERE/FIXES/2025-11-20T1500--pricing-chat-clears-overlap.md
@@ -1,0 +1,7 @@
+# Pricing chat clears overlap on comparison table
+_When:_ 2025-11-20 15:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Added an `onOpenChange` callback to the pricing chat widget and used it on the pricing page to animate additional right padding when the panel is open so the comparison table stays fully visible.
+- **Why:** Opening the chat drawer previously covered the pricing grid, forcing visitors to close the panel to keep reading details.
+- **Files:** `apps/www/components/ask/PricingChat.tsx`, `apps/www/app/[locale]/(site)/pricing/page.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/pricing/page.tsx
+++ b/apps/www/app/[locale]/(site)/pricing/page.tsx
@@ -5,10 +5,12 @@ import { Particles } from "@/components/particles";
 import { PricingCompareTable } from "@/components/pricing/pricing-compare-table";
 import { ShinyCardGroup } from "@/components/shiny-card";
 import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/hero";
+import { cn } from "@/lib/utils";
 import { Check, GraduationCap, Handshake, Sparkles } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
+import { useState } from "react";
 import {
   BelowEnterpriseSvg,
   Bullet,
@@ -29,175 +31,183 @@ import {
 export default function PricingPage() {
   const header = useTranslations("Pricing.Header");
   const packages = useTranslations("Pricing.Packages");
+  const [isChatOpen, setIsChatOpen] = useState(false);
 
   const educationContactHref = "mailto:support@unkey.dev?subject=TransformAI%20Education%20Package";
   const introductionContactHref = "mailto:support@unkey.dev?subject=TransformAI%20Introduction%20Package";
   const enterpriseContactHref = "mailto:support@unkey.dev?subject=TransformAI%20Enterprise%20Solutions";
   return (
-    <div className="px-4 mx-auto lg:px-0 pt-[64px]">
-      <PricingChat />
-      <TopRightShiningLight />
-      <TopLeftShiningLight />
+    <div className="pt-[64px]">
+      <PricingChat onOpenChange={setIsChatOpen} />
       <div
-        aria-hidden
-        className="absolute -top-[4.5rem] left-1/2 -translate-x-1/2 w-[2679px] h-[540px] -scale-x-100"
+        className={cn(
+          "px-4 mx-auto lg:px-0",
+          "transition-[padding-right] duration-500 ease-out motion-reduce:transition-none",
+          isChatOpen ? "lg:pr-[28rem] xl:pr-[30rem]" : "lg:pr-0",
+        )}
       >
-        <div className="absolute -left-[100px] w-[1400px] aspect-[1400/541] [mask-image:radial-gradient(50%_76%_at_92%_28%,_#FFF_0%,_#FFF_30.03%,_rgba(255,_255,_255,_0.00)_100%)]">
-          <Image
-            alt="Visual decoration auth chip"
-            src="/images/landing/leveled-up-api-auth-chip-min.svg"
-            fill
-          />
-        </div>
-        <div className="absolute right-0 w-[1400px] aspect-[1400/541] [mask-image:radial-gradient(26%_76%_at_30%_6%,_#FFF_0%,_#FFF_30.03%,_rgba(255,_255,_255,_0.00)_100%)]">
-          <Image
-            alt="Visual decoration auth chip"
-            src="/images/landing/leveled-up-api-auth-chip-min.svg"
-            fill
-          />
-        </div>
-      </div>
-
-      <div className="flex flex-col items-center justify-center my-16 xl:my-24">
-        <h1
-          className="max-sm:mx-6 max-sm:text-4xl font-medium text-[4rem] leading-[4rem] max-w-xl text-center bg-gradient-to-r from-[#02DEFC] via-[#0239FC] to-[#7002FC] bg-clip-text text-transparent drop-shadow-[0_0_24px_rgba(32,57,252,0.45)]"
+        <TopRightShiningLight />
+        <TopLeftShiningLight />
+        <div
+          aria-hidden
+          className="absolute -top-[4.5rem] left-1/2 -translate-x-1/2 w-[2679px] h-[540px] -scale-x-100"
         >
-          {header("title")}
-        </h1>
+          <div className="absolute -left-[100px] w-[1400px] aspect-[1400/541] [mask-image:radial-gradient(50%_76%_at_92%_28%,_#FFF_0%,_#FFF_30.03%,_rgba(255,_255,_255,_0.00)_100%)]">
+            <Image
+              alt="Visual decoration auth chip"
+              src="/images/landing/leveled-up-api-auth-chip-min.svg"
+              fill
+            />
+          </div>
+          <div className="absolute right-0 w-[1400px] aspect-[1400/541] [mask-image:radial-gradient(26%_76%_at_30%_6%,_#FFF_0%,_#FFF_30.03%,_rgba(255,_255,_255,_0.00)_100%)]">
+            <Image
+              alt="Visual decoration auth chip"
+              src="/images/landing/leveled-up-api-auth-chip-min.svg"
+              fill
+            />
+          </div>
+        </div>
 
-        {/* <p className="mt-8 bg-gradient-to-br text-transparent bg-gradient-stop bg-clip-text from-white via-white via-40% to-white/30 max-w-lg text-center">
+        <div className="flex flex-col items-center justify-center my-16 xl:my-24">
+          <h1
+            className="max-sm:mx-6 max-sm:text-4xl font-medium text-[4rem] leading-[4rem] max-w-xl text-center bg-gradient-to-r from-[#02DEFC] via-[#0239FC] to-[#7002FC] bg-clip-text text-transparent drop-shadow-[0_0_24px_rgba(32,57,252,0.45)]"
+          >
+            {header("title")}
+          </h1>
+
+          {/* <p className="mt-8 bg-gradient-to-br text-transparent bg-gradient-stop bg-clip-text from-white via-white via-40% to-white/30 max-w-lg text-center">
           We wanted pricing to be simple and affordable for anyone, so we've created flexible plans
           that don't need an accounting degree to figure out.
         </p>  */}
-      </div>
+        </div>
 
-      <PricingCompareTable />
+        <PricingCompareTable />
 
-      <div id="pricing-tier-grid" className="mt-12">
-        <ShinyCardGroup className="grid h-full max-w-4xl grid-cols-2 gap-6 mx-auto group">
-          <PricingCard id="pricing-tier-1" color={Color.White} className="col-span-2 md:col-span-1">
-            <FreeCardHighlight className="absolute top-0 right-0 pointer-events-none" />
+        <div id="pricing-tier-grid" className="mt-12">
+          <ShinyCardGroup className="grid h-full max-w-4xl grid-cols-2 gap-6 mx-auto group">
+            <PricingCard id="pricing-tier-1" color={Color.White} className="col-span-2 md:col-span-1">
+              <FreeCardHighlight className="absolute top-0 right-0 pointer-events-none" />
 
-            <PricingCardHeader
-              title={packages("education.title")}
-              description={packages("education.description")}
-              className="bg-gradient-to-tr from-transparent to-[#ffffff]/10 "
-              color={Color.White}
-              icon={GraduationCap}
-            />
-            <Separator />
-
-            <PricingCardContent>
-              <Cost
-                dollar={packages("education.price")}
-                frequency={packages("education.frequency")}
+              <PricingCardHeader
+                title={packages("education.title")}
+                description={packages("education.description")}
+                className="bg-gradient-to-tr from-transparent to-[#ffffff]/10 "
+                color={Color.White}
+                icon={GraduationCap}
               />
-              <Button label={packages("education.cta")} href={educationContactHref} />
-              <Bullets title={packages("common.included")}>
-                <li>
-                  <Bullet Icon={Check} label={packages("education.bullets.courseV1")} color={Color.White} />
-                </li>
-                <li>
-                  <Bullet Icon={Check} label={packages("education.bullets.courseV2")} color={Color.White} />
-                </li>
-                <li>
-                  <Bullet Icon={Check} label={packages("education.bullets.workshops")} color={Color.White} />
-                </li>
-                <li>
-                  <Bullet
-                    Icon={Check}
-                    label={packages("education.bullets.trainingMaterials")}
-                    color={Color.White}
-                  />
-                </li>
-                <li>
-                  <Bullet Icon={Check} label={packages("education.bullets.certification")} color={Color.White} />
-                </li>
-              </Bullets>
-            </PricingCardContent>
-            <PricingCardFooter>
-              <div className="flex flex-col gap-2">
-                <p className="text-sm font-bold text-white">{packages("education.footer.title")}</p>
-                <p className="text-xs text-white/60">{packages("education.footer.body")}</p>
-              </div>
-            </PricingCardFooter>
-          </PricingCard>
+              <Separator />
 
-          <PricingCard id="pricing-tier-2" color={Color.Yellow} className="col-span-2 md:col-span-1">
-            <ProCardHighlight className="absolute top-0 right-0 pointer-events-none" />
-
-            <PricingCardHeader
-              title={packages("introduction.title")}
-              description={packages("introduction.description")}
-              className="bg-gradient-to-tr from-black/50 to-[#FFD600]/10 "
-              color={Color.Yellow}
-              icon={Handshake}
-            />
-            <Separator />
-
-            <PricingCardContent>
-              <Cost
-                dollar={packages("introduction.price")}
-                frequency={packages("introduction.frequency")}
-              />
-              <Button label={packages("introduction.cta")} href={introductionContactHref} />
-              <Bullets title={packages("common.included")}>
-                <li>
-                  <Bullet Icon={Check} label={packages("introduction.bullets.aiReadiness")} color={Color.Yellow} />
-                </li>
-                <li>
-                  <Bullet
-                    Icon={Check}
-                    label={packages("introduction.bullets.automationSetup")}
-                    color={Color.Yellow}
-                  />
-                </li>
-                <li>
-                  <Bullet Icon={Check} label={packages("introduction.bullets.pilotIntegration")} color={Color.Yellow} />
-                </li>
-                <li>
-                  <Bullet Icon={Check} label={packages("introduction.bullets.assessment")} color={Color.Yellow} />
-                </li>
-                <li>
-                  <Bullet Icon={Check} label={packages("introduction.bullets.guidance")} color={Color.Yellow} />
-                </li>
-              </Bullets>
-            </PricingCardContent>
-            <PricingCardFooter>
-              <div className="flex flex-col gap-2">
-                <p className="text-sm font-bold text-white">{packages("introduction.footer.title")}</p>
-                <p className="text-xs text-white/60">{packages("introduction.footer.body")}</p>
-              </div>
-            </PricingCardFooter>
-          </PricingCard>
-
-          <PricingCard id="pricing-tier-3" color={Color.Purple} className="col-span-2">
-            <EnterpriseCardHighlight className="absolute top-0 right-0 pointer-events-none" />
-
-            <div className="flex flex-col h-full md:flex-row">
-              <div className="flex flex-col w-full gap-8">
-                <PricingCardHeader
-                  title={packages("enterprise.title")}
-                  description={packages("enterprise.description")}
-                  color={Color.Purple}
-                  className="bg-gradient-to-tr from-transparent to-[#9D72FF]/10 "
-                  icon={Sparkles}
+              <PricingCardContent>
+                <Cost
+                  dollar={packages("education.price")}
+                  frequency={packages("education.frequency")}
                 />
-                <PricingCardContent>
-                  <Cost
-                    dollar={packages("enterprise.price")}
-                    frequency={packages("enterprise.frequency")}
+                <Button label={packages("education.cta")} href={educationContactHref} />
+                <Bullets title={packages("common.included")}>
+                  <li>
+                    <Bullet Icon={Check} label={packages("education.bullets.courseV1")} color={Color.White} />
+                  </li>
+                  <li>
+                    <Bullet Icon={Check} label={packages("education.bullets.courseV2")} color={Color.White} />
+                  </li>
+                  <li>
+                    <Bullet Icon={Check} label={packages("education.bullets.workshops")} color={Color.White} />
+                  </li>
+                  <li>
+                    <Bullet
+                      Icon={Check}
+                      label={packages("education.bullets.trainingMaterials")}
+                      color={Color.White}
+                    />
+                  </li>
+                  <li>
+                    <Bullet Icon={Check} label={packages("education.bullets.certification")} color={Color.White} />
+                  </li>
+                </Bullets>
+              </PricingCardContent>
+              <PricingCardFooter>
+                <div className="flex flex-col gap-2">
+                  <p className="text-sm font-bold text-white">{packages("education.footer.title")}</p>
+                  <p className="text-xs text-white/60">{packages("education.footer.body")}</p>
+                </div>
+              </PricingCardFooter>
+            </PricingCard>
+
+            <PricingCard id="pricing-tier-2" color={Color.Yellow} className="col-span-2 md:col-span-1">
+              <ProCardHighlight className="absolute top-0 right-0 pointer-events-none" />
+
+              <PricingCardHeader
+                title={packages("introduction.title")}
+                description={packages("introduction.description")}
+                className="bg-gradient-to-tr from-black/50 to-[#FFD600]/10 "
+                color={Color.Yellow}
+                icon={Handshake}
+              />
+              <Separator />
+
+              <PricingCardContent>
+                <Cost
+                  dollar={packages("introduction.price")}
+                  frequency={packages("introduction.frequency")}
+                />
+                <Button label={packages("introduction.cta")} href={introductionContactHref} />
+                <Bullets title={packages("common.included")}>
+                  <li>
+                    <Bullet Icon={Check} label={packages("introduction.bullets.aiReadiness")} color={Color.Yellow} />
+                  </li>
+                  <li>
+                    <Bullet
+                      Icon={Check}
+                      label={packages("introduction.bullets.automationSetup")}
+                      color={Color.Yellow}
+                    />
+                  </li>
+                  <li>
+                    <Bullet Icon={Check} label={packages("introduction.bullets.pilotIntegration")} color={Color.Yellow} />
+                  </li>
+                  <li>
+                    <Bullet Icon={Check} label={packages("introduction.bullets.assessment")} color={Color.Yellow} />
+                  </li>
+                  <li>
+                    <Bullet Icon={Check} label={packages("introduction.bullets.guidance")} color={Color.Yellow} />
+                  </li>
+                </Bullets>
+              </PricingCardContent>
+              <PricingCardFooter>
+                <div className="flex flex-col gap-2">
+                  <p className="text-sm font-bold text-white">{packages("introduction.footer.title")}</p>
+                  <p className="text-xs text-white/60">{packages("introduction.footer.body")}</p>
+                </div>
+              </PricingCardFooter>
+            </PricingCard>
+
+            <PricingCard id="pricing-tier-3" color={Color.Purple} className="col-span-2">
+              <EnterpriseCardHighlight className="absolute top-0 right-0 pointer-events-none" />
+
+              <div className="flex flex-col h-full md:flex-row">
+                <div className="flex flex-col w-full gap-8">
+                  <PricingCardHeader
+                    title={packages("enterprise.title")}
+                    description={packages("enterprise.description")}
+                    color={Color.Purple}
+                    className="bg-gradient-to-tr from-transparent to-[#9D72FF]/10 "
+                    icon={Sparkles}
                   />
-                  <Link href={enterpriseContactHref}>
-                    <div className="w-full p-px rounded-lg h-10 bg-gradient-to-r from-[#02DEFC] via-[#0239FC] to-[#7002FC] overflow-hidden">
-                      <div className="bg-black rounded-[7px] h-full bg-opacity-95 hover:bg-opacity-25 duration-1000">
-                        <div className="flex items-center justify-center w-full h-full bg-gradient-to-tr from-[#02DEFC]/20 via-[#0239FC]/20 to-[#7002FC]/20  rounded-[7px]">
-                          <span className="text-sm font-semibold text-white">{packages("enterprise.cta")}</span>
+                  <PricingCardContent>
+                    <Cost
+                      dollar={packages("enterprise.price")}
+                      frequency={packages("enterprise.frequency")}
+                    />
+                    <Link href={enterpriseContactHref}>
+                      <div className="w-full p-px rounded-lg h-10 bg-gradient-to-r from-[#02DEFC] via-[#0239FC] to-[#7002FC] overflow-hidden">
+                        <div className="bg-black rounded-[7px] h-full bg-opacity-95 hover:bg-opacity-25 duration-1000">
+                          <div className="flex items-center justify-center w-full h-full bg-gradient-to-tr from-[#02DEFC]/20 via-[#0239FC]/20 to-[#7002FC]/20  rounded-[7px]">
+                            <span className="text-sm font-semibold text-white">{packages("enterprise.cta")}</span>
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  </Link>
-                </PricingCardContent>
+                    </Link>
+                  </PricingCardContent>
               </div>
               <Separator orientation="vertical" className="hidden md:flex" />
               <Separator orientation="horizontal" className="md:hidden" />
@@ -236,6 +246,7 @@ export default function PricingPage() {
       <div className="-mx-4 lg:mx-0">
         <CTA />
       </div>
+    </div>
     </div>
   );
 }

--- a/apps/www/components/ask/PricingChat.tsx
+++ b/apps/www/components/ask/PricingChat.tsx
@@ -15,9 +15,10 @@ const ChatPanel = dynamic(() => import("./ChatPanel").then((mod) => mod.ChatPane
 
 type PricingChatProps = {
   className?: string;
+  onOpenChange?: (isOpen: boolean) => void;
 };
 
-export const PricingChat: React.FC<PricingChatProps> = ({ className }) => {
+export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChange }) => {
   const t = useTranslations("Pricing.Chat");
   const locale = useMemo<ChatLocale>(
     () => ({
@@ -91,6 +92,10 @@ export const PricingChat: React.FC<PricingChatProps> = ({ className }) => {
       buttonRef.current.focus();
     }
   }, [isOpen]);
+
+  useEffect(() => {
+    onOpenChange?.(isOpen);
+  }, [isOpen, onOpenChange]);
 
   const sendToAssistant = useCallback(
     async (conversation: ChatMessage[], prompt: string | null) => {


### PR DESCRIPTION
## Summary
- add an optional `onOpenChange` callback to `PricingChat` so pages can react to the drawer state
- apply responsive right padding with a smooth transition on the pricing page when the assistant opens to keep the comparison grid visible
- log the fix in `WRITE_HERE/FIXES`

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint`

## Plan
- update the pricing chat component to report its open/close status
- adjust the pricing page layout to reserve space for the chat when open and animate the shift
- document the resolved overlap issue in the fixes log and run workspace checks


------
https://chatgpt.com/codex/tasks/task_e_68d23ba8975c832aa0deee324c8c78b0