### PR TITLE
Fix Ask CTA centering during chat load

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-21T2000--centered-ask-cta-during-chat-open.md
+++ b/WRITE_HERE/FIXES/2025-11-21T2000--centered-ask-cta-during-chat-open.md
@@ -1,0 +1,7 @@
+# Ask CTA stays centered during chat transitions
+_When:_ 2025-11-21 20:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Updated the sticky chat CTA positioning logic to use a single centering style across floating, anchored, and pinned states so the button no longer shifts horizontally when the assistant opens automatically or by click.
+- **Why:** The Ask TransformAI button visibly jumped toward the left edge as the chat panel mounted, which made the interaction feel glitchy.
+- **Files:** `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -231,21 +231,51 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
   const stickyBottomOffset = isDesktop ? 80 : 64;
 
   const floatingBottomOffset = isDesktop ? 72 : 32;
-  const floatingCtaStyle: CSSProperties = {
-    position: "fixed",
-    bottom: `${floatingBottomOffset}px`,
-    left: "50%",
-    transform: "translateX(-50%)",
-    zIndex: 60,
-    width: "fit-content",
-    maxWidth: "calc(100% - 32px)",
-  };
-
-  const pinnedCtaStyle: CSSProperties = isDesktop
-    ? { position: "sticky", top: `${stickyTopOffset}px` }
-    : { position: "sticky", bottom: `${stickyBottomOffset}px` };
-
   const shouldAnchorCta = hasReachedAnchor || (isDesktop && hasReachedBoundary);
+
+  const baseCtaStyle = useMemo<CSSProperties>(
+    () => {
+      const style: CSSProperties = {
+        marginLeft: "auto",
+        marginRight: "auto",
+        zIndex: 60,
+      };
+
+      if (!isOpen) {
+        style.width = "fit-content";
+        style.maxWidth = "calc(100% - 32px)";
+      }
+
+      if (isOpen || shouldAnchorCta) {
+        style.position = "sticky";
+        if (isDesktop) {
+          style.top = `${stickyTopOffset}px`;
+          style.bottom = undefined;
+        } else {
+          style.bottom = `${stickyBottomOffset}px`;
+          style.top = undefined;
+        }
+        style.left = undefined;
+        style.right = undefined;
+      } else {
+        style.position = "fixed";
+        style.bottom = `${floatingBottomOffset}px`;
+        style.top = undefined;
+        style.left = 0;
+        style.right = 0;
+      }
+
+      return style;
+    },
+    [
+      floatingBottomOffset,
+      isDesktop,
+      isOpen,
+      shouldAnchorCta,
+      stickyBottomOffset,
+      stickyTopOffset,
+    ],
+  );
 
   useEffect(() => {
     if (shouldAnchorCta) {
@@ -258,30 +288,6 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
     anchorDismissedRef.current = false;
   }, [isOpen, shouldAnchorCta]);
 
-  const anchoredCtaStyle: CSSProperties | null =
-    !isOpen && shouldAnchorCta
-      ? isDesktop
-        ? {
-            position: "sticky",
-            top: `${stickyTopOffset}px`,
-            left: "auto",
-            right: "auto",
-            bottom: "auto",
-            transform: "none",
-            zIndex: 60,
-          }
-        : {
-            position: "sticky",
-            bottom: `${stickyBottomOffset}px`,
-            left: "auto",
-            right: "auto",
-            top: "auto",
-            transform: "none",
-            zIndex: 60,
-          }
-      : null;
-
-  const baseCtaStyle = isOpen ? pinnedCtaStyle : anchoredCtaStyle ?? floatingCtaStyle;
   const shouldShowCta = isOpen || hasReachedTrigger;
   const chatHasContent = shouldRender && displayPanel;
   const ctaOrderClass = chatHasContent ? "order-2" : "order-1";


### PR DESCRIPTION
## Summary
- replace the Ask CTA positioning styles with a memoized helper that keeps the button centered across floating, anchored, and pinned states
- drop the redundant anchored style branches now that a single centering path covers all cases
- log the fix in WRITE_HERE/FIXES so the centering regression is documented

## Testing
- pnpm --filter www run lint *(fails: pre-existing lint errors in unrelated files such as startups and yc components)*
- pnpm --filter www run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d2bf797284832a8d0805f4ee310f78