### PR TITLE
Fix founder section body translation fallback

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-23T1651--restored-founder-intro-copy.md
+++ b/WRITE_HERE/FIXES/2025-09-23T1651--restored-founder-intro-copy.md
@@ -1,0 +1,5 @@
+# Restored founder intro copy
+- **What:** Reverted the About page founder section title and body text to the original English and Dutch messaging, keeping the existing subtitle intact.
+- **Why:** The new founder text duplicated content from lower on the page; restoring the prior copy resolves the user request.
+- **Files:** `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-22T1100--fixed-founder-body-copy-rendering.md
+++ b/WRITE_HERE/FIXES/2025-11-22T1100--fixed-founder-body-copy-rendering.md
@@ -1,0 +1,6 @@
+# Ensured founder body copy renders from translations
+
+- **What:** Updated the About page to pull the founder body copy directly from the locale messages and parse embedded highlight tags so the section renders paragraphs instead of showing the `About.Founder.body` key.
+- **Why:** After restoring the historic founder copy, the page was outputting the translation key because the plain translator lookup no longer returned the localized string.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`.
+- **Follow-ups:** Consider extracting a shared rich-copy helper if other sections need highlight parsing in the future.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -13,7 +13,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 
-import { Fragment } from "react";
+import { Fragment, type ReactNode } from "react";
 
 import { BorderBeam } from "@/components/border-beam";
 import { RainbowDarkButton } from "@/components/button";
@@ -65,6 +65,8 @@ import james from "@/images/team/james.jpg";
 
 import { ImageWithBlur } from "@/components/image-with-blur";
 import { cn } from "@/lib/utils";
