### PR TITLE
Restore founder intro copy

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-23T1651--restored-founder-intro-copy.md
+++ b/WRITE_HERE/FIXES/2025-09-23T1651--restored-founder-intro-copy.md
@@ -1,0 +1,5 @@
+# Restored founder intro copy
+- **What:** Reverted the About page founder section title and body text to the original English and Dutch messaging, keeping the existing subtitle intact.
+- **Why:** The new founder text duplicated content from lower on the page; restoring the prior copy resolves the user request.
+- **Files:** `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -194,9 +194,9 @@
       "cta": "Case study: AI adaptation"
     },
     "Founder": {
-      "title": "Few words from our Founder",
+      "title": "Founded to redefine the AI transformation landscape",
       "subtitle": "Why we started TransformAI",
-      "body": "Hi, my name is Yergush. I founded TransformAI after seeing how many organizations struggled with the complexity and pace of AI adoption. I wanted to help build a future where businesses can truly harness the power of AI.\n\nWith TransformAI, we’re heading in the right direction. It’s inspiring to see our team grow with such talented people and to witness the impact of the projects we’ve already delivered. At the same time, there is still so much more to achieve — and that excites me. I look forward to working with future partners to keep building the future, together."
+      "body": "TransformAI was founded by <highlight>Yergush Bloetjes</highlight> out of frustration with the slow and poorly executed way companies were adapting to the most transformative technology of our time. Combining deep theoretical knowledge, hands-on experience in the AI field, and successful integrations at other firms, he recognized the lack of high-quality solutions for business-wide AI transformation. This gap led to the creation of TransformAI, with the mission of making AI adoption both successful and sustainable."
     },
     "FAQ": {
       "q1": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -194,9 +194,9 @@
       "cta": "Casestudy: AI-integratie"
     },
     "Founder": {
-      "title": "Een woord van onze oprichter",
+      "title": "Opgericht om AI-transformatie opnieuw vorm te geven",
       "subtitle": "Waarom we TransformAI zijn gestart",
-      "body": "Hallo, mijn naam is Yergush. Ik heb TransformAI opgericht nadat ik zag hoe veel organisaties worstelden met de complexiteit en het tempo van AI-adoptie. Ik wilde bijdragen aan een toekomst waarin bedrijven de kracht van AI echt kunnen benutten.\n\nMet TransformAI zetten we de juiste stappen. Het is inspirerend om ons team te zien groeien met zoveel talent en om het resultaat van onze projecten terug te zien bij onze klanten. Tegelijkertijd ligt er nog een enorme weg voor ons — en dat maakt mij enthousiast. Ik kijk ernaar uit om samen met toekomstige partners verder te bouwen aan de toekomst."
+      "body": "TransformAI is opgericht door <highlight>Yergush Bloetjes</highlight> uit frustratie over de trage en slecht uitgevoerde manier waarop bedrijven de meest ingrijpende technologie van onze tijd omarmen. Met diepgaande theoretische kennis, praktijkervaring in AI en succesvolle implementaties bij andere organisaties, zag hij dat er een groot tekort was aan hoogwaardige oplossingen voor bedrijfsbrede AI-transformatie. Dit leidde tot de oprichting van TransformAI, met de missie om AI-adoptie zowel succesvol als duurzaam te maken."
     },
     "FAQ": {
       "q1": {


### PR DESCRIPTION
## Summary
- Restore the About page founder section title and body to the original English messaging while keeping the existing subtitle.
- Mirror the restored founder copy in the Dutch translation file for parity.
- Record the change in the FIXES log for traceability.

## Plan
- Update the English messages file with the previous founder section title and paragraph.
- Apply the equivalent Dutch translation changes to maintain localization consistency.
- Run the www workspace checks to confirm nothing else regressed.

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: pre-existing lint violations in various files)*
- `pnpm -w turbo run build --filter=www` *(fails: same lint violations surfaced during build)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ceaef154832a96407bec392d8620