### PR TITLE
Refine platform project showcase

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-21T1000--platform-showcase-layout.md
+++ b/WRITE_HERE/UPDATES/2025-11-21T1000--platform-showcase-layout.md
@@ -1,0 +1,5 @@
+# Refined platform project showcase in code examples
+- **What:** Added translated project copy and a dedicated showcase layout so the Platform image sits left with rounded edges, descriptive text, and a call-to-action button.
+- **Why:** Aligns the carousel with the latest request to highlight the education platform with copy in both English and Dutch and improve visual balance.
+- **Files:** `apps/www/app/code-examples.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Replace the placeholder button with a real destination once the project page is ready.

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -392,7 +392,10 @@ type Framework = {
     width: number;
     height: number;
   };
+  contentKey?: string;
 };
+
+type ProjectCopyFormatter = (key: string) => string;
 
 const languagesList = {
   Typescript: [
@@ -487,6 +490,7 @@ const languagesList = {
         width: 1200,
         height: 800,
       },
+      contentKey: "platform",
     },
   ],
   Curl: [
@@ -569,6 +573,7 @@ LanguageTrigger.displayName = TabsPrimitive.Trigger.displayName;
 export const CodeExamples: React.FC<Props> = ({ className }) => {
   const t = useTranslations("CodeExamples");
   const cta = useTranslations("CTA");
+  const projectCopy = useTranslations("CodeExamples.projects");
   const [language, setLanguage] = useState<Language>("Typescript");
   const [framework, setFramework] = useState<FrameworkName>("Typescript");
   const [languageHover, setLanguageHover] = useState("Typescript");
@@ -650,21 +655,18 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
           />
           <div
             className={cn(
-              "relative flex w-full pt-4 pb-8 pl-8 text-white",
+              "relative flex w-full pt-4 pb-8 pl-8 pr-8 text-white",
               currentFrameworkData?.image
-                ? "items-center justify-center pr-8"
+                ? "flex-col gap-8 lg:flex-row lg:items-center"
                 : "font-mono text-xs sm:text-sm",
             )}
           >
             {currentFrameworkData?.image ? (
-              <Image
-                src={currentFrameworkData.image.src}
-                alt={currentFrameworkData.image.alt}
-                width={currentFrameworkData.image.width}
-                height={currentFrameworkData.image.height}
-                className="object-contain w-full h-auto max-h-[420px] rounded-2xl border border-white/10 bg-white/5"
-                sizes="(min-width: 1280px) 720px, (min-width: 640px) 75vw, 90vw"
-                priority={language === "Rust"}
+              <ProjectShowcase
+                image={currentFrameworkData.image}
+                contentKey={currentFrameworkData.contentKey}
+                language={language}
+                projectCopy={projectCopy}
               />
             ) : (
               <>
@@ -700,6 +702,70 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
     </section>
   );
 };
+
+function ProjectShowcase({
+  image,
+  contentKey,
+  language,
+  projectCopy,
+}: {
+  image: NonNullable<Framework["image"]>;
+  contentKey?: string;
+  language: Language;
+  projectCopy: ProjectCopyFormatter;
+}) {
+  const title = contentKey ? projectCopy(`${contentKey}.title`) : undefined;
+  const description = contentKey
+    ? projectCopy(`${contentKey}.description`)
+    : undefined;
+  const result = contentKey ? projectCopy(`${contentKey}.result`) : undefined;
+  const cta = contentKey ? projectCopy(`${contentKey}.cta`) : undefined;
+
+  return (
+    <div className="flex flex-col w-full gap-8 lg:flex-row lg:items-center">
+      <div className="flex justify-start w-full lg:flex-1">
+        <div className="relative w-full max-w-[720px] overflow-hidden rounded-[32px] border border-white/10 bg-white/5 shadow-[0_24px_60px_rgba(0,0,0,0.35)]">
+          <Image
+            src={image.src}
+            alt={image.alt}
+            width={image.width}
+            height={image.height}
+            className="h-full w-full object-contain"
+            sizes="(min-width: 1280px) 720px, (min-width: 640px) 70vw, 90vw"
+            priority={language === "Rust"}
+          />
+        </div>
+      </div>
+      {(title || description || result || cta) && (
+        <div className="flex flex-col justify-center gap-4 text-white/80 lg:max-w-sm">
+          {title ? (
+            <h3 className="text-2xl font-semibold leading-tight text-white sm:text-3xl">
+              {title}
+            </h3>
+          ) : null}
+          {description ? (
+            <p className="text-sm leading-relaxed text-white/80">
+              {description}
+            </p>
+          ) : null}
+          {result ? (
+            <p className="text-sm leading-relaxed text-white/80">
+              {result}
+            </p>
+          ) : null}
+          {cta ? (
+            <button
+              type="button"
+              className="inline-flex items-center justify-center self-start px-5 py-2 text-sm font-semibold text-black transition-colors duration-200 bg-white rounded-lg shadow-sm hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+            >
+              {cta}
+            </button>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
 
 function FrameworkSwitcher({
   frameworks,

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -292,6 +292,14 @@
         "retry": "Retry"
       }
     },
+    "projects": {
+      "platform": {
+        "title": "Education platform for using AI.",
+        "description": "We created an education platform that makes it fun and interactive to learn how to use AI within a company. We design custom modules based on each partner’s needs.",
+        "result": "This platform has delivered massive AI productivity gains across the company.",
+        "cta": "Read more"
+      }
+    },
     "bottom": {
       "title": "Explore the projects we’ve been part of",
       "text": "Click through the interface below to explore sample projects."

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -292,6 +292,14 @@
         "retry": "Opnieuw"
       }
     },
+    "projects": {
+      "platform": {
+        "title": "Educatieplatform voor het gebruik van AI.",
+        "description": "We hebben een educatieplatform gebouwd dat het leuk en interactief maakt om binnen een bedrijf te leren werken met AI. We ontwikkelen modules op maat op basis van de behoeften van elke partner.",
+        "result": "Dit platform heeft geleid tot enorme productiviteitswinsten met AI binnen het bedrijf.",
+        "cta": "Lees meer"
+      }
+    },
     "bottom": {
       "title": "Ontdek de projecten waar wij aan hebben meegewerkt",
       "text": "Klik door de interface hieronder om enkele projecten te ontdekken."


### PR DESCRIPTION
## Summary
- add a translation-aware project showcase layout for the Rust tab so the platform image anchors left with rounded framing and supporting copy
- supply English and Dutch copy for the platform project, including the planned "Read more" call-to-action
- log the update for future reference

## Plan
- adjust the Rust tab entry to support paired image + translated text content
- implement a flexible showcase layout that places the image left with rounded edges and text/button stack on the right
- populate EN/NL locale files with the requested copy and CTA label

## Testing
- `pnpm --filter www run lint` *(fails: repository has existing lint violations in unrelated files)*
- `pnpm --filter www run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68d244e0ce68832a8d723adfb4c17587