### PR TITLE
Unify pricing section and add info tooltips

### DIFF
--- a/WRITE_HERE/UPDATES/2025-09-19T1200--integrated-pricing-section-tooltips.md
+++ b/WRITE_HERE/UPDATES/2025-09-19T1200--integrated-pricing-section-tooltips.md
@@ -1,0 +1,7 @@
+# Unified pricing section with tooltips
+_When:_ 2025-09-19 12:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Integrated the pricing hero and comparison table into a single gradient card and added an information column with hover tooltips across desktop and mobile layouts.
+- **Why:** To create a cohesive pricing experience while supplying contextual explanations for every service row.
+- **Files:** `apps/www/app/[locale]/(site)/pricing/page.tsx`, `apps/www/components/pricing/pricing-compare-table.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Consider sourcing tooltip content from CMS or translation workflows if copy will evolve frequently.

--- a/apps/www/app/[locale]/(site)/pricing/page.tsx
+++ b/apps/www/app/[locale]/(site)/pricing/page.tsx
@@ -83,40 +83,50 @@ export default function PricingPage() {
         </div>
 
         <div className="relative my-16 xl:my-24 flex justify-center">
-          <div className="relative isolate w-full max-w-5xl overflow-hidden rounded-[32px] border border-white/10 bg-white/[0.02] px-6 py-14 text-center shadow-[0_28px_120px_rgba(15,23,42,0.45)] backdrop-blur sm:px-12 sm:py-16">
+          <section className="relative isolate w-full max-w-5xl overflow-hidden rounded-[32px] border border-white/10 bg-white/[0.02] text-center shadow-[0_28px_160px_rgba(15,23,42,0.55)] backdrop-blur">
             <div className="pointer-events-none absolute inset-0 -z-10">
-              <div className="absolute inset-x-10 -top-40 h-[360px] rounded-full bg-gradient-to-r from-sky-400/40 via-blue-500/10 to-fuchsia-500/40 blur-3xl" />
-              <div className="absolute left-1/2 top-1/2 h-[520px] w-[520px] -translate-x-1/2 -translate-y-1/2 bg-[radial-gradient(circle_at_center,_rgba(14,165,233,0.25),_rgba(15,23,42,0))]" />
+              <div className="absolute inset-x-8 -top-48 h-[420px] rounded-full bg-gradient-to-r from-sky-400/35 via-blue-500/12 to-fuchsia-500/40 blur-3xl" />
+              <div className="absolute inset-x-0 bottom-[-220px] h-[420px] bg-[radial-gradient(circle_at_center,_rgba(2,222,252,0.15),_rgba(15,23,42,0))]" />
             </div>
-
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/[0.06] px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-white/70 shadow-[0_0_32px_rgba(59,130,246,0.15)]">
-              <Sparkles className="h-4 w-4 text-sky-200" />
-              {header("eyebrow")}
-            </span>
-
-            <h1 className="mt-6 text-balance text-4xl font-semibold leading-tight text-transparent sm:text-5xl sm:leading-tight bg-gradient-to-r from-white via-white to-white/70 bg-clip-text">
-              {header("title")}
-            </h1>
-
-            <p className="mt-4 text-balance text-base text-white/70 sm:text-lg">
-              {header("subtitle")}
-            </p>
-
-            <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-              {highlightItems.map(({ icon: Icon, label }) => (
-                <span
-                  key={label}
-                  className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.05] px-4 py-2 text-sm text-white/80 shadow-[0_0_24px_rgba(76,29,149,0.25)]"
-                >
-                  <Icon className="h-4 w-4 text-white/70" />
-                  {label}
+            <Particles
+              className="absolute inset-0 opacity-40 transition-opacity duration-700 pointer-events-none motion-reduce:hidden"
+              quantity={60}
+              color={Color.Purple}
+              vx={0.08}
+              vy={-0.06}
+            />
+            <div className="relative z-10 flex flex-col divide-y divide-white/10">
+              <div className="px-6 py-14 sm:px-12 sm:py-16">
+                <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/[0.06] px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-white/70 shadow-[0_0_32px_rgba(59,130,246,0.15)]">
+                  <Sparkles className="h-4 w-4 text-sky-200" />
+                  {header("eyebrow")}
                 </span>
-              ))}
-            </div>
-          </div>
-        </div>
 
-        <PricingCompareTable />
+                <h1 className="mt-6 text-balance text-4xl font-semibold leading-tight text-transparent sm:text-5xl sm:leading-tight bg-gradient-to-r from-white via-white to-white/70 bg-clip-text">
+                  {header("title")}
+                </h1>
+
+                <p className="mt-4 text-balance text-base text-white/70 sm:text-lg">
+                  {header("subtitle")}
+                </p>
+
+                <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+                  {highlightItems.map(({ icon: Icon, label }) => (
+                    <span
+                      key={label}
+                      className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.05] px-4 py-2 text-sm text-white/80 shadow-[0_0_24px_rgba(76,29,149,0.25)]"
+                    >
+                      <Icon className="h-4 w-4 text-white/70" />
+                      {label}
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              <PricingCompareTable className="px-4 py-10 sm:px-10 sm:py-12" />
+            </div>
+          </section>
+        </div>
 
         <div id="pricing-tier-grid" className="mt-12">
           <ShinyCardGroup className="grid h-full max-w-4xl grid-cols-2 gap-6 mx-auto group">

--- a/apps/www/components/pricing/pricing-compare-table.tsx
+++ b/apps/www/components/pricing/pricing-compare-table.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { Color, EnterpriseCardHighlight } from "@/app/[locale]/(site)/pricing/components";
-import { Particles } from "@/components/particles";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -17,6 +15,7 @@ type PricingTableRow = {
   id: string;
   labelKey: string;
   availability: Record<TierId, Availability>;
+  infoKey: string;
   noteKey?: string;
 };
 
@@ -29,6 +28,10 @@ type PricingTableCategory = {
 type PricingTableData = {
   tiers: Array<{ id: TierId; labelKey: string; priceKey: string; anchor: string; priceRangeKey: string }>;
   categories: PricingTableCategory[];
+};
+
+type PricingCompareTableProps = {
+  className?: string;
 };
 
 const TABLE_DATA: PricingTableData = {
@@ -63,26 +66,31 @@ const TABLE_DATA: PricingTableData = {
         {
           id: "educationCourseV1",
           labelKey: "rows.educationCourseV1",
+          infoKey: "info.items.educationCourseV1",
           availability: { t1: "yes", t2: "yes", t3: "yes" },
         },
         {
           id: "educationCourseV2",
           labelKey: "rows.educationCourseV2",
+          infoKey: "info.items.educationCourseV2",
           availability: { t1: "yes", t2: "yes", t3: "yes" },
         },
         {
           id: "workshops",
           labelKey: "rows.workshops",
+          infoKey: "info.items.workshops",
           availability: { t1: "yes", t2: "yes", t3: "yes" },
         },
         {
           id: "trainingMaterials",
           labelKey: "rows.trainingMaterials",
+          infoKey: "info.items.trainingMaterials",
           availability: { t1: "yes", t2: "yes", t3: "yes" },
         },
         {
           id: "certification",
           labelKey: "rows.certification",
+          infoKey: "info.items.certification",
           availability: { t1: "yes", t2: "yes", t3: "yes" },
         },
       ],
@@ -94,26 +102,31 @@ const TABLE_DATA: PricingTableData = {
         {
           id: "aiReadiness",
           labelKey: "rows.aiReadiness",
+          infoKey: "info.items.aiReadiness",
           availability: { t1: "no", t2: "yes", t3: "yes" },
         },
         {
           id: "automationSetup",
           labelKey: "rows.automationSetup",
+          infoKey: "info.items.automationSetup",
           availability: { t1: "no", t2: "yes", t3: "yes" },
         },
         {
           id: "pilotIntegration",
           labelKey: "rows.pilotIntegration",
+          infoKey: "info.items.pilotIntegration",
           availability: { t1: "no", t2: "yes", t3: "yes" },
         },
         {
           id: "assessment",
           labelKey: "rows.assessment",
+          infoKey: "info.items.assessment",
           availability: { t1: "no", t2: "yes", t3: "yes" },
         },
         {
           id: "guidance",
           labelKey: "rows.guidance",
+          infoKey: "info.items.guidance",
           availability: { t1: "no", t2: "yes", t3: "yes" },
         },
       ],
@@ -125,26 +138,31 @@ const TABLE_DATA: PricingTableData = {
         {
           id: "tailoredIntegrations",
           labelKey: "rows.tailoredIntegrations",
+          infoKey: "info.items.tailoredIntegrations",
           availability: { t1: "no", t2: "no", t3: "yes" },
         },
         {
           id: "researchSupport",
           labelKey: "rows.researchSupport",
+          infoKey: "info.items.researchSupport",
           availability: { t1: "no", t2: "no", t3: "yes" },
         },
         {
           id: "customModel",
           labelKey: "rows.customModel",
+          infoKey: "info.items.customModel",
           availability: { t1: "no", t2: "no", t3: "yes" },
         },
         {
           id: "consulting",
           labelKey: "rows.consulting",
+          infoKey: "info.items.consulting",
           availability: { t1: "no", t2: "no", t3: "yes" },
         },
         {
           id: "continuousSupport",
           labelKey: "rows.continuousSupport",
+          infoKey: "info.items.continuousSupport",
           availability: { t1: "no", t2: "no", t3: "yes" },
         },
       ],
@@ -179,6 +197,56 @@ const sizeMap = {
   md: "h-10 w-10 text-base",
   sm: "h-8 w-8 text-sm",
 } satisfies Record<NonNullable<AvailabilityIndicatorProps["size"]>, string>;
+
+const infoTriggerSizeMap = {
+  md: "h-9 w-9 text-sm",
+  sm: "h-8 w-8 text-xs",
+} satisfies Record<"md" | "sm", string>;
+
+const infoLetterSizeMap = {
+  md: "text-base",
+  sm: "text-sm",
+} satisfies Record<"md" | "sm", string>;
+
+type RowInfoProps = {
+  info: string;
+  readMoreLabel: string;
+  ariaLabel: string;
+  size?: "md" | "sm";
+};
+
+function RowInfo({ info, readMoreLabel, ariaLabel, size = "md" }: RowInfoProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "inline-flex shrink-0 items-center justify-center rounded-full border border-white/15 bg-white/[0.06] text-white/80 transition hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900",
+            infoTriggerSizeMap[size],
+          )}
+          aria-label={ariaLabel}
+        >
+          <span aria-hidden className={cn("font-semibold", infoLetterSizeMap[size])}>i</span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent
+        side="top"
+        align="start"
+        sideOffset={12}
+        className="max-w-xs space-y-3 border-white/10 bg-neutral-950/90 px-4 py-4 text-left text-white shadow-[0_30px_90px_rgba(15,23,42,0.45)] backdrop-blur-md"
+      >
+        <p className="text-sm leading-relaxed text-white/80">{info}</p>
+        <Link
+          href="#"
+          className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/[0.07] px-3 py-1.5 text-xs font-medium text-white transition hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
+        >
+          {readMoreLabel}
+        </Link>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
 
 function AvailabilityIndicator({ value, label, note, priceRange, size = "md" }: AvailabilityIndicatorProps) {
   const meta = AVAILABILITY_META[value];
@@ -240,7 +308,7 @@ function AvailabilityIndicator({ value, label, note, priceRange, size = "md" }: 
   );
 }
 
-export function PricingCompareTable() {
+export function PricingCompareTable({ className }: PricingCompareTableProps) {
   const t = useTranslations("Pricing.Table");
 
   const availabilityLabels: Record<Availability, string> = {
@@ -249,73 +317,74 @@ export function PricingCompareTable() {
     partial: t("legend.partial"),
   };
 
+  const infoReadMoreLabel = t("info.readMore");
+  const getInfoAriaLabel = (feature: string) => t("info.ariaLabel", { feature });
+
   return (
     <TooltipProvider delayDuration={200} skipDelayDuration={200}>
-      <section aria-labelledby="pricing-compare-heading" className="relative w-full max-w-4xl mx-auto">
-        <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-black/60 shadow-[0_40px_120px_-60px_rgba(88,54,179,0.85)]">
-          <div
-            aria-hidden
-            className="absolute inset-0 bg-gradient-to-br from-[#140F2C]/90 via-[#1A1440]/70 to-[#031B4A]/80"
-          />
-          <div
-            aria-hidden
-            className="absolute inset-x-8 -top-40 h-96 bg-[radial-gradient(circle_at_top,_rgba(157,114,255,0.45),_transparent_60%)]"
-          />
-          <EnterpriseCardHighlight className="absolute -top-28 -right-24 w-[420px] opacity-60 mix-blend-screen" />
-          <Particles
-            className="absolute inset-0 opacity-40 transition-opacity duration-700 pointer-events-none motion-reduce:hidden"
-            quantity={60}
-            color={Color.Purple}
-            vx={0.08}
-            vy={-0.06}
-          />
-          <div className="relative z-10 px-6 py-10 sm:px-10 sm:py-12">
-            <div className="text-center">
-              <h2
-                id="pricing-compare-heading"
-                className="text-3xl font-semibold tracking-tight text-white sm:text-[2.25rem]"
-              >
-                {t("title")}
-              </h2>
-            </div>
+      <section
+        aria-labelledby="pricing-compare-heading"
+        className={cn("relative w-full max-w-4xl mx-auto", className)}
+      >
+        <div className="flex flex-col gap-10">
+          <div className="flex flex-col gap-2 text-left">
+            <h2
+              id="pricing-compare-heading"
+              className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60"
+            >
+              {t("title")}
+            </h2>
+          </div>
 
-            <div className="mt-10 hidden md:block">
-              <table className="w-full border-collapse text-left">
-                <caption className="sr-only">{t("title")}</caption>
-                <thead>
-                  <tr className="text-sm text-white/80">
-                    <th scope="col" className="px-6 py-4 text-left font-medium text-white/70">
-                      {t("headers.feature")}
+          <div className="hidden overflow-hidden rounded-2xl border border-white/10 bg-white/[0.02] shadow-[0_24px_90px_rgba(15,23,42,0.35)] backdrop-blur-sm md:block">
+            <table className="w-full border-collapse text-left">
+              <caption className="sr-only">{t("title")}</caption>
+              <thead>
+                <tr className="text-sm text-white/80">
+                  <th scope="col" className="px-6 py-4 text-left font-medium text-white/70">
+                    {t("headers.feature")}
+                  </th>
+                  <th scope="col" className="px-4 py-4 text-left font-medium text-white/70">
+                    {t("headers.info")}
+                  </th>
+                  {TABLE_DATA.tiers.map((tier) => (
+                    <th key={tier.id} scope="col" className="px-6 py-4 text-center font-semibold text-white">
+                      <div className="flex flex-col items-center gap-1">
+                        <span className="text-base sm:text-lg">{t(tier.labelKey)}</span>
+                        <span className="text-sm font-normal text-muted-foreground">{t(tier.priceKey)}</span>
+                      </div>
                     </th>
-                    {TABLE_DATA.tiers.map((tier) => (
-                      <th key={tier.id} scope="col" className="px-6 py-4 text-center font-semibold text-white">
-                        <div className="flex flex-col items-center gap-1">
-                          <span className="text-base sm:text-lg">{t(tier.labelKey)}</span>
-                          <span className="text-sm font-normal text-muted-foreground">{t(tier.priceKey)}</span>
-                        </div>
-                      </th>
-                    ))}
+                  ))}
+                </tr>
+              </thead>
+              {TABLE_DATA.categories.map((category) => (
+                <tbody key={category.id}>
+                  <tr>
+                    <th
+                      scope="colgroup"
+                      colSpan={TABLE_DATA.tiers.length + 2}
+                      className="px-6 pt-8 pb-3 text-xs font-semibold uppercase tracking-[0.35em] text-white/50"
+                    >
+                      {t(category.labelKey)}
+                    </th>
                   </tr>
-                </thead>
-                {TABLE_DATA.categories.map((category) => (
-                  <tbody key={category.id}>
-                    <tr>
-                      <th
-                        scope="colgroup"
-                        colSpan={TABLE_DATA.tiers.length + 1}
-                        className="px-6 pt-8 pb-3 text-xs font-semibold uppercase tracking-[0.3em] text-white/60"
-                      >
-                        {t(category.labelKey)}
-                      </th>
-                    </tr>
-                    {category.rows.map((row) => (
-                      <tr
-                        key={row.id}
-                        className="border-t border-white/10 text-sm"
-                      >
+                  {category.rows.map((row) => {
+                    const featureLabel = t(row.labelKey);
+                    const infoText = t(row.infoKey);
+                    const infoAriaLabel = getInfoAriaLabel(featureLabel);
+
+                    return (
+                      <tr key={row.id} className="border-t border-white/10 text-sm">
                         <th scope="row" className="px-6 py-5 text-left font-medium text-white/90">
-                          {t(row.labelKey)}
+                          {featureLabel}
                         </th>
+                        <td className="px-4 py-5 text-left align-top">
+                          <RowInfo
+                            info={infoText}
+                            readMoreLabel={infoReadMoreLabel}
+                            ariaLabel={infoAriaLabel}
+                          />
+                        </td>
                         {TABLE_DATA.tiers.map((tier) => (
                           <td key={tier.id} className="px-6 py-5 text-center">
                             <AvailabilityIndicator
@@ -331,31 +400,58 @@ export function PricingCompareTable() {
                           </td>
                         ))}
                       </tr>
-                    ))}
-                  </tbody>
-                ))}
-              </table>
-            </div>
+                    );
+                  })}
+                </tbody>
+              ))}
+            </table>
+          </div>
 
-            <div className="mt-10 md:hidden">
-              <Accordion type="multiple" defaultValue={TABLE_DATA.categories.map((category) => category.id)}>
-                {TABLE_DATA.categories.map((category) => (
-                  <AccordionItem key={category.id} value={category.id} className="border-b border-white/10">
-                    <AccordionTrigger className="text-left text-base font-semibold text-white">
-                      {t(category.labelKey)}
-                    </AccordionTrigger>
-                    <AccordionContent className="px-1">
-                      <div className="space-y-4">
-                        {category.rows.map((row) => (
+          <div className="md:hidden">
+            <Accordion
+              type="multiple"
+              defaultValue={TABLE_DATA.categories.map((category) => category.id)}
+            >
+              {TABLE_DATA.categories.map((category) => (
+                <AccordionItem
+                  key={category.id}
+                  value={category.id}
+                  className="border-b border-white/10"
+                >
+                  <AccordionTrigger className="text-left text-base font-semibold text-white">
+                    {t(category.labelKey)}
+                  </AccordionTrigger>
+                  <AccordionContent className="px-1">
+                    <div className="space-y-4">
+                      {category.rows.map((row) => {
+                        const featureLabel = t(row.labelKey);
+                        const infoText = t(row.infoKey);
+                        const infoAriaLabel = getInfoAriaLabel(featureLabel);
+
+                        return (
                           <div
                             key={row.id}
                             className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur-sm"
                           >
-                            <p className="text-sm font-medium text-white">{t(row.labelKey)}</p>
+                            <div className="flex items-start justify-between gap-3">
+                              <p className="text-sm font-medium text-white">{featureLabel}</p>
+                              <RowInfo
+                                info={infoText}
+                                readMoreLabel={infoReadMoreLabel}
+                                ariaLabel={infoAriaLabel}
+                                size="sm"
+                              />
+                            </div>
+                            <p className="mt-2 text-xs text-white/60">{infoText}</p>
                             <div className="mt-4 grid grid-cols-3 gap-3">
                               {TABLE_DATA.tiers.map((tier) => (
-                                <div key={tier.id} className="flex flex-col items-center gap-2 text-center">
-                                  <span className="text-xs font-medium text-white/80">{t(tier.labelKey)}</span>
+                                <div
+                                  key={tier.id}
+                                  className="flex flex-col items-center gap-2 text-center"
+                                >
+                                  <span className="text-xs font-medium text-white/80">
+                                    {t(tier.labelKey)}
+                                  </span>
                                   <AvailabilityIndicator
                                     value={row.availability[tier.id]}
                                     label={availabilityLabels[row.availability[tier.id]]}
@@ -367,35 +463,39 @@ export function PricingCompareTable() {
                                     }
                                     size="sm"
                                   />
-                                  <span className="text-[11px] text-muted-foreground">{t(tier.priceKey)}</span>
+                                  <span className="text-[11px] text-muted-foreground">
+                                    {t(tier.priceKey)}
+                                  </span>
                                 </div>
                               ))}
                             </div>
                             {row.noteKey ? (
-                              <p className="mt-3 text-xs text-muted-foreground md:hidden">{t(row.noteKey)}</p>
+                              <p className="mt-3 text-xs text-muted-foreground md:hidden">
+                                {t(row.noteKey)}
+                              </p>
                             ) : null}
                           </div>
-                        ))}
-                      </div>
-                    </AccordionContent>
-                  </AccordionItem>
-                ))}
-              </Accordion>
-            </div>
+                        );
+                      })}
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          </div>
 
-            <div className="mt-10 flex flex-col items-center gap-3 text-center sm:flex-row sm:justify-between sm:text-left">
-              <p className="text-sm text-muted-foreground">{t("cta.scrollLabel")}</p>
-              <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row">
-                {TABLE_DATA.tiers.map((tier) => (
-                  <Link
-                    key={tier.id}
-                    href={tier.anchor}
-                    className="inline-flex items-center justify-center rounded-full border border-white/20 px-4 py-2 text-sm font-medium text-white/90 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
-                  >
-                    {t(`cta.chooseTier${tier.id.slice(1)}`)}
-                  </Link>
-                ))}
-              </div>
+          <div className="flex flex-col gap-4 border-t border-white/10 pt-6 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+            <p className="text-sm text-muted-foreground">{t("cta.scrollLabel")}</p>
+            <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row">
+              {TABLE_DATA.tiers.map((tier) => (
+                <Link
+                  key={tier.id}
+                  href={tier.anchor}
+                  className="inline-flex items-center justify-center rounded-full border border-white/20 px-4 py-2 text-sm font-medium text-white/90 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
+                >
+                  {t(`cta.chooseTier${tier.id.slice(1)}`)}
+                </Link>
+              ))}
             </div>
           </div>
         </div>

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -99,7 +99,8 @@
     "Table": {
       "title": "Compare packages",
       "headers": {
-        "feature": "Feature"
+        "feature": "Feature",
+        "info": "Info"
       },
       "tiers": {
         "t1": "Education Package",
@@ -148,6 +149,27 @@
         "chooseTier1": "Explore the Education Package",
         "chooseTier2": "Explore the Introduction Package",
         "chooseTier3": "Talk to Enterprise Solutions"
+      },
+      "info": {
+        "readMore": "Read more",
+        "ariaLabel": "More information about {feature}",
+        "items": {
+          "educationCourseV1": "Introductory training on AI foundations and practical impact for your teams. Builds shared language so employees can spot opportunities quickly.",
+          "educationCourseV2": "Advanced sessions that dive into governance, prompt engineering, and sector-specific workflows. Ideal for teams ready to apply AI inside daily operations.",
+          "workshops": "Facilitated workshops where cross-functional teams co-create adoption scenarios. Every session results in prioritized experiments to launch within weeks.",
+          "trainingMaterials": "Curated playbooks, checklists, and templates to reinforce learning after live sessions. They make it easy to repeat training internally for new hires.",
+          "certification": "Participants earn a TransformAI certificate validating their readiness to work with AI processes. It provides proof of capability for internal HR and clients.",
+          "aiReadiness": "We analyze your current systems, governance, and data quality to gauge AI readiness. The findings map the fastest path to value and highlight any blockers.",
+          "automationSetup": "Our specialists configure initial automations aligned to high-impact processes. You receive documented workflows that teams can extend after hand-off.",
+          "pilotIntegration": "We connect AI services into one live use case to demonstrate measurable value. The pilot is scoped to prove ROI without disrupting critical operations.",
+          "assessment": "A structured review of efficiency gains, adoption metrics, and compliance requirements. Decision-makers get clear benchmarks to justify the next investment.",
+          "guidance": "Senior advisors meet with stakeholders to align roadmap, roles, and success metrics. The session ensures leadership and teams stay synchronized on priorities.",
+          "tailoredIntegrations": "We design custom integrations that link AI services with your existing stack and data. Security, compliance, and change management are handled end-to-end.",
+          "researchSupport": "Our research team investigates emerging models, regulations, and best practices relevant to your sector. You receive actionable briefs to steer strategic choices.",
+          "customModel": "Data scientists evaluate your datasets and train bespoke models when off-the-shelf tools fall short. Deployment includes monitoring and retraining guidance.",
+          "consulting": "Dedicated consultants work alongside your teams during major transformation milestones. They help govern execution, manage risks, and accelerate adoption.",
+          "continuousSupport": "We provide ongoing office hours, incident response, and performance reviews after launch. The support team keeps automation, models, and people aligned."
+        }
       }
     },
     "Chat": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -99,7 +99,8 @@
     "Table": {
       "title": "Vergelijk pakketten",
       "headers": {
-        "feature": "Kenmerk"
+        "feature": "Kenmerk",
+        "info": "Informatie"
       },
       "tiers": {
         "t1": "Educatiepakket",
@@ -148,6 +149,27 @@
         "chooseTier1": "Bekijk het educatiepakket",
         "chooseTier2": "Bekijk het introductiepakket",
         "chooseTier3": "Neem contact op voor enterprise"
+      },
+      "info": {
+        "readMore": "Lees meer",
+        "ariaLabel": "Meer informatie over {feature}",
+        "items": {
+          "educationCourseV1": "Introductietraining over AI-basiskennis en de praktische impact voor jullie teams. Zorgt voor een gedeelde taal zodat medewerkers kansen sneller herkennen.",
+          "educationCourseV2": "Verdiepende sessies over governance, prompt-engineering en sectorspecifieke workflows. Ideaal voor teams die AI meteen in hun dagelijkse werk willen toepassen.",
+          "workshops": "Begeleide workshops waarin multidisciplinaire teams adoptiescenario's cocreëren. Elke sessie levert geprioriteerde experimenten op die binnen enkele weken live kunnen gaan.",
+          "trainingMaterials": "Geselecteerde playbooks, checklists en templates die de lessen uit de live sessies versterken. Zo kan het trainingsprogramma eenvoudig intern worden herhaald voor nieuwe medewerkers.",
+          "certification": "Deelnemers ontvangen een TransformAI-certificaat dat aantoont dat ze klaar zijn om met AI-processen te werken. Het biedt een tastbaar bewijs van vaardigheden voor HR en klanten.",
+          "aiReadiness": "We analyseren jullie systemen, governance en datakwaliteit om de AI-gereedheid te bepalen. De inzichten tonen de snelste route naar waarde en maken eventuele blokkades zichtbaar.",
+          "automationSetup": "Onze specialisten richten de eerste automatiseringen in rond processen met de grootste impact. Je ontvangt gedocumenteerde workflows die teams na overdracht kunnen uitbreiden.",
+          "pilotIntegration": "We koppelen AI-services in één live use-case om meetbare waarde te tonen. De pilot is zo opgezet dat hij ROI bewijst zonder kritieke processen te verstoren.",
+          "assessment": "Een gestructureerde evaluatie van efficiëntiewinst, adoptie-indicatoren en compliance-eisen. Beslissers ontvangen heldere benchmarks om vervolginvesteringen te onderbouwen.",
+          "guidance": "Senior adviseurs stemmen met stakeholders de roadmap, rollen en succesindicatoren af. De sessie zorgt dat leiderschap en teams synchroon blijven op de belangrijkste prioriteiten.",
+          "tailoredIntegrations": "We ontwerpen maatwerk-integraties die AI-diensten koppelen aan jullie bestaande stack en data. Veiligheid, compliance en change management worden volledig meegenomen.",
+          "researchSupport": "Ons researchteam onderzoekt nieuwe modellen, regelgeving en best practices die relevant zijn voor jullie sector. Je ontvangt bruikbare briefs die strategische keuzes richting geven.",
+          "customModel": "Data scientists beoordelen jullie datasets en trainen maatwerkmodellen wanneer standaardtools tekortschieten. Oplevering bevat begeleiding voor monitoring en hertraining.",
+          "consulting": "Toegewijde consultants werken naast jullie teams tijdens cruciale transformatiefases. Ze helpen de uitvoering te sturen, risico's te beheren en adoptie te versnellen.",
+          "continuousSupport": "We bieden doorlopende office hours, incidentrespons en prestatierapportages na de lancering. Het supportteam houdt automatisering, modellen en mensen op één lijn."
+        }
       }
     },
     "Chat": {


### PR DESCRIPTION
## Summary
- merge the pricing hero and comparison table into a single gradient-backed section to keep the experience cohesive
- extend the comparison table with an information column that exposes tooltip explanations and a CTA across desktop and mobile views
- add translation copy for the new info tooltips in English and Dutch and log the work in WRITE_HERE

## Testing
- pnpm --filter www run lint *(fails: missing next-intl package in the environment)*
- pnpm --filter www run typecheck *(fails: missing next-intl package and implicit any errors in existing codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ede51510832aa8cbf0cbb2362c3c