### PR TITLE
Center pricing info tooltip overlays

### DIFF
--- a/WRITE_HERE/UPDATES/2025-09-24T0530--pricing-table-integration.md
+++ b/WRITE_HERE/UPDATES/2025-09-24T0530--pricing-table-integration.md
@@ -1,0 +1,5 @@
+# Integrated pricing comparison with hero aesthetic
+- **What:** Restyled the pricing comparison table to mirror the hero's glassmorphism, added a dedicated information column with hover tooltip, and refreshed responsiveness across desktop and mobile.
+- **Why:** Aligns the pricing grid with the refreshed header for a cohesive, conversion-focused experience while providing clearer coverage cues for each package.
+- **Files:** `apps/www/components/pricing/pricing-compare-table.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Audit global lint debt so `pnpm --filter www run lint` can pass without unrelated errors.

--- a/WRITE_HERE/UPDATES/2025-11-22T0900--pricing-compare-alignment.md
+++ b/WRITE_HERE/UPDATES/2025-11-22T0900--pricing-compare-alignment.md
@@ -1,0 +1,7 @@
+# Harmonized pricing comparison with hero visuals
+_When:_ 2025-11-22 09:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Darkened the pricing comparison shell, expanded hero-inspired gradients, and aligned its width to the hero while reworking the info column into an icon-triggered tooltip with richer glow styling.
+- **Why:** Ensure the pricing matrix reads as a seamless continuation of the refreshed hero while keeping it distinct enough to scan quickly and understand coverage details.
+- **Files:** `apps/www/components/pricing/pricing-compare-table.tsx`.
+- **Follow-ups:** Monitor tooltip discoverability during usability reviews; extend the pattern to other pricing surfaces if it resonates.

--- a/WRITE_HERE/UPDATES/2025-11-22T1500--pricing-info-icon-tooltips.md
+++ b/WRITE_HERE/UPDATES/2025-11-22T1500--pricing-info-icon-tooltips.md
@@ -1,0 +1,5 @@
+# Simplified pricing info column with icon-triggered tooltips
+- **What:** Replaced the pricing table's information column cards with a consistent info icon trigger that opens a gradient tooltip containing the coverage summary and call-to-action copy on both desktop and mobile layouts.
+- **Why:** Match the requested interaction so each row reveals details on hover while keeping the section visually aligned with the pricing hero styling.
+- **Files:** `apps/www/components/pricing/pricing-compare-table.tsx`.
+- **Follow-ups:** Monitor mobile usability; consider a tap-friendly popover if hover tooltips prove hard to discover on touch devices.

--- a/WRITE_HERE/UPDATES/2025-11-22T1700--pricing-tooltip-centering.md
+++ b/WRITE_HERE/UPDATES/2025-11-22T1700--pricing-tooltip-centering.md
@@ -1,0 +1,7 @@
+# Centered pricing info tooltips within the viewport
+_When:_ 2025-11-22 17:00 · _Scope:_ apps/www · _Author:_ AI assistant
+
+- **What:** Adjusted the pricing info tooltip alignment to anchor toward the interior of the layout and added collision padding so the panel stays fully visible on hover.
+- **Why:** Prevent the coverage summary overlay from spilling off-screen on the right side of the table and ensure it feels visually centered within the comparison surface.
+- **Files:** `apps/www/components/pricing/pricing-compare-table.tsx`.
+- **Follow-ups:** Validate on-device that touch interactions remain comfortable; consider promoting the tooltip content into a dedicated modal if deeper detail is needed.

--- a/apps/www/components/pricing/pricing-compare-table.tsx
+++ b/apps/www/components/pricing/pricing-compare-table.tsx
@@ -8,7 +8,8 @@ import { cn } from "@/lib/utils";
 import { Check, Info, Minus, X } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
+import { useMemo } from "react";
 
 type TierId = "t1" | "t2" | "t3";
 type Availability = "yes" | "no" | "partial";
@@ -180,6 +181,160 @@ const sizeMap = {
   sm: "h-8 w-8 text-sm",
 } satisfies Record<NonNullable<AvailabilityIndicatorProps["size"]>, string>;
 
+const TIER_SEGMENT_STYLES: Record<TierId, string> = {
+  t1: "bg-gradient-to-r from-white/80 via-white/45 to-white/10 shadow-[0_0_28px_rgba(255,255,255,0.28)]",
+  t2: "bg-gradient-to-r from-[#FFD600]/80 via-[#FFD600]/45 to-transparent shadow-[0_0_28px_rgba(255,214,0,0.32)]",
+  t3: "bg-gradient-to-r from-[#9D72FF]/80 via-[#9D72FF]/45 to-transparent shadow-[0_0_32px_rgba(157,114,255,0.32)]",
+};
+
+type InformationSummaryProps = {
+  availability: PricingTableRow["availability"];
+  className?: string;
+  variant?: "table" | "card";
+};
+
+function InformationSummary({ availability, className, variant = "table" }: InformationSummaryProps) {
+  const t = useTranslations("Pricing.Table");
+  const locale = useLocale();
+
+  const listFormatter = useMemo(
+    () =>
+      new Intl.ListFormat(locale, {
+        style: "short",
+        type: "conjunction",
+      }),
+    [locale],
+  );
+
+  const includedTiers = TABLE_DATA.tiers.filter((tier) => availability[tier.id] === "yes");
+  const partialTiers = TABLE_DATA.tiers.filter((tier) => availability[tier.id] === "partial");
+
+  const includedLabels = includedTiers.map((tier) => t(tier.labelKey));
+  const partialLabels = partialTiers.map((tier) => t(tier.labelKey));
+
+  const infoLines: string[] = [];
+
+  if (includedLabels.length > 0) {
+    infoLines.push(
+      t("infoColumn.availableIn", {
+        packages: listFormatter.format(includedLabels),
+      }),
+    );
+  }
+
+  if (partialLabels.length > 0) {
+    infoLines.push(
+      t("infoColumn.partialIn", {
+        packages: listFormatter.format(partialLabels),
+      }),
+    );
+  }
+
+  if (infoLines.length === 0) {
+    infoLines.push(t("infoColumn.notIncluded"));
+  }
+
+  const includedCount = includedLabels.length;
+  const hasPartial = partialLabels.length > 0;
+  const countDisplay = `${includedCount}${hasPartial ? "+" : ""}/${TABLE_DATA.tiers.length}`;
+  const srLabel = infoLines.join(" ");
+
+  const triggerClasses = cn(
+    "group relative inline-flex items-center justify-center overflow-hidden rounded-full border border-white/15 bg-white/[0.05] text-white/80 shadow-[0_16px_60px_rgba(79,70,229,0.4)] transition hover:border-white/35 hover:text-white hover:shadow-[0_22px_80px_rgba(99,102,241,0.55)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950",
+    variant === "card" ? "h-10 w-10" : "h-11 w-11",
+    className,
+  );
+
+  const tooltipSideOffset = variant === "card" ? 12 : 18;
+  const tooltipAlignOffset = variant === "card" ? -8 : -24;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button type="button" className={triggerClasses} aria-label={srLabel}>
+          <span
+            aria-hidden
+            className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.18),_transparent_70%)] opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+          />
+          <span
+            aria-hidden
+            className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(157,114,255,0.22),_transparent_72%)] opacity-60"
+          />
+          <Info className="relative z-10 h-4 w-4 transition-transform duration-500 group-hover:scale-110" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent
+        side="top"
+        align="end"
+        alignOffset={tooltipAlignOffset}
+        sideOffset={tooltipSideOffset}
+        collisionPadding={{ left: 24, right: 24 }}
+        className="relative w-[300px] max-w-[85vw] overflow-hidden rounded-3xl border border-white/12 bg-neutral-950/95 p-5 text-left text-sm text-white/80 shadow-[0_32px_160px_rgba(8,12,24,0.78)] backdrop-blur-xl"
+      >
+        <div aria-hidden className="pointer-events-none absolute inset-0">
+          <div className="absolute -top-20 left-1/2 h-48 w-48 -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.32),_transparent_70%)] blur-2xl" />
+          <div className="absolute -bottom-24 right-0 h-40 w-40 rounded-full bg-[radial-gradient(circle_at_bottom,_rgba(147,51,234,0.3),_transparent_72%)] blur-2xl" />
+          <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/30 to-transparent opacity-80" />
+        </div>
+        <div className="relative space-y-4">
+          <div className="space-y-2">
+            <p className="leading-relaxed text-white/85">{t("infoColumn.tooltip.line1")}</p>
+            <p className="leading-relaxed text-white/70">{t("infoColumn.tooltip.line2")}</p>
+          </div>
+          <div className="relative overflow-hidden rounded-2xl border border-white/12 bg-white/[0.04] p-4 shadow-[0_24px_100px_rgba(8,12,24,0.55)]">
+            <div aria-hidden className="pointer-events-none absolute inset-0">
+              <div className="absolute inset-0 bg-[radial-gradient(120%_90%_at_0%_20%,rgba(59,130,246,0.16),transparent_75%)]" />
+              <div className="absolute inset-0 bg-[radial-gradient(120%_90%_at_100%_80%,rgba(157,114,255,0.2),transparent_75%)]" />
+              <div className="absolute inset-x-2 top-0 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent opacity-80" />
+            </div>
+            <div className="relative flex items-center justify-between gap-4">
+              <div className="flex flex-1 items-center gap-2">
+                {TABLE_DATA.tiers.map((tier) => {
+                  const value = availability[tier.id];
+                  return (
+                    <span
+                      key={`${tier.id}-coverage`}
+                      aria-hidden="true"
+                      className={cn(
+                        "h-2.5 w-9 rounded-full transition-all duration-500 ease-out",
+                        value === "yes" ? TIER_SEGMENT_STYLES[tier.id] : "bg-white/10",
+                        value === "partial" && "opacity-70 ring-2 ring-amber-200/60 ring-offset-[2px] ring-offset-black/60",
+                        value === "no" && "opacity-40",
+                      )}
+                    />
+                  );
+                })}
+              </div>
+              <div className="flex flex-col text-right">
+                <span className="text-[10px] font-semibold uppercase tracking-[0.35em] text-white/55">
+                  {t("infoColumn.label")}
+                </span>
+                <span className="text-sm font-semibold text-white">{countDisplay}</span>
+                {hasPartial ? (
+                  <span className="text-[10px] font-medium uppercase tracking-[0.3em] text-amber-200/80">
+                    {t("legend.partial")}
+                  </span>
+                ) : null}
+              </div>
+            </div>
+            <div className="relative mt-3 space-y-1 text-xs leading-relaxed text-white/75">
+              {infoLines.map((line, index) => (
+                <p key={`${line}-${index}`}>{line}</p>
+              ))}
+            </div>
+          </div>
+          <Link
+            href="#"
+            className="relative inline-flex items-center justify-center rounded-full border border-white/20 bg-white/[0.08] px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:border-white/40 hover:bg-white/[0.16] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950"
+          >
+            {t("infoColumn.tooltip.cta")}
+          </Link>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function AvailabilityIndicator({ value, label, note, priceRange, size = "md" }: AvailabilityIndicatorProps) {
   const meta = AVAILABILITY_META[value];
   const Icon = meta.icon;
@@ -251,50 +406,100 @@ export function PricingCompareTable() {
 
   return (
     <TooltipProvider delayDuration={200} skipDelayDuration={200}>
-      <section aria-labelledby="pricing-compare-heading" className="relative w-full max-w-4xl mx-auto">
-        <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-black/60 shadow-[0_40px_120px_-60px_rgba(88,54,179,0.85)]">
-          <div
-            aria-hidden
-            className="absolute inset-0 bg-gradient-to-br from-[#140F2C]/90 via-[#1A1440]/70 to-[#031B4A]/80"
-          />
-          <div
-            aria-hidden
-            className="absolute inset-x-8 -top-40 h-96 bg-[radial-gradient(circle_at_top,_rgba(157,114,255,0.45),_transparent_60%)]"
-          />
-          <EnterpriseCardHighlight className="absolute -top-28 -right-24 w-[420px] opacity-60 mix-blend-screen" />
+      <section
+        aria-labelledby="pricing-compare-heading"
+        className="relative mx-auto w-full max-w-5xl"
+      >
+        <div className="relative isolate overflow-hidden rounded-[32px] border border-white/12 bg-neutral-950/80 px-6 py-12 shadow-[0_36px_160px_rgba(8,12,24,0.72)] ring-1 ring-white/5 backdrop-blur-2xl sm:px-12 sm:py-16">
+          <div aria-hidden className="pointer-events-none absolute inset-0">
+            <div className="absolute inset-0 bg-[radial-gradient(120%_80%_at_50%_-20%,rgba(56,189,248,0.16),transparent_70%)]" />
+            <div className="absolute inset-0 bg-[radial-gradient(110%_90%_at_90%_120%,rgba(157,114,255,0.24),transparent_75%)]" />
+            <div className="absolute inset-0 bg-[radial-gradient(100%_90%_at_0%_40%,rgba(76,29,149,0.18),transparent_70%)]" />
+            <div className="absolute -top-44 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.35),_transparent_68%)] blur-3xl" />
+            <div className="absolute -bottom-48 right-12 h-96 w-96 rounded-full bg-[radial-gradient(circle_at_bottom,_rgba(157,114,255,0.4),_transparent_72%)] blur-[140px]" />
+            <div className="absolute -left-28 top-1/2 h-80 w-80 -translate-y-1/2 rounded-full bg-[radial-gradient(circle,_rgba(99,102,241,0.36),_transparent_70%)] blur-[120px]" />
+            <div className="absolute inset-x-12 -top-px h-px bg-gradient-to-r from-transparent via-white/30 to-transparent opacity-70" />
+          </div>
+          <EnterpriseCardHighlight className="absolute -top-40 -right-32 w-[520px] opacity-60 mix-blend-screen" />
           <Particles
-            className="absolute inset-0 opacity-40 transition-opacity duration-700 pointer-events-none motion-reduce:hidden"
-            quantity={60}
+            className="pointer-events-none absolute inset-0 opacity-55 transition-opacity duration-700 motion-reduce:hidden"
+            quantity={70}
             color={Color.Purple}
-            vx={0.08}
-            vy={-0.06}
+            vx={0.06}
+            vy={-0.04}
           />
-          <div className="relative z-10 px-6 py-10 sm:px-10 sm:py-12">
-            <div className="text-center">
+          <div className="relative z-10 flex flex-col gap-12">
+            <div className="mx-auto max-w-3xl text-center">
               <h2
                 id="pricing-compare-heading"
-                className="text-3xl font-semibold tracking-tight text-white sm:text-[2.25rem]"
+                className="bg-gradient-to-r from-white via-white to-white/60 bg-clip-text text-3xl font-semibold tracking-tight text-transparent sm:text-[2.25rem] sm:leading-tight"
               >
                 {t("title")}
               </h2>
             </div>
 
-            <div className="mt-10 hidden md:block">
+            <div className="hidden md:block">
               <table className="w-full border-collapse text-left">
                 <caption className="sr-only">{t("title")}</caption>
                 <thead>
                   <tr className="text-sm text-white/80">
-                    <th scope="col" className="px-6 py-4 text-left font-medium text-white/70">
+                    <th scope="col" className="px-6 pb-4 text-left font-medium text-white/70">
                       {t("headers.feature")}
                     </th>
                     {TABLE_DATA.tiers.map((tier) => (
-                      <th key={tier.id} scope="col" className="px-6 py-4 text-center font-semibold text-white">
+                      <th key={tier.id} scope="col" className="px-6 pb-4 text-center font-semibold text-white">
                         <div className="flex flex-col items-center gap-1">
                           <span className="text-base sm:text-lg">{t(tier.labelKey)}</span>
-                          <span className="text-sm font-normal text-muted-foreground">{t(tier.priceKey)}</span>
+                          <span className="text-xs font-medium text-white/60">{t(tier.priceKey)}</span>
                         </div>
                       </th>
                     ))}
+                    <th scope="col" className="px-6 pb-4 text-right font-semibold text-white">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            aria-label={t("headers.info")}
+                            className="group relative inline-flex h-11 w-11 items-center justify-center overflow-hidden rounded-full border border-white/15 bg-white/[0.05] text-white/80 shadow-[0_16px_60px_rgba(79,70,229,0.4)] transition hover:border-white/35 hover:text-white hover:shadow-[0_22px_80px_rgba(99,102,241,0.55)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950"
+                          >
+                            <span className="sr-only">{t("headers.info")}</span>
+                            <span
+                              aria-hidden
+                              className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.18),_transparent_70%)] opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+                            />
+                            <span
+                              aria-hidden
+                              className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(157,114,255,0.2),_transparent_70%)] opacity-60"
+                            />
+                            <Info className="relative z-10 h-5 w-5 transition-transform duration-500 group-hover:scale-110" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent
+                          side="top"
+                          align="end"
+                          alignOffset={-16}
+                          sideOffset={16}
+                          collisionPadding={{ left: 24, right: 24 }}
+                          className="w-[280px] overflow-hidden rounded-3xl border border-white/12 bg-neutral-950/95 p-5 text-left text-sm text-white/80 shadow-[0_32px_160px_rgba(8,12,24,0.75)] backdrop-blur-xl"
+                        >
+                          <div className="relative space-y-4">
+                            <div aria-hidden className="pointer-events-none absolute inset-0">
+                              <div className="absolute -top-20 left-1/2 h-48 w-48 -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.32),_transparent_70%)] blur-2xl" />
+                              <div className="absolute -bottom-24 right-0 h-40 w-40 rounded-full bg-[radial-gradient(circle_at_bottom,_rgba(147,51,234,0.32),_transparent_72%)] blur-2xl" />
+                              <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/30 to-transparent opacity-80" />
+                            </div>
+                            <p className="relative z-10 leading-relaxed text-white/85">{t("infoColumn.tooltip.line1")}</p>
+                            <p className="relative z-10 leading-relaxed text-white/70">{t("infoColumn.tooltip.line2")}</p>
+                            <Link
+                              href="#"
+                              className="relative z-10 inline-flex items-center justify-center rounded-full border border-white/20 bg-white/[0.08] px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:border-white/40 hover:bg-white/[0.16] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950"
+                            >
+                              {t("infoColumn.tooltip.cta")}
+                            </Link>
+                          </div>
+                        </TooltipContent>
+                      </Tooltip>
+                    </th>
                   </tr>
                 </thead>
                 {TABLE_DATA.categories.map((category) => (
@@ -302,8 +507,8 @@ export function PricingCompareTable() {
                     <tr>
                       <th
                         scope="colgroup"
-                        colSpan={TABLE_DATA.tiers.length + 1}
-                        className="px-6 pt-8 pb-3 text-xs font-semibold uppercase tracking-[0.3em] text-white/60"
+                        colSpan={TABLE_DATA.tiers.length + 2}
+                        className="px-6 pt-8 pb-3 text-xs font-semibold uppercase tracking-[0.35em] text-white/60"
                       >
                         {t(category.labelKey)}
                       </th>
@@ -311,13 +516,13 @@ export function PricingCompareTable() {
                     {category.rows.map((row) => (
                       <tr
                         key={row.id}
-                        className="border-t border-white/10 text-sm"
+                        className="border-t border-white/10 text-sm transition-colors hover:bg-white/[0.05]"
                       >
                         <th scope="row" className="px-6 py-5 text-left font-medium text-white/90">
                           {t(row.labelKey)}
                         </th>
                         {TABLE_DATA.tiers.map((tier) => (
-                          <td key={tier.id} className="px-6 py-5 text-center">
+                          <td key={tier.id} className="px-6 py-5 text-center align-top">
                             <AvailabilityIndicator
                               value={row.availability[tier.id]}
                               label={availabilityLabels[row.availability[tier.id]]}
@@ -330,6 +535,9 @@ export function PricingCompareTable() {
                             />
                           </td>
                         ))}
+                        <td className="px-6 py-5 align-top">
+                          <InformationSummary availability={row.availability} className="mx-auto" />
+                        </td>
                       </tr>
                     ))}
                   </tbody>
@@ -337,7 +545,7 @@ export function PricingCompareTable() {
               </table>
             </div>
 
-            <div className="mt-10 md:hidden">
+            <div className="md:hidden">
               <Accordion type="multiple" defaultValue={TABLE_DATA.categories.map((category) => category.id)}>
                 {TABLE_DATA.categories.map((category) => (
                   <AccordionItem key={category.id} value={category.id} className="border-b border-white/10">
@@ -349,10 +557,22 @@ export function PricingCompareTable() {
                         {category.rows.map((row) => (
                           <div
                             key={row.id}
-                            className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur-sm"
+                            className="relative overflow-hidden rounded-3xl border border-white/12 bg-neutral-950/75 p-5 shadow-[0_24px_110px_rgba(8,12,24,0.6)] backdrop-blur-xl"
                           >
-                            <p className="text-sm font-medium text-white">{t(row.labelKey)}</p>
-                            <div className="mt-4 grid grid-cols-3 gap-3">
+                            <div aria-hidden className="pointer-events-none absolute inset-0">
+                              <div className="absolute inset-0 bg-[radial-gradient(120%_90%_at_0%_20%,rgba(59,130,246,0.18),transparent_75%)]" />
+                              <div className="absolute inset-0 bg-[radial-gradient(120%_90%_at_100%_80%,rgba(157,114,255,0.22),transparent_75%)]" />
+                              <div className="absolute inset-x-4 top-0 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent opacity-75" />
+                            </div>
+                            <div className="relative z-10 flex items-start justify-between gap-3">
+                              <p className="flex-1 text-sm font-medium leading-snug text-white">{t(row.labelKey)}</p>
+                              <InformationSummary
+                                availability={row.availability}
+                                variant="card"
+                                className="shrink-0"
+                              />
+                            </div>
+                            <div className="relative z-10 mt-4 grid grid-cols-3 gap-3">
                               {TABLE_DATA.tiers.map((tier) => (
                                 <div key={tier.id} className="flex flex-col items-center gap-2 text-center">
                                   <span className="text-xs font-medium text-white/80">{t(tier.labelKey)}</span>
@@ -367,12 +587,12 @@ export function PricingCompareTable() {
                                     }
                                     size="sm"
                                   />
-                                  <span className="text-[11px] text-muted-foreground">{t(tier.priceKey)}</span>
+                                  <span className="text-[11px] text-white/60">{t(tier.priceKey)}</span>
                                 </div>
                               ))}
                             </div>
                             {row.noteKey ? (
-                              <p className="mt-3 text-xs text-muted-foreground md:hidden">{t(row.noteKey)}</p>
+                              <p className="mt-3 text-xs text-white/60 md:hidden">{t(row.noteKey)}</p>
                             ) : null}
                           </div>
                         ))}
@@ -383,14 +603,14 @@ export function PricingCompareTable() {
               </Accordion>
             </div>
 
-            <div className="mt-10 flex flex-col items-center gap-3 text-center sm:flex-row sm:justify-between sm:text-left">
-              <p className="text-sm text-muted-foreground">{t("cta.scrollLabel")}</p>
+            <div className="flex flex-col gap-4 border-t border-white/10 pt-8 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+              <p className="text-sm text-white/60">{t("cta.scrollLabel")}</p>
               <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row">
                 {TABLE_DATA.tiers.map((tier) => (
                   <Link
                     key={tier.id}
                     href={tier.anchor}
-                    className="inline-flex items-center justify-center rounded-full border border-white/20 px-4 py-2 text-sm font-medium text-white/90 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
+                    className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/[0.06] px-5 py-2 text-sm font-medium text-white/80 transition hover:border-white/40 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
                   >
                     {t(`cta.chooseTier${tier.id.slice(1)}`)}
                   </Link>

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -99,7 +99,8 @@
     "Table": {
       "title": "Compare packages",
       "headers": {
-        "feature": "Feature"
+        "feature": "Feature",
+        "info": "Information"
       },
       "tiers": {
         "t1": "Education Package",
@@ -137,6 +138,17 @@
         "t1": "Estimated investment per included service: €450 – €1,200",
         "t2": "Estimated investment per included service: €900 – €2,500",
         "t3": "Custom engagements typically range from €2,500 – €8,500"
+      },
+      "infoColumn": {
+        "label": "Information",
+        "availableIn": "Available in {packages}",
+        "partialIn": "Limited availability in {packages}",
+        "notIncluded": "Not included in any package",
+        "tooltip": {
+          "line1": "Get a quick view of how each service spans across our packages.",
+          "line2": "Use it to guide conversations with your team before you dive into the detailed comparisons.",
+          "cta": "Read more"
+        }
       },
       "legend": {
         "included": "Included",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -99,7 +99,8 @@
     "Table": {
       "title": "Vergelijk pakketten",
       "headers": {
-        "feature": "Kenmerk"
+        "feature": "Kenmerk",
+        "info": "Informatie"
       },
       "tiers": {
         "t1": "Educatiepakket",
@@ -137,6 +138,17 @@
         "t1": "Geschatte investering per inbegrepen service: €450 – €1.200",
         "t2": "Geschatte investering per inbegrepen service: €900 – €2.500",
         "t3": "Maatwerktrajecten variëren doorgaans van €2.500 – €8.500"
+      },
+      "infoColumn": {
+        "label": "Informatie",
+        "availableIn": "Beschikbaar in {packages}",
+        "partialIn": "Beperkt beschikbaar in {packages}",
+        "notIncluded": "Niet inbegrepen in een pakket",
+        "tooltip": {
+          "line1": "Bekijk in één oogopslag hoe elke dienst over de pakketten is verdeeld.",
+          "line2": "Gebruik dit overzicht als vertrekpunt voor gesprekken met je team vóórdat je de details induikt.",
+          "cta": "Lees meer"
+        }
       },
       "legend": {
         "included": "Inbegrepen",


### PR DESCRIPTION
## Summary
- re-anchor the pricing info tooltip overlays toward the interior and add collision padding so hover panels stay fully visible
- mirror the alignment tweak on the column header trigger to keep the experience consistent
- record the centering adjustment in the project updates log

## Plan
- Inspect the current tooltip alignment for the pricing info column
- Adjust tooltip alignment and collision padding for row and header triggers
- Run the existing www workspace checks to confirm nothing regresses
- Capture the change in WRITE_HERE/UPDATES for continuity

## Testing
- pnpm --filter www run typecheck *(fails: repository still missing `next-intl` packages/typings)*
- pnpm --filter www run lint *(fails: `next-intl` package resolution is not present in the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d37fba9774832abd8f72bac87a270b