### PR TITLE
Replace partner logos with PNG assets

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-21T1530--refreshed-partner-logo-cloud.md
+++ b/WRITE_HERE/UPDATES/2025-11-21T1530--refreshed-partner-logo-cloud.md
@@ -1,0 +1,5 @@
+# Swapped partner logo cloud to production client marks
+- **What:** Replaced the home page partner logo cloud assets with PNG logos for ASR Nederland, Mercedes-Benz, and Albert Heijn while preserving the existing animation, sizing, and responsiveness logic.
+- **Why:** Aligns the showcased partners with current TransformAI clients without altering layout polish.
+- **Files:** `apps/www/app/[locale]/(site)/(components)/logo-cloud-content.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/(components)/logo-cloud-content.tsx
+++ b/apps/www/app/[locale]/(site)/(components)/logo-cloud-content.tsx
@@ -7,19 +7,19 @@ import { getTranslations } from "next-intl/server";
 
 const logos = [
   {
-    name: "Fireworks",
-    url: "/images/logo-cloud/fireworks-ai.svg",
-    href: "https://fireworks.ai",
+    name: "ASR Nederland",
+    url: "/images/logo-cloud/ASRfromweb.png",
+    href: "https://www.asr.nl/",
   },
   {
-    name: "cal.com",
-    url: "/images/logo-cloud/calcom.svg",
-    href: "https://cal.com",
+    name: "Mercedes-Benz",
+    url: "/images/logo-cloud/mercfileready.png",
+    href: "https://www.mercedes-benz.com/",
   },
   {
-    name: "Mintlify",
-    url: "/images/logo-cloud/mintlify.svg",
-    href: "https://mintlify.com",
+    name: "Albert Heijn",
+    url: "/images/logo-cloud/albertheinai.png",
+    href: "https://www.ah.nl/",
   },
 ];
 
@@ -53,7 +53,13 @@ export async function DesktopLogoCloud() {
               }
             >
               <Link href={logo.href} target="_blank">
-                <Image src={logo.url} alt={logo.name} fill />
+                <Image
+                  src={logo.url}
+                  alt={logo.name}
+                  fill
+                  className="object-contain"
+                  sizes="229px"
+                />
               </Link>
             </div>
           ))}
@@ -90,7 +96,13 @@ export async function MobileLogoCloud() {
                   className="relative w-[229px] aspect-[229/36]"
                 >
                   <Link href={logo.href} target="_blank">
-                    <Image src={logo.url} alt={logo.name} fill />
+                    <Image
+                      src={logo.url}
+                      alt={logo.name}
+                      fill
+                      className="object-contain"
+                      sizes="229px"
+                    />
                   </Link>
                 </div>
               ))}


### PR DESCRIPTION
## Plan
- Inspect the homepage logo cloud component to understand how partner data and styling are wired.
- Swap the SVG asset references with the provided PNG logos while preserving container sizing and animation behavior.
- Verify desktop and mobile logo cloud rendering to ensure no distortion or layout shift.

## Summary
- Replaced the partner logo list with ASR Nederland, Mercedes-Benz, and Albert Heijn PNG assets and updated outbound links.
- Applied `object-contain` and `sizes` configuration to the Next.js `<Image>` instances so the PNGs respect their native aspect ratios without disturbing the logo cloud grid.
- Logged the asset swap in WRITE_HERE/UPDATES for project traceability.

## Mapping
- Fireworks → ASR Nederland (`/images/logo-cloud/ASRfromweb.png`)
- cal.com → Mercedes-Benz (`/images/logo-cloud/mercfileready.png`)
- Mintlify → Albert Heijn (`/images/logo-cloud/albertheinai.png`)

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: repository contains pre-existing lint violations in unrelated files)*

## Visuals
![Desktop partners row](browser:/invocations/rlqoinvy/artifacts/partners-section.png)

## Validation
- Desktop (≥1280px): Verified via Playwright-driven screenshot; sizing and alignment match the prior SVG presentation.
- Mobile (≤768px): Confirmed the marquee reuses the updated PNG sources with `object-contain`, keeping the scrolling layout balanced.


------
https://chatgpt.com/codex/tasks/task_e_68d2b83c89dc832a9adba7b5c7c521fd