+import { loadMessages } from "@/i18n/messages";
+import type { Messages } from "@/i18n/messages";
 import { isLocale } from "@/i18n/routing";
 
 export const metadata = {
@@ -141,34 +143,27 @@ export default async function Page({ params }: PageProps) {
   }
 
   const t = await getTranslations({ locale, namespace: "About" });
+  const messages = await loadMessages(locale);
   const heroTitle = t("Hero.title");
   const heroBody = t("Hero.body");
   const heroCta = t("Hero.cta");
   const founderTitle = t("Founder.title");
   const founderSubtitle = t("Founder.subtitle");
-  const founderBodySegments = t("Founder.body")
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(/\r/g, "")
-    .split(/\n{2,}/)
-    .map((segment) => segment.trim())
-    .filter(Boolean);
+  let founderBodyCopy = getNestedMessage(
+    messages,
+    ["About", "Founder", "body"],
+  );
 
-  const founderBody = founderBodySegments.flatMap((segment, index) => {
-    const nodes = [
-      <Fragment key={`founder-text-${index}`}>{segment}</Fragment>,
-    ];
+  if (!founderBodyCopy && locale !== "en") {
+    const fallbackMessages = await loadMessages("en");
+    founderBodyCopy = getNestedMessage(fallbackMessages, [
+      "About",
+      "Founder",
+      "body",
+    ]);
+  }
 
-    if (index < founderBodySegments.length - 1) {
-      nodes.push(
-        <Fragment key={`founder-break-${index}`}>
-          <br />
-          <br />
-        </Fragment>,
-      );
-    }
-
-    return nodes;
-  });
+  const founderBody = formatFounderBody(founderBodyCopy ?? "");
 
   const values = [
     {
@@ -461,6 +456,90 @@ export default async function Page({ params }: PageProps) {
       <CTA />
     </div>
   );
+}
+
+function getNestedMessage(
+  messages: Messages,
+  path: string[],
+): string | undefined {
+  let current: unknown = messages;
+
+  for (const key of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+
+    if (!(key in current)) {
+      return undefined;
+    }
+
+    const record = current as Record<string, unknown>;
+    current = record[key];
+  }
+
+  return typeof current === "string" ? current : undefined;
+}
+
+function formatFounderBody(copy: string): ReactNode[] {
+  const segments = copy
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/\r/g, "")
+    .split(/\n{2,}/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  return segments.flatMap((segment, segmentIndex) => {
+    const nodes: ReactNode[] = [];
+    const highlightRegex = /<highlight>(.*?)<\/highlight>/gi;
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = highlightRegex.exec(segment)) !== null) {
+      if (match.index > lastIndex) {
+        nodes.push(
+          <Fragment
+            key={`founder-text-${segmentIndex}-${nodes.length}`}
+          >
+            {segment.slice(lastIndex, match.index)}
+          </Fragment>,
+        );
+      }
+
+      nodes.push(
+        <span
+          key={`founder-highlight-${segmentIndex}-${nodes.length}`}
+          className="font-semibold text-inherit"
+        >
+          {match[1]}
+        </span>,
+      );
+
+      lastIndex = match.index + match[0].length;
+    }
+
+    if (lastIndex < segment.length) {
+      nodes.push(
+        <Fragment key={`founder-text-${segmentIndex}-${nodes.length}`}>
+          {segment.slice(lastIndex)}
+        </Fragment>,
+      );
+    }
+
+    if (segmentIndex < segments.length - 1) {
+      nodes.push(
+        <Fragment key={`founder-break-${segmentIndex}`}>
+          <br />
+          <br />
+        </Fragment>,
+      );
+    }
+
+    return nodes;
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function PhotoLabel({ text, className }: { text: string; className: string }) {

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -194,9 +194,9 @@
       "cta": "Case study: AI adaptation"
     },
     "Founder": {
-      "title": "Few words from our Founder",
+      "title": "Founded to redefine the AI transformation landscape",
       "subtitle": "Why we started TransformAI",
-      "body": "Hi, my name is Yergush. I founded TransformAI after seeing how many organizations struggled with the complexity and pace of AI adoption. I wanted to help build a future where businesses can truly harness the power of AI.\n\nWith TransformAI, we’re heading in the right direction. It’s inspiring to see our team grow with such talented people and to witness the impact of the projects we’ve already delivered. At the same time, there is still so much more to achieve — and that excites me. I look forward to working with future partners to keep building the future, together."
+      "body": "TransformAI was founded by <highlight>Yergush Bloetjes</highlight> out of frustration with the slow and poorly executed way companies were adapting to the most transformative technology of our time. Combining deep theoretical knowledge, hands-on experience in the AI field, and successful integrations at other firms, he recognized the lack of high-quality solutions for business-wide AI transformation. This gap led to the creation of TransformAI, with the mission of making AI adoption both successful and sustainable."
     },
     "FAQ": {
       "q1": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -194,9 +194,9 @@
       "cta": "Casestudy: AI-integratie"
     },
     "Founder": {
-      "title": "Een woord van onze oprichter",
+      "title": "Opgericht om AI-transformatie opnieuw vorm te geven",
       "subtitle": "Waarom we TransformAI zijn gestart",
-      "body": "Hallo, mijn naam is Yergush. Ik heb TransformAI opgericht nadat ik zag hoe veel organisaties worstelden met de complexiteit en het tempo van AI-adoptie. Ik wilde bijdragen aan een toekomst waarin bedrijven de kracht van AI echt kunnen benutten.\n\nMet TransformAI zetten we de juiste stappen. Het is inspirerend om ons team te zien groeien met zoveel talent en om het resultaat van onze projecten terug te zien bij onze klanten. Tegelijkertijd ligt er nog een enorme weg voor ons — en dat maakt mij enthousiast. Ik kijk ernaar uit om samen met toekomstige partners verder te bouwen aan de toekomst."
+      "body": "TransformAI is opgericht door <highlight>Yergush Bloetjes</highlight> uit frustratie over de trage en slecht uitgevoerde manier waarop bedrijven de meest ingrijpende technologie van onze tijd omarmen. Met diepgaande theoretische kennis, praktijkervaring in AI en succesvolle implementaties bij andere organisaties, zag hij dat er een groot tekort was aan hoogwaardige oplossingen voor bedrijfsbrede AI-transformatie. Dit leidde tot de oprichting van TransformAI, met de missie om AI-adoptie zowel succesvol als duurzaam te maken."
     },
     "FAQ": {
       "q1": {


### PR DESCRIPTION
## Summary
- Load the About page founder body copy from the locale messages so the section renders translated text instead of the `About.Founder.body` key.
- Parse the founder copy for `<highlight>` tags to emphasize names while keeping paragraph breaks intact.
- Document the fix in the WRITE_HERE/FIXES log for future reference.

## Plan
- Fetch the merged locale messages alongside the `getTranslations` call on the About page.
- Add helpers to extract the founder body text, fall back to English when needed, and render highlight markup.
- Record the resolved issue in the fixes log.

## Testing
- [ ] `pnpm --filter www run typecheck`
- [ ] `pnpm --filter www run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d2ceaef154832a96407bec392d8620