### PR TITLE
Add hours-saved badge between hero CTAs

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-23T1036--hero-hours-saved-badge.md
+++ b/WRITE_HERE/FIXES/2025-09-23T1036--hero-hours-saved-badge.md
@@ -1,0 +1,5 @@
+# Added hero hours-saved badge between CTAs
+- **What:** Inserted a centered "Hours saved using AI" badge between the hero primary and secondary calls-to-action, styling it with our shimmer border/glass treatment and translation-driven copy for both locales.
+- **Why:** Users asked for the hours-saved stat to sit between the buttons while remaining visually balanced and aligned with the hero layout.
+- **Files:** `apps/www/components/hero/hero-main-section.tsx`, `apps/www/components/hero/hero.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/apps/www/components/hero/hero-main-section.tsx
+++ b/apps/www/components/hero/hero-main-section.tsx
@@ -8,6 +8,8 @@ type HeroMainSectionProps = {
   body: string;
   primaryCtaLabel: string;
   secondaryCtaLabel: string;
+  hoursSavedLabel: string;
+  hoursSavedAmount: string;
 };
 
 export function HeroMainSection({
@@ -15,9 +17,11 @@ export function HeroMainSection({
   body,
   primaryCtaLabel,
   secondaryCtaLabel,
+  hoursSavedLabel,
+  hoursSavedAmount,
 }: HeroMainSectionProps) {
   return (
-    <div className="relative flex flex-col items-center text-center ">
+    <div className="relative flex flex-col items-center text-center">
       <h1 className="bg-gradient-to-br text-balance text-transparent bg-gradient-stop bg-clip-text from-white via-white via-30% to-white/30  font-medium text-6xl leading-none xl:text-[82px] tracking-tighter">
         {title}
       </h1>
@@ -26,21 +30,26 @@ export function HeroMainSection({
         {body}
       </p>
 
-      <div className="flex items-center gap-6 mt-16">
-        <Link href="https://app.unkey.com" className="group">
+      <div className="mt-16 flex w-full flex-col items-center gap-4 sm:flex-row sm:items-center sm:justify-center sm:gap-8">
+        <Link href="https://app.unkey.com" className="group block w-full sm:inline-flex sm:w-auto sm:flex-shrink-0">
           <PrimaryButton
             shiny
             IconLeft={LogIn}
             label={primaryCtaLabel}
-            className="h-10"
+            className="h-10 w-full justify-center sm:w-auto sm:min-w-[200px]"
           />
         </Link>
-
-        <Link href="/docs" className="hidden sm:flex">
+        <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-6 py-2 font-semibold uppercase text-white/70 backdrop-blur-sm sm:gap-3 sm:px-8 sm:py-2.5 whitespace-nowrap">
+          <span className="text-[0.75rem] tracking-[0.35em] text-white/60 sm:text-xs">{hoursSavedLabel}</span>
+          <span className="text-white/40">:</span>
+          <span className="text-sm tracking-[0.2em] text-white sm:text-base">{hoursSavedAmount}</span>
+        </div>
+        <Link href="/docs" className="hidden w-full sm:inline-flex sm:w-auto sm:flex-shrink-0">
           <SecondaryButton
             IconLeft={BookOpen}
             label={secondaryCtaLabel}
             IconRight={ChevronRight}
+            className="sm:min-w-[200px] justify-center"
           />
         </Link>
       </div>

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -41,6 +41,8 @@ export const Hero: React.FC = () => {
           body={hero("body")}
           primaryCtaLabel={cta("getStarted")}
           secondaryCtaLabel={cta("exploreProjects")}
+          hoursSavedLabel={cta("hoursSavedLabel")}
+          hoursSavedAmount={cta("hoursSavedAmount")}
         />
       </motion.div>
 

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -307,7 +307,9 @@
   },
   "CTA": {
     "getStarted": "Get Started",
-    "exploreProjects": "Explore All projects"
+    "exploreProjects": "Explore All projects",
+    "hoursSavedLabel": "Hours saved using AI",
+    "hoursSavedAmount": "100000+"
   },
   "Cta": {
     "title": "Unlock your company’s AI advantage",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -307,7 +307,9 @@
   },
   "CTA": {
     "getStarted": "Begin Nu",
-    "exploreProjects": "Ontdek alle projecten"
+    "exploreProjects": "Ontdek alle projecten",
+    "hoursSavedLabel": "Uren bespaard met AI",
+    "hoursSavedAmount": "100.000+"
   },
   "Cta": {
     "title": "Zet de stap naar het AI-tijdperk",


### PR DESCRIPTION
## Summary
- add a centered "Hours saved using AI" badge between the hero primary and secondary CTAs with balanced spacing
- supply translation strings for the new badge in both English and Dutch locales
- log the UI tweak in the FIXES changelog

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: pre-existing ESLint violations in careers/startups/templates flows, unchanged by this PR)*
- `pnpm -w turbo run build --filter=www` *(fails: same ESLint violations as lint step)*

## Plan
- Inspect the landing hero CTA layout to locate the insertion point
- Add a translation-driven badge component between the CTAs and adjust spacing for symmetry
- Update locale files and changelog entry
- Run typecheck/lint/build to ensure nothing regressed

------
https://chatgpt.com/codex/tasks/task_e_68d2771d1e70832ab91187c90ff3cf13