### PR TITLE
Restore distinct founder story and message copy

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-23T1651--restored-founder-intro-copy.md
+++ b/WRITE_HERE/FIXES/2025-09-23T1651--restored-founder-intro-copy.md
@@ -1,0 +1,5 @@
+# Restored founder intro copy
+- **What:** Reverted the About page founder section title and body text to the original English and Dutch messaging, keeping the existing subtitle intact.
+- **Why:** The new founder text duplicated content from lower on the page; restoring the prior copy resolves the user request.
+- **Files:** `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-09-23T1858--restore-unique-founder-copy.md
+++ b/WRITE_HERE/FIXES/2025-09-23T1858--restore-unique-founder-copy.md
@@ -1,0 +1,5 @@
+# Restore unique founder copy on About page
+- **What:** Split the founder story and personal message into distinct translation entries so the About page shows unique copy in both founder sections for English and Dutch locales.
+- **Why:** The previous fallback work reused the same body text in two sections, causing duplicate messaging and overwriting the intended personal note from the founder.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-22T1100--fixed-founder-body-copy-rendering.md
+++ b/WRITE_HERE/FIXES/2025-11-22T1100--fixed-founder-body-copy-rendering.md
@@ -1,0 +1,6 @@
+# Ensured founder body copy renders from translations
+
+- **What:** Updated the About page to pull the founder body copy directly from the locale messages and parse embedded highlight tags so the section renders paragraphs instead of showing the `About.Founder.body` key.
+- **Why:** After restoring the historic founder copy, the page was outputting the translation key because the plain translator lookup no longer returned the localized string.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`.
+- **Follow-ups:** Consider extracting a shared rich-copy helper if other sections need highlight parsing in the future.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -13,7 +13,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 
-import { Fragment } from "react";
+import { Fragment, type ReactNode } from "react";
 
 import { BorderBeam } from "@/components/border-beam";
 import { RainbowDarkButton } from "@/components/button";
@@ -65,6 +65,8 @@ import james from "@/images/team/james.jpg";
 
 import { ImageWithBlur } from "@/components/image-with-blur";
 import { cn } from "@/lib/utils";
