### PR TITLE
Add hero hours saved ticker

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-23T0900--homepage-hours-saved-ticker.md
+++ b/WRITE_HERE/UPDATES/2025-11-23T0900--homepage-hours-saved-ticker.md
@@ -1,0 +1,6 @@
+# Added homepage AI hours saved ticker
+
+- **What:** Inserted a live "hours saved using AI" ticker between the hero CTAs with a deterministic growth algorithm seeded on 23 September, plus translations and styling to match the hero reveal animation.
+- **Why:** Surface a constantly increasing metric without persistent storage while highlighting the 23 September baseline requested by the user.
+- **Files:** `apps/www/components/hours-saved-ticker.tsx`, `apps/www/components/hero/hero-main-section.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/apps/www/components/hero/hero-main-section.tsx
+++ b/apps/www/components/hero/hero-main-section.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { PrimaryButton, SecondaryButton } from "@/components/button";
+import { HoursSavedTicker } from "@/components/hours-saved-ticker";
 import { BookOpen, ChevronRight, LogIn } from "lucide-react";
 
 type HeroMainSectionProps = {
@@ -26,7 +27,7 @@ export function HeroMainSection({
         {body}
       </p>
 
-      <div className="flex items-center gap-6 mt-16">
+      <div className="mt-16 flex flex-wrap items-center justify-center gap-4 sm:gap-6">
         <Link href="https://app.unkey.com" className="group">
           <PrimaryButton
             shiny
@@ -35,6 +36,8 @@ export function HeroMainSection({
             className="h-10"
           />
         </Link>
+
+        <HoursSavedTicker />
 
         <Link href="/docs" className="hidden sm:flex">
           <SecondaryButton

--- a/apps/www/components/hours-saved-ticker.tsx
+++ b/apps/www/components/hours-saved-ticker.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { useTranslations } from "next-intl";
+
+import { cn } from "@/lib/utils";
+
+const START_DATE_MS = Date.UTC(2024, 8, 23, 0, 0, 0);
+const BASE_HOURS = 100_000;
+const INITIAL_DAILY_HOURS = 1_000;
+const DAILY_GROWTH_FACTOR = 1.1;
+const MS_PER_DAY = 86_400_000;
+const UPDATE_INTERVAL_MS = 1_000;
+
+const scheduleCache = new Map<number, DailyUpdate[]>();
+
+type DailyUpdate = {
+  timeFraction: number;
+  cumulativeProgress: number;
+  easingWindow: number;
+};
+
+function createSeededRandom(seed: number) {
+  return () => {
+    seed = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    seed = (seed + Math.imul(seed ^ (seed >>> 7), 61 | seed)) ^ seed;
+    return ((seed ^ (seed >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function clamp(value: number, min = 0, max = 1) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function easeOutCubic(value: number) {
+  return 1 - Math.pow(1 - value, 3);
+}
+
+function getDailySchedule(dayIndex: number): DailyUpdate[] {
+  const cached = scheduleCache.get(dayIndex);
+  if (cached) {
+    return cached;
+  }
+
+  const random = createSeededRandom(0x4ba2d + dayIndex * 0x9e3779b1);
+  const baseUpdates = 18 + Math.floor(random() * 12);
+  const updates: { timeFraction: number; weight: number }[] = [];
+
+  for (let index = 0; index < baseUpdates; index += 1) {
+    updates.push({
+      timeFraction: random(),
+      weight: 0.45 + random(),
+    });
+  }
+
+  updates.push({
+    timeFraction: 0.02 + random() * 0.08,
+    weight: 0.6 + random() * 0.4,
+  });
+  updates.push({
+    timeFraction: 0.88 + random() * 0.1,
+    weight: 0.7 + random() * 0.5,
+  });
+  updates.push({ timeFraction: 1, weight: 1 });
+
+  updates.sort((a, b) => a.timeFraction - b.timeFraction);
+
+  const totalWeight = updates.reduce((total, update) => total + update.weight, 0);
+
+  const schedule: DailyUpdate[] = [];
+  let cumulative = 0;
+  let previousTime = 0;
+
+  updates.forEach((update, index) => {
+    cumulative += update.weight / totalWeight;
+    const normalizedProgress = clamp(cumulative, 0, 1);
+    const gap = Math.max(update.timeFraction - previousTime, 0.01);
+    const easingWindow = index === updates.length - 1 ? 0.08 : clamp(gap * 0.6, 0.015, 0.12);
+
+    schedule.push({
+      timeFraction: clamp(update.timeFraction, 0, 1),
+      cumulativeProgress: normalizedProgress,
+      easingWindow,
+    });
+
+    previousTime = update.timeFraction;
+  });
+
+  scheduleCache.set(dayIndex, schedule);
+  return schedule;
+}
+
+function getDailyProgress(dayIndex: number, nowMs: number): number {
+  if (nowMs <= START_DATE_MS) {
+    return 0;
+  }
+
+  const dayStart = START_DATE_MS + dayIndex * MS_PER_DAY;
+  const dayEnd = dayStart + MS_PER_DAY;
+
+  if (nowMs <= dayStart) {
+    return 0;
+  }
+
+  if (nowMs >= dayEnd) {
+    return 1;
+  }
+
+  const fraction = (nowMs - dayStart) / MS_PER_DAY;
+  const schedule = getDailySchedule(dayIndex);
+
+  let previousProgress = 0;
+
+  for (const update of schedule) {
+    const { timeFraction, cumulativeProgress, easingWindow } = update;
+    const windowStart = timeFraction - easingWindow;
+
+    if (fraction >= timeFraction) {
+      previousProgress = cumulativeProgress;
+      continue;
+    }
+
+    if (fraction >= windowStart) {
+      const local = easingWindow > 0 ? (fraction - windowStart) / easingWindow : 1;
+      const eased = easeOutCubic(clamp(local));
+      return clamp(previousProgress + (cumulativeProgress - previousProgress) * eased);
+    }
+
+    return previousProgress;
+  }
+
+  return 1;
+}
+
+function calculateHoursSaved(nowMs: number): number {
+  if (nowMs <= START_DATE_MS) {
+    return BASE_HOURS;
+  }
+
+  const elapsedMs = nowMs - START_DATE_MS;
+  const elapsedDays = elapsedMs / MS_PER_DAY;
+  const fullDays = Math.floor(elapsedDays);
+  const safeFullDays = Math.max(0, fullDays);
+
+  const completedAddition =
+    safeFullDays > 0
+      ? (INITIAL_DAILY_HOURS * (Math.pow(DAILY_GROWTH_FACTOR, safeFullDays) - 1)) /
+        (DAILY_GROWTH_FACTOR - 1)
+      : 0;
+
+  const currentDayAddition = INITIAL_DAILY_HOURS * Math.pow(DAILY_GROWTH_FACTOR, safeFullDays);
+  const currentDayProgress = getDailyProgress(safeFullDays, nowMs);
+  const partialAddition = currentDayAddition * currentDayProgress;
+
+  return BASE_HOURS + completedAddition + partialAddition;
+}
+
+type HoursSavedTickerProps = {
+  className?: string;
+};
+
+export function HoursSavedTicker({ className }: HoursSavedTickerProps) {
+  const t = useTranslations("CTA");
+  const shouldReduceMotion = useReducedMotion();
+  const [hoursSaved, setHoursSaved] = useState(() => Math.floor(calculateHoursSaved(Date.now())));
+
+  useEffect(() => {
+    const update = () => {
+      setHoursSaved(Math.floor(calculateHoursSaved(Date.now())));
+    };
+
+    const interval = window.setInterval(update, UPDATE_INTERVAL_MS);
+
+    update();
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  const formatter = useMemo(
+    () =>
+      new Intl.NumberFormat(undefined, {
+        maximumFractionDigits: 0,
+        minimumFractionDigits: 0,
+      }),
+    [],
+  );
+
+  return (
+    <motion.div
+      initial={shouldReduceMotion ? false : { opacity: 0, y: 24 }}
+      animate={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
+      transition={shouldReduceMotion ? undefined : { duration: 0.6, ease: "easeOut" }}
+      className={cn(
+        "flex min-h-[2.5rem] min-w-[170px] flex-col items-center justify-center rounded-2xl border border-white/15 bg-white/5 px-5 py-2 text-center backdrop-blur-md",
+        "[background:radial-gradient(circle_at_top,_rgba(255,255,255,0.12)_0%,_rgba(255,255,255,0)_65%)]",
+        className,
+      )}
+    >
+      <span className="text-[0.65rem] font-semibold uppercase tracking-[0.24em] text-white">
+        {t("hoursSavedSince")}
+      </span>
+      <span className="mt-1 text-2xl font-bold text-white tabular-nums" aria-live="polite" aria-atomic="true">
+        {formatter.format(hoursSaved)}
+      </span>
+      <span className="mt-1 text-xs font-semibold text-white">
+        {t("hoursSavedLabel")}
+      </span>
+    </motion.div>
+  );
+}

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -299,7 +299,9 @@
   },
   "CTA": {
     "getStarted": "Get Started",
-    "exploreProjects": "Explore All projects"
+    "exploreProjects": "Explore All projects",
+    "hoursSavedLabel": "Hours saved using AI",
+    "hoursSavedSince": "Base value: 100,000 hours · Since 23 September"
   },
   "Cta": {
     "title": "Unlock your company’s AI advantage",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -299,7 +299,9 @@
   },
   "CTA": {
     "getStarted": "Begin Nu",
-    "exploreProjects": "Ontdek alle projecten"
+    "exploreProjects": "Ontdek alle projecten",
+    "hoursSavedLabel": "Uren bespaard met AI",
+    "hoursSavedSince": "Basiswaarde: 100.000 uur · Sinds 23 september"
   },
   "Cta": {
     "title": "Zet de stap naar het AI-tijdperk",


### PR DESCRIPTION
## Plan
- implement a deterministic growth algorithm for the AI hours-saved metric keyed to the 23 September baseline
- mount the live ticker between the hero call-to-action buttons with matching animation and styling
- localize the new copy and document the change in WRITE_HERE

## Summary
- add a client-side HoursSavedTicker component that simulates daily growth with seeded randomness and live updates from a 23 September baseline
- insert the ticker between the Get Started and Explore All Projects CTAs on the homepage hero and adjust layout spacing
- localize the new strings and record the update in WRITE_HERE/UPDATES

## Testing
- pnpm --filter www run lint *(fails: existing lint errors in untouched career/startup/template files)*
- pnpm --filter www run typecheck
- pnpm -w turbo run build --filter=www *(fails: existing lint errors in untouched career/startup/template files)*

------
https://chatgpt.com/codex/tasks/task_e_68d23ea59658832ab22789d9261e9202