### PR TITLE
Add hours saved stat to homepage CTA

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-22T1200--cta-hours-saved-pill.md
+++ b/WRITE_HERE/UPDATES/2025-11-22T1200--cta-hours-saved-pill.md
@@ -1,0 +1,5 @@
+# Added hours-saved highlight to homepage CTA
+- **What:** Inserted a translated stat pill between the primary and secondary CTA buttons on the homepage hero to emphasize "Hours saved using AI: 100000+".
+- **Why:** Improves the hero call-to-action by showcasing tangible impact and balancing the layout symmetrically around the new metric.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Consider animating the metric or connecting it to dynamic analytics once real usage data is available.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -176,21 +176,32 @@ export default async function Landing({
               text={hero("secondaryBody")}
               align="center"
             >
-              <div className="flex mt-10 mb-10 space-x-6">
-                <Link href="https://app.unkey.com" className="group">
-                  <PrimaryButton
-                    shiny
-                    IconLeft={LogIn}
-                    label={cta("getStarted")}
-                    className="h-10"
-                  />
-                </Link>
-                <Link href="/docs">
-                  <SecondaryButton
-                    label={cta("exploreProjects")}
-                    IconRight={ChevronRight}
-                  />
-                </Link>
+              <div
+                className="mt-10 mb-10 flex flex-col items-center gap-4 sm:grid sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] sm:items-center sm:gap-x-6"
+              >
+                <div className="flex w-full justify-center sm:justify-end">
+                  <Link href="https://app.unkey.com" className="group">
+                    <PrimaryButton
+                      shiny
+                      IconLeft={LogIn}
+                      label={cta("getStarted")}
+                      className="h-10"
+                    />
+                  </Link>
+                </div>
+                <span
+                  className="inline-flex items-center justify-center rounded-full border border-black/10 bg-black/5 px-5 py-2 text-sm font-semibold tracking-tight text-black/70 backdrop-blur-sm dark:border-white/10 dark:bg-white/5 dark:text-white/80"
+                >
+                  {cta("hoursSaved")}
+                </span>
+                <div className="flex w-full justify-center sm:justify-start">
+                  <Link href="/docs">
+                    <SecondaryButton
+                      label={cta("exploreProjects")}
+                      IconRight={ChevronRight}
+                    />
+                  </Link>
+                </div>
               </div>
             </SectionTitle>
             {/* Temporarily hidden: One-way hashed Keys section (including heading/paragraph) */}

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -307,7 +307,8 @@
   },
   "CTA": {
     "getStarted": "Get Started",
-    "exploreProjects": "Explore All projects"
+    "exploreProjects": "Explore All projects",
+    "hoursSaved": "Hours saved using AI: 100000+"
   },
   "Cta": {
     "title": "Unlock your company’s AI advantage",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -307,7 +307,8 @@
   },
   "CTA": {
     "getStarted": "Begin Nu",
-    "exploreProjects": "Ontdek alle projecten"
+    "exploreProjects": "Ontdek alle projecten",
+    "hoursSaved": "Uren bespaard met AI: 100000+"
   },
   "Cta": {
     "title": "Zet de stap naar het AI-tijdperk",


### PR DESCRIPTION
## Summary
- center the homepage CTA buttons around a new hours-saved stat pill for better balance
- add English and Dutch translations for the AI hours-saved metric
- log the homepage update in the WRITE_HERE updates directory

## Plan
- inspect the landing page CTA layout and identify where to position the new stat
- update the markup to keep the buttons symmetrical with a centered metric chip
- surface translated copy for the stat in both locales and document the change

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: existing lint issues in unrelated files)*
- `pnpm -w turbo run build --filter=www` *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d2771d1e70832ab91187c90ff3cf13