### PR TITLE
Add hero hours-saved counter

### DIFF
--- a/WRITE_HERE/UPDATES/2025-09-23T0851--added-hero-hours-saved-counter.md
+++ b/WRITE_HERE/UPDATES/2025-09-23T0851--added-hero-hours-saved-counter.md
@@ -1,0 +1,5 @@
+# Added hero "Hours saved" counter to homepage hero
+- **What:** Introduced a deterministic, client-side hours-saved counter between the primary hero CTAs with animated updates and localStorage persistence, including the supporting time series utilities and translations.
+- **Why:** Highlight the cumulative impact of TransformAI's work while meeting the requirement for a live, non-decreasing metric without backend dependencies.
+- **Files:** `apps/www/components/HeroHoursSaved.tsx`, `apps/www/components/hero/hero-main-section.tsx`, `apps/www/lib/timeSeries/hoursSaved.ts`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Monitor animation timing once deployed and adjust visual styling if the hero layout evolves.

--- a/apps/www/components/HeroHoursSaved.tsx
+++ b/apps/www/components/HeroHoursSaved.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useReducedMotion } from "framer-motion";
+import { useLocale, useTranslations } from "next-intl";
+
+import { cn } from "@/lib/utils";
+import {
+  formatInt,
+  getStorageKey,
+  totalHoursUTC,
+} from "@/lib/timeSeries/hoursSaved";
+
+const HOURS_SAVED_STORAGE_KEY = getStorageKey();
+const INITIAL_ANIMATION_DURATION = 1100;
+const UPDATE_ANIMATION_DURATION = 400;
+const TICK_INTERVAL_MS = 1000;
+
+type StoredValue = {
+  value: number;
+  timestamp: string;
+};
+
+type HeroHoursSavedProps = {
+  className?: string;
+};
+
+const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
+
+export function HeroHoursSaved({ className }: HeroHoursSavedProps) {
+  const locale = useLocale();
+  const t = useTranslations("Hero.hoursSaved");
+  const prefersReducedMotion = useReducedMotion();
+
+  const [displayed, setDisplayed] = useState(0);
+  const displayedRef = useRef(0);
+  const storedValueRef = useRef(0);
+  const animationFrameRef = useRef<number | null>(null);
+  const intervalRef = useRef<number | null>(null);
+  const hasBootstrappedRef = useRef(false);
+
+  const updateDisplayed = useCallback((value: number) => {
+    displayedRef.current = value;
+    setDisplayed(value);
+  }, []);
+
+  const persistValue = useCallback((value: number, timestamp: Date) => {
+    const next = Math.max(value, storedValueRef.current);
+    storedValueRef.current = next;
+
+    try {
+      const payload: StoredValue = {
+        value: next,
+        timestamp: timestamp.toISOString(),
+      };
+      window.localStorage.setItem(
+        HOURS_SAVED_STORAGE_KEY,
+        JSON.stringify(payload),
+      );
+    } catch (error) {
+      // Silently ignore storage errors (e.g., Safari private mode)
+    }
+  }, []);
+
+  const animateTo = useCallback(
+    (target: number, duration: number) => {
+      if (target <= displayedRef.current) {
+        return;
+      }
+
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+
+      if (prefersReducedMotion || duration <= 0) {
+        updateDisplayed(target);
+        return;
+      }
+
+      const startValue = displayedRef.current;
+      const delta = target - startValue;
+      const startTime = performance.now();
+
+      const tick = (now: number) => {
+        const elapsed = now - startTime;
+        const progress = Math.min(1, elapsed / duration);
+        const eased = easeOutCubic(progress);
+        const value = Math.round(startValue + delta * eased);
+        updateDisplayed(value);
+
+        if (progress < 1) {
+          animationFrameRef.current = requestAnimationFrame(tick);
+        } else {
+          animationFrameRef.current = null;
+        }
+      };
+
+      animationFrameRef.current = requestAnimationFrame(tick);
+    },
+    [prefersReducedMotion, updateDisplayed],
+  );
+
+  useEffect(() => {
+    if (hasBootstrappedRef.current) {
+      return;
+    }
+
+    hasBootstrappedRef.current = true;
+
+    const now = new Date();
+    const computed = totalHoursUTC(now);
+    let storedValue = 0;
+
+    try {
+      const storedRaw = window.localStorage.getItem(HOURS_SAVED_STORAGE_KEY);
+      if (storedRaw) {
+        const parsed = JSON.parse(storedRaw) as Partial<StoredValue>;
+        if (typeof parsed.value === "number" && Number.isFinite(parsed.value)) {
+          storedValue = parsed.value;
+        }
+      }
+    } catch (error) {
+      // Ignore JSON/availability errors and fall back to computed value
+    }
+
+    const initialTarget = Math.max(computed, storedValue);
+    persistValue(initialTarget, now);
+    animateTo(initialTarget, INITIAL_ANIMATION_DURATION);
+
+    intervalRef.current = window.setInterval(() => {
+      const current = new Date();
+      const algoValue = totalHoursUTC(current);
+      const target = Math.max(algoValue, storedValueRef.current);
+
+      if (target > displayedRef.current) {
+        persistValue(target, current);
+        animateTo(target, UPDATE_ANIMATION_DURATION);
+      }
+    }, TICK_INTERVAL_MS);
+
+    return () => {
+      if (intervalRef.current) {
+        window.clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [animateTo, persistValue]);
+
+  useEffect(() => {
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, []);
+
+  const formatted = useMemo(
+    () => formatInt(displayed, locale),
+    [displayed, locale],
+  );
+
+  return (
+    <div
+      className={cn(
+        "relative flex w-full flex-col items-center justify-center gap-3 rounded-3xl border border-white/10 bg-white/[0.03] px-6 py-5 text-center backdrop-blur-md",
+        "sm:min-w-[220px]",
+        className,
+      )}
+    >
+      <span className="text-xs font-medium uppercase tracking-[0.28em] text-white/60">
+        {t("title")}
+      </span>
+      <div className="flex flex-col items-center">
+        <span className="min-h-[3.5rem] text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+          {formatted}
+        </span>
+        <span className="mt-3 h-[2px] w-full max-w-[160px] rounded-full bg-gradient-to-r from-white/25 via-white/5 to-white/25" />
+      </div>
+    </div>
+  );
+}

--- a/apps/www/components/hero/hero-main-section.tsx
+++ b/apps/www/components/hero/hero-main-section.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import Link from "next/link";
 
 import { PrimaryButton, SecondaryButton } from "@/components/button";
+import { HeroHoursSaved } from "@/components/HeroHoursSaved";
 import { BookOpen, ChevronRight, LogIn } from "lucide-react";
 
 type HeroMainSectionProps = {
@@ -26,23 +29,28 @@ export function HeroMainSection({
         {body}
       </p>
 
-      <div className="flex items-center gap-6 mt-16">
-        <Link href="https://app.unkey.com" className="group">
-          <PrimaryButton
-            shiny
-            IconLeft={LogIn}
-            label={primaryCtaLabel}
-            className="h-10"
-          />
-        </Link>
+      <div className="mt-16 w-full max-w-3xl">
+        <div className="flex w-full flex-col items-center gap-4 sm:flex-row sm:items-stretch sm:justify-center sm:gap-6">
+          <Link href="https://app.unkey.com" className="group w-full sm:w-auto">
+            <PrimaryButton
+              shiny
+              IconLeft={LogIn}
+              label={primaryCtaLabel}
+              className="h-10 w-full justify-center sm:w-auto"
+            />
+          </Link>
 
-        <Link href="/docs" className="hidden sm:flex">
-          <SecondaryButton
-            IconLeft={BookOpen}
-            label={secondaryCtaLabel}
-            IconRight={ChevronRight}
-          />
-        </Link>
+          <HeroHoursSaved className="w-full sm:w-auto" />
+
+          <Link href="/docs" className="w-full sm:w-auto">
+            <SecondaryButton
+              IconLeft={BookOpen}
+              label={secondaryCtaLabel}
+              IconRight={ChevronRight}
+              className="w-full justify-center sm:w-auto"
+            />
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/apps/www/lib/timeSeries/hoursSaved.ts
+++ b/apps/www/lib/timeSeries/hoursSaved.ts
@@ -1,0 +1,214 @@
+export type Burst = {
+  offsetMs: number;
+  value: number;
+};
+
+const START_DATE_UTC_MS = Date.UTC(2025, 8, 23); // 23 September 2025 UTC
+const BASE_TOTAL = 100_000;
+const DAILY_CAP_BASE = 1_000;
+const DAILY_GROWTH = 1.01;
+const MS_PER_DAY = 86_400_000;
+const STORAGE_KEY = "ta.hoursSaved.v1";
+
+const scheduleCache = new Map<number, Burst[]>();
+const cumulativeCapsCache = new Map<number, number>([[0, 0]]);
+let highestCachedDay = 0;
+
+function formatDayKey(dayIndex: number): string {
+  const date = new Date(START_DATE_UTC_MS + dayIndex * MS_PER_DAY);
+  const year = date.getUTCFullYear();
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getUTCDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function seededRng(seed: string): () => number {
+  let h = 1779033703 ^ seed.length;
+  for (let i = 0; i < seed.length; i++) {
+    h = Math.imul(h ^ seed.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  return () => {
+    h = Math.imul(h ^ (h >>> 16), 2246822507);
+    h = Math.imul(h ^ (h >>> 13), 3266489909);
+    h ^= h >>> 16;
+    const t = (h >>> 0) + 0.5;
+    return t / 4294967296;
+  };
+}
+
+export function getDaysSinceStart(nowUTC: Date): number {
+  if (!Number.isFinite(nowUTC.getTime())) {
+    return 0;
+  }
+  const startOfDay = Date.UTC(
+    nowUTC.getUTCFullYear(),
+    nowUTC.getUTCMonth(),
+    nowUTC.getUTCDate(),
+  );
+  const diff = startOfDay - START_DATE_UTC_MS;
+  return Math.floor(diff / MS_PER_DAY);
+}
+
+export function dailyCap(dayIndex: number): number {
+  if (dayIndex < 0) {
+    return 0;
+  }
+  const cap = DAILY_CAP_BASE * Math.pow(DAILY_GROWTH, dayIndex);
+  return Math.round(cap);
+}
+
+function cumulativeCapsUntil(dayIndexExclusive: number): number {
+  if (dayIndexExclusive <= 0) {
+    return 0;
+  }
+  if (cumulativeCapsCache.has(dayIndexExclusive)) {
+    return cumulativeCapsCache.get(dayIndexExclusive)!;
+  }
+
+  let total = cumulativeCapsCache.get(highestCachedDay) ?? 0;
+  let start = highestCachedDay;
+
+  if (dayIndexExclusive < highestCachedDay) {
+    // If we already computed beyond this day, return cached value directly.
+    return cumulativeCapsCache.get(dayIndexExclusive) ?? 0;
+  }
+
+  for (let d = start; d < dayIndexExclusive; d++) {
+    const nextIndex = d + 1;
+    total += dailyCap(d);
+    cumulativeCapsCache.set(nextIndex, total);
+  }
+
+  highestCachedDay = Math.max(highestCachedDay, dayIndexExclusive);
+  return total;
+}
+
+export function getDailyScheduleUTC(dayIndex: number): Burst[] {
+  if (dayIndex < 0) {
+    return [];
+  }
+
+  if (scheduleCache.has(dayIndex)) {
+    return scheduleCache.get(dayIndex)!;
+  }
+
+  const cap = dailyCap(dayIndex);
+  if (cap <= 0) {
+    scheduleCache.set(dayIndex, []);
+    return [];
+  }
+
+  const seed = `hours-saved-${formatDayKey(dayIndex)}`;
+  const rng = seededRng(seed);
+  const burstCount = 20 + Math.floor(rng() * 21); // 20-40 bursts inclusive
+
+  const offsets = Array.from({ length: burstCount }, () =>
+    Math.floor(rng() * MS_PER_DAY),
+  );
+
+  const weights = Array.from({ length: burstCount }, () => rng() + 0.01);
+  const weightSum = weights.reduce((sum, weight) => sum + weight, 0);
+  const rawAllocations = weights.map((weight) => (weight / weightSum) * cap);
+  const values = rawAllocations.map((allocation) => Math.floor(allocation));
+
+  let remainder = cap - values.reduce((sum, value) => sum + value, 0);
+  if (remainder > 0) {
+    const fractions = rawAllocations.map((value, index) => ({
+      index,
+      fraction: value - values[index],
+    }));
+
+    fractions.sort((a, b) => {
+      if (b.fraction === a.fraction) {
+        return a.index - b.index;
+      }
+      return b.fraction - a.fraction;
+    });
+
+    let pointer = 0;
+    while (remainder > 0) {
+      const target = fractions[pointer % fractions.length];
+      values[target.index] += 1;
+      pointer += 1;
+      remainder -= 1;
+    }
+  }
+
+  if (cap > 0) {
+    let zeroIndex = values.findIndex((value) => value === 0);
+    while (zeroIndex !== -1) {
+      const donor = values
+        .map((value, index) => ({ value, index }))
+        .filter((entry) => entry.value > 1)
+        .sort((a, b) => {
+          if (b.value === a.value) {
+            return a.index - b.index;
+          }
+          return b.value - a.value;
+        })[0];
+
+      if (!donor) {
+        break;
+      }
+
+      values[donor.index] -= 1;
+      values[zeroIndex] = 1;
+      zeroIndex = values.findIndex((value) => value === 0);
+    }
+  }
+
+  const bursts = offsets.map((offset, index) => ({
+    offsetMs: offset,
+    value: values[index],
+  }));
+
+  bursts.sort((a, b) => a.offsetMs - b.offsetMs);
+  scheduleCache.set(dayIndex, bursts);
+  return bursts;
+}
+
+export function totalHoursUTC(nowUTC: Date): number {
+  const timestamp = nowUTC.getTime();
+  if (!Number.isFinite(timestamp)) {
+    return BASE_TOTAL;
+  }
+
+  if (timestamp <= START_DATE_UTC_MS) {
+    return BASE_TOTAL;
+  }
+
+  const diff = timestamp - START_DATE_UTC_MS;
+  const dayIndex = Math.floor(diff / MS_PER_DAY);
+  const startOfCurrentDay = START_DATE_UTC_MS + dayIndex * MS_PER_DAY;
+  const elapsedToday = Math.max(0, timestamp - startOfCurrentDay);
+
+  let total = BASE_TOTAL + cumulativeCapsUntil(dayIndex);
+
+  if (elapsedToday >= MS_PER_DAY) {
+    return total + dailyCap(dayIndex);
+  }
+
+  const schedule = getDailyScheduleUTC(dayIndex);
+  for (const burst of schedule) {
+    if (burst.offsetMs <= elapsedToday) {
+      total += burst.value;
+    } else {
+      break;
+    }
+  }
+
+  return total;
+}
+
+export function formatInt(value: number, locale: string): string {
+  const formatter = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 0,
+  });
+
+  return formatter.format(Math.max(0, Math.round(value)));
+}
+
+export function getStorageKey(): string {
+  return STORAGE_KEY;
+}

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -185,7 +185,10 @@
     "title": "Your Transformation Partner for the Age of AI",
     "body": "We help companies adapt successfully and sustainably to the challenges and opportunities that Artificial Intelligence brings.",
     "secondaryTitle": "Optimised for AI Productivity and Performance",
-    "secondaryBody": "Our platform helps companies boost productivity, cut costs, and improve AI performance. It builds on existing structures to amplify results, while offering customisation, long-term reliability, and seamless model selection for every use case."
+    "secondaryBody": "Our platform helps companies boost productivity, cut costs, and improve AI performance. It builds on existing structures to amplify results, while offering customisation, long-term reliability, and seamless model selection for every use case.",
+    "hoursSaved": {
+      "title": "Hours saved using AI"
+    }
   },
   "About": {
     "Hero": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -185,7 +185,10 @@
     "title": "Jouw transformatiepartner voor het AI-tijdperk",
     "body": "Wij helpen bedrijven zich succesvol en duurzaam aan te passen aan de kansen en uitdagingen die Kunstmatige Intelligentie met zich meebrengt.",
     "secondaryTitle": "Geoptimaliseerd voor AI-productiviteit en prestaties",
-    "secondaryBody": "Ons platform helpt bedrijven productiever te werken, kosten te verlagen en AI-prestaties te verbeteren. Het bouwt voort op bestaande structuren om resultaten te versterken, en biedt aanpasbaarheid, langdurige betrouwbaarheid en eenvoudige modelselectie voor elke use-case."
+    "secondaryBody": "Ons platform helpt bedrijven productiever te werken, kosten te verlagen en AI-prestaties te verbeteren. Het bouwt voort op bestaande structuren om resultaten te versterken, en biedt aanpasbaarheid, langdurige betrouwbaarheid en eenvoudige modelselectie voor elke use-case.",
+    "hoursSaved": {
+      "title": "Uren bespaard met AI"
+    }
   },
   "About": {
     "Hero": {


### PR DESCRIPTION
## Plan
- implement deterministic hours-saved time-series utilities to support burst pacing and monotonic totals
- build a hero counter component with animations, localStorage persistence, and locale-aware formatting
- insert the counter between the hero CTAs, wire up translations, and record the update log entry

## Summary
- add deterministic hours saved helpers that derive daily burst schedules, cumulative totals, and formatting utilities
- introduce a HeroHoursSaved client component that animates toward the deterministic total, respects reduced motion, and persists values in localStorage
- center the counter between the hero CTAs, expose new i18n strings, and document the change in WRITE_HERE/UPDATES

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: pre-existing lint violations under app/[locale]/(site)/startups and related shared components)*
- `pnpm -w turbo run build --filter=www` *(fails: same lint violations reported during build step)*

------
https://chatgpt.com/codex/tasks/task_e_68d25d05737c832a9f7301a5239fa982