### PR TITLE
Fix ASR logo reference in partner cloud

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-22T0900--asr-logo-path-aligned.md
+++ b/WRITE_HERE/FIXES/2025-11-22T0900--asr-logo-path-aligned.md
@@ -1,0 +1,7 @@
+# Restored ASR logo in partner cloud
+_When:_ 2025-11-22 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Pointed the partner logo cloud to the new `Asrbakc.png` asset so the ASR Nederland logo renders again across desktop and mobile variants.
+- **Why:** The previous filename `ASRfromweb.png` no longer existed, leaving an empty slot in the carousel.
+- **Files:** `apps/www/app/[locale]/(site)/(components)/logo-cloud-content.tsx`.
+- **Follow-ups:** Clean up unused legacy ASR logo assets if they are no longer needed.

--- a/apps/www/app/[locale]/(site)/(components)/logo-cloud-content.tsx
+++ b/apps/www/app/[locale]/(site)/(components)/logo-cloud-content.tsx
@@ -8,7 +8,7 @@ import { getTranslations } from "next-intl/server";
 const logos = [
   {
     name: "ASR Nederland",
-    url: "/images/logo-cloud/ASRfromweb.png",
+    url: "/images/logo-cloud/Asrbakc.png",
     href: "https://www.asr.nl/",
   },
   {


### PR DESCRIPTION
## Summary
- swap the ASR Nederland logo entry to load the new Asrbakc.png asset
- document the asset swap in a new WRITE_HERE fix log entry

## Testing
- `pnpm --filter www run lint` *(fails: pre-existing lint errors in unrelated files)*
- `pnpm --filter www run typecheck`
- `pnpm -w turbo run build --filter=www` *(fails: same pre-existing lint errors during Next build)*

## Plan
- Inspect available logo assets to confirm the desired filename
- Update the partner logo cloud configuration to reference the new asset
- Keep partner metadata (name, href) unchanged for continuity
- Record the fix in WRITE_HERE with what/why/files/follow-ups
- Run the www lint, typecheck, and build commands (best effort)


------
https://chatgpt.com/codex/tasks/task_e_68d2cba29f40832aba35597be0d30fd8