+import { loadMessages } from "@/i18n/messages";
+import type { Messages } from "@/i18n/messages";
 import { isLocale } from "@/i18n/routing";
 
 export const metadata = {
@@ -141,34 +143,34 @@ export default async function Page({ params }: PageProps) {
   }
 
   const t = await getTranslations({ locale, namespace: "About" });
+  const messages = await loadMessages(locale);
   const heroTitle = t("Hero.title");
   const heroBody = t("Hero.body");
   const heroCta = t("Hero.cta");
+  const founderStoryTitle = t("FounderStory.title");
   const founderTitle = t("Founder.title");
   const founderSubtitle = t("Founder.subtitle");
-  const founderBodySegments = t("Founder.body")
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(/\r/g, "")
-    .split(/\n{2,}/)
-    .map((segment) => segment.trim())
-    .filter(Boolean);
 
-  const founderBody = founderBodySegments.flatMap((segment, index) => {
-    const nodes = [
-      <Fragment key={`founder-text-${index}`}>{segment}</Fragment>,
-    ];
+  const fallbackMessages = locale === "en" ? undefined : await loadMessages("en");
 
-    if (index < founderBodySegments.length - 1) {
-      nodes.push(
-        <Fragment key={`founder-break-${index}`}>
-          <br />
-          <br />
-        </Fragment>,
-      );
-    }
+  const founderStoryBodyCopy =
+    getNestedMessage(messages, ["About", "FounderStory", "body"]) ??
+    (fallbackMessages
+      ? getNestedMessage(fallbackMessages, [
+          "About",
+          "FounderStory",
+          "body",
+        ])
+      : undefined);
 
-    return nodes;
-  });
+  const founderBodyCopy =
+    getNestedMessage(messages, ["About", "Founder", "body"]) ??
+    (fallbackMessages
+      ? getNestedMessage(fallbackMessages, ["About", "Founder", "body"])
+      : undefined);
+
+  const founderStoryBody = formatFounderBody(founderStoryBodyCopy ?? "");
+  const founderBody = formatFounderBody(founderBodyCopy ?? "");
 
   const values = [
     {
@@ -264,10 +266,10 @@ export default async function Page({ params }: PageProps) {
             </div>
             <div className="about-radial relative px-[50px] md:px-[144px] pb-[100px] pt-[60px] overflow-hidden bg-black text-white flex flex-col items-center rounded-[48px] border-l border-r border-b border-white/[0.15]">
               <h2 className="text-[32px] font-medium leading-[48px] mt-10 text-center text-balance">
-                {founderTitle}
+                {founderStoryTitle}
               </h2>
               <p className="mt-[40px] text-white/50 leading-[32px] max-w-[720px] text-center">
-                {founderBody}
+                {founderStoryBody}
               </p>
               <div className="absolute pointer-events-none scale-[1.5] bottom-[-350px]">
                 <AboutLight />
@@ -461,6 +463,90 @@ export default async function Page({ params }: PageProps) {
       <CTA />
     </div>
   );
+}
+
+function getNestedMessage(
+  messages: Messages,
+  path: string[],
+): string | undefined {
+  let current: unknown = messages;
+
+  for (const key of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+
+    if (!(key in current)) {
+      return undefined;
+    }
+
+    const record = current as Record<string, unknown>;
+    current = record[key];
+  }
+
+  return typeof current === "string" ? current : undefined;
+}
+
+function formatFounderBody(copy: string): ReactNode[] {
+  const segments = copy
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/\r/g, "")
+    .split(/\n{2,}/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  return segments.flatMap((segment, segmentIndex) => {
+    const nodes: ReactNode[] = [];
+    const highlightRegex = /<highlight>(.*?)<\/highlight>/gi;
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = highlightRegex.exec(segment)) !== null) {
+      if (match.index > lastIndex) {
+        nodes.push(
+          <Fragment
+            key={`founder-text-${segmentIndex}-${nodes.length}`}
+          >
+            {segment.slice(lastIndex, match.index)}
+          </Fragment>,
+        );
+      }
+
+      nodes.push(
+        <span
+          key={`founder-highlight-${segmentIndex}-${nodes.length}`}
+          className="font-semibold text-inherit"
+        >
+          {match[1]}
+        </span>,
+      );
+
+      lastIndex = match.index + match[0].length;
+    }
+
+    if (lastIndex < segment.length) {
+      nodes.push(
+        <Fragment key={`founder-text-${segmentIndex}-${nodes.length}`}>
+          {segment.slice(lastIndex)}
+        </Fragment>,
+      );
+    }
+
+    if (segmentIndex < segments.length - 1) {
+      nodes.push(
+        <Fragment key={`founder-break-${segmentIndex}`}>
+          <br />
+          <br />
+        </Fragment>,
+      );
+    }
+
+    return nodes;
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function PhotoLabel({ text, className }: { text: string; className: string }) {

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -193,6 +193,10 @@
       "body": "AI is transformative, demanding structural change across all business departments. Because of its complexity, successful integration can be challenging. With our expertise, your company can adapt sustainably and thrive in the AI era.",
       "cta": "Case study: AI adaptation"
     },
+    "FounderStory": {
+      "title": "Founded to redefine the AI transformation landscape",
+      "body": "TransformAI was founded by <highlight>Yergush Bloetjes</highlight> out of frustration with the slow and poorly executed way companies were adapting to the most transformative technology of our time. Combining deep theoretical knowledge, hands-on experience in the AI field, and successful integrations at other firms, he recognized the lack of high-quality solutions for business-wide AI transformation. This gap led to the creation of TransformAI, with the mission of making AI adoption both successful and sustainable."
+    },
     "Founder": {
       "title": "Few words from our Founder",
       "subtitle": "Why we started TransformAI",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -193,6 +193,10 @@
       "body": "AI verandert alles en vraagt om structurele aanpassingen in iedere afdeling van je bedrijf. Door de complexiteit is het niet eenvoudig om dit succesvol te realiseren. Dankzij onze expertise kan jouw organisatie zich duurzaam aanpassen en profiteren van de voordelen van AI.",
       "cta": "Casestudy: AI-integratie"
     },
+    "FounderStory": {
+      "title": "Opgericht om AI-transformatie opnieuw vorm te geven",
+      "body": "TransformAI is opgericht door <highlight>Yergush Bloetjes</highlight> uit frustratie over de trage en slecht uitgevoerde manier waarop bedrijven de meest ingrijpende technologie van onze tijd omarmen. Met diepgaande theoretische kennis, praktijkervaring in AI en succesvolle implementaties bij andere organisaties, zag hij dat er een groot tekort was aan hoogwaardige oplossingen voor bedrijfsbrede AI-transformatie. Dit leidde tot de oprichting van TransformAI, met de missie om AI-adoptie zowel succesvol als duurzaam te maken."
+    },
     "Founder": {
       "title": "Een woord van onze oprichter",
       "subtitle": "Waarom we TransformAI zijn gestart",


### PR DESCRIPTION
## Summary
- Split the About page founder content into separate story and personal message translations for English and Dutch.
- Update the About page to render the new founder story copy in the radial section while keeping the personal note in the quote block.
- Document the fix in the WRITE_HERE/FIXES log for future reference.

## Plan
- Add a new `FounderStory` translation entry that stores the historical founder story copy in both locales.
- Restore the original founder note under `Founder` so it can render independently from the story text.
- Update the About page to load both bodies with English fallbacks and show them in the appropriate sections.
- Record the resolution in `WRITE_HERE/FIXES/` per repository guidelines.

## Testing
- [ ] `pnpm --filter www run typecheck` *(fails: missing `next-intl` dependency in this environment)*
- [ ] `pnpm --filter www run lint` *(fails: missing `next-intl` dependency during Next lint run)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ceaef154832a96407bec392d8620