### PR TITLE
Fix founder story paragraph breaks

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-23T0757--remove-founder-br-tags.md
+++ b/WRITE_HERE/FIXES/2025-09-23T0757--remove-founder-br-tags.md
@@ -1,0 +1,5 @@
+# Removed literal `<br/><br/>` sequences from founder story
+- **What:** Normalized the founder story translation to use paragraph breaks instead of embedded HTML and updated the about page to render clean line breaks whether translations use newlines or legacy `<br/>` markers.
+- **Why:** The about page was showing the raw `<br/><br/>` text to visitors in both English and Dutch instead of splitting the copy into separate paragraphs.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -13,6 +13,8 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 
+import { Fragment } from "react";
+
 import { BorderBeam } from "@/components/border-beam";
 import { RainbowDarkButton } from "@/components/button";
 import { Container } from "@/components/container";
@@ -144,8 +146,28 @@ export default async function Page({ params }: PageProps) {
   const heroCta = t("Hero.cta");
   const founderTitle = t("Founder.title");
   const founderSubtitle = t("Founder.subtitle");
-  const founderBody = t.rich("Founder.body", {
-    br: () => <br />,
+  const founderBodySegments = t("Founder.body")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/\r/g, "")
+    .split(/\n{2,}/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  const founderBody = founderBodySegments.flatMap((segment, index) => {
+    const nodes = [
+      <Fragment key={`founder-text-${index}`}>{segment}</Fragment>,
+    ];
+
+    if (index < founderBodySegments.length - 1) {
+      nodes.push(
+        <Fragment key={`founder-break-${index}`}>
+          <br />
+          <br />
+        </Fragment>,
+      );
+    }
+
+    return nodes;
   });
 
   const values = [

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -196,7 +196,7 @@
     "Founder": {
       "title": "Few words from our Founder",
       "subtitle": "Why we started TransformAI",
-      "body": "Hi, my name is Yergush. I founded TransformAI after seeing how many organizations struggled with the complexity and pace of AI adoption. I wanted to help build a future where businesses can truly harness the power of AI.<br/><br/>With TransformAI, we’re heading in the right direction. It’s inspiring to see our team grow with such talented people and to witness the impact of the projects we’ve already delivered. At the same time, there is still so much more to achieve — and that excites me. I look forward to working with future partners to keep building the future, together."
+      "body": "Hi, my name is Yergush. I founded TransformAI after seeing how many organizations struggled with the complexity and pace of AI adoption. I wanted to help build a future where businesses can truly harness the power of AI.\n\nWith TransformAI, we’re heading in the right direction. It’s inspiring to see our team grow with such talented people and to witness the impact of the projects we’ve already delivered. At the same time, there is still so much more to achieve — and that excites me. I look forward to working with future partners to keep building the future, together."
     },
     "FAQ": {
       "q1": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -196,7 +196,7 @@
     "Founder": {
       "title": "Een woord van onze oprichter",
       "subtitle": "Waarom we TransformAI zijn gestart",
-      "body": "Hallo, mijn naam is Yergush. Ik heb TransformAI opgericht nadat ik zag hoe veel organisaties worstelden met de complexiteit en het tempo van AI-adoptie. Ik wilde bijdragen aan een toekomst waarin bedrijven de kracht van AI echt kunnen benutten.<br/><br/>Met TransformAI zetten we de juiste stappen. Het is inspirerend om ons team te zien groeien met zoveel talent en om het resultaat van onze projecten terug te zien bij onze klanten. Tegelijkertijd ligt er nog een enorme weg voor ons — en dat maakt mij enthousiast. Ik kijk ernaar uit om samen met toekomstige partners verder te bouwen aan de toekomst."
+      "body": "Hallo, mijn naam is Yergush. Ik heb TransformAI opgericht nadat ik zag hoe veel organisaties worstelden met de complexiteit en het tempo van AI-adoptie. Ik wilde bijdragen aan een toekomst waarin bedrijven de kracht van AI echt kunnen benutten.\n\nMet TransformAI zetten we de juiste stappen. Het is inspirerend om ons team te zien groeien met zoveel talent en om het resultaat van onze projecten terug te zien bij onze klanten. Tegelijkertijd ligt er nog een enorme weg voor ons — en dat maakt mij enthousiast. Ik kijk ernaar uit om samen met toekomstige partners verder te bouwen aan de toekomst."
     },
     "FAQ": {
       "q1": {


### PR DESCRIPTION
## Summary
- convert the founder story translations to use paragraph breaks instead of embedded `<br/>` markup
- adjust the about page to split the founder body copy on paragraph boundaries so no literal markup appears
- log the fix in WRITE_HERE/FIXES for continuity

## Plan
- remove hard-coded `<br/><br/>` sequences from the English and Dutch founder story messages
- normalize the about page logic to interpret double line breaks (and legacy `<br/>` tags) as paragraph separators
- verify both locales render cleanly without showing raw HTML markers

## Testing
- `pnpm --filter www run typecheck` *(fails: repository currently missing next-intl typings and several components trigger React 19 JSX errors)*
- `pnpm --filter www run lint` *(fails: Next.js lint cannot resolve the next-intl package referenced by next.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68d24d0839f0832a96008e4540cfb89f