### PR TITLE
Improve pricing hover performance

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-22T2100--smoothed-pricing-scroll-performance.md
+++ b/WRITE_HERE/FIXES/2025-11-22T2100--smoothed-pricing-scroll-performance.md
@@ -1,0 +1,5 @@
+# Smoothed pricing scroll performance
+- **What:** Swapped the global mouse tracking in the pricing particles and shiny card group for scoped pointer listeners with rAF-throttled updates so the hover effects update without forcing repeated React renders.
+- **Why:** The pricing page lagged during scroll because every mousemove triggered React state updates across the page, causing expensive layout reads on each frame.
+- **Files:** `apps/www/components/particles.tsx`, `apps/www/components/shiny-card.tsx`.
+- **Follow-ups:** Monitor the hover gradients after major layout shifts; the resize observer will keep offsets in sync, but additional cards may need a refresh toggle if they mount asynchronously.

--- a/apps/www/components/particles.tsx
+++ b/apps/www/components/particles.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMousePosition } from "@/lib/mouse";
 import type React from "react";
 import { useCallback, useEffect, useRef } from "react";
 
@@ -41,7 +40,6 @@ export const Particles: React.FC<ParticlesProps> = ({
   const canvasContainerRef = useRef<HTMLDivElement>(null);
   const context = useRef<CanvasRenderingContext2D | null>(null);
   const circles = useRef<any[]>([]);
-  const mousePosition = useMousePosition();
   const mouse = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
   const canvasSize = useRef<{ w: number; h: number }>({ w: 0, h: 0 });
   const dpr = typeof window !== "undefined" ? window.devicePixelRatio : 1;
@@ -71,23 +69,67 @@ export const Particles: React.FC<ParticlesProps> = ({
     initCanvas();
   }, [initCanvas, refresh]);
 
-  const onMouseMove = useCallback(() => {
-    if (canvasRef.current) {
-      const rect = canvasRef.current.getBoundingClientRect();
-      const { w, h } = canvasSize.current;
-      const x = mousePosition.x - rect.left - w / 2;
-      const y = mousePosition.y - rect.top - h / 2;
-      const inside = x < w / 2 && x > -w / 2 && y < h / 2 && y > -h / 2;
-      if (inside) {
-        mouse.current.x = x;
-        mouse.current.y = y;
-      }
-    }
-  }, [mousePosition.x, mousePosition.y]);
-
   useEffect(() => {
-    onMouseMove();
-  }, [onMouseMove]);
+    const container = canvasContainerRef.current;
+    const canvas = canvasRef.current;
+    if (!container || !canvas) {
+      return;
+    }
+
+    let pointerFrame: number | null = null;
+
+    const updatePointer = (event: PointerEvent) => {
+      if (pointerFrame !== null) {
+        window.cancelAnimationFrame(pointerFrame);
+      }
+
+      pointerFrame = window.requestAnimationFrame(() => {
+        const { w, h } = canvasSize.current;
+        if (w === 0 || h === 0) {
+          pointerFrame = null;
+          return;
+        }
+
+        const rect = canvas.getBoundingClientRect();
+        const x = event.clientX - rect.left - w / 2;
+        const y = event.clientY - rect.top - h / 2;
+        const inside = x < w / 2 && x > -w / 2 && y < h / 2 && y > -h / 2;
+
+        if (inside) {
+          mouse.current.x = x;
+          mouse.current.y = y;
+        } else {
+          mouse.current.x = 0;
+          mouse.current.y = 0;
+        }
+
+        pointerFrame = null;
+      });
+    };
+
+    const resetPointer = () => {
+      if (pointerFrame !== null) {
+        window.cancelAnimationFrame(pointerFrame);
+      }
+
+      pointerFrame = window.requestAnimationFrame(() => {
+        mouse.current.x = 0;
+        mouse.current.y = 0;
+        pointerFrame = null;
+      });
+    };
+
+    container.addEventListener("pointermove", updatePointer);
+    container.addEventListener("pointerleave", resetPointer);
+
+    return () => {
+      container.removeEventListener("pointermove", updatePointer);
+      container.removeEventListener("pointerleave", resetPointer);
+      if (pointerFrame !== null) {
+        window.cancelAnimationFrame(pointerFrame);
+      }
+    };
+  }, []);
 
   type Circle = {
     x: number;

--- a/apps/www/components/shiny-card.tsx
+++ b/apps/www/components/shiny-card.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { useMousePosition } from "@/lib/mouse";
 import type React from "react";
-import { type PropsWithChildren, useCallback, useEffect, useRef, useState } from "react";
+import {
+  Children,
+  type PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 
 type ShinyCardGroupProps = {
   children: React.ReactNode;
@@ -16,62 +22,120 @@ export const ShinyCardGroup: React.FC<ShinyCardGroupProps> = ({
   refresh = false,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  const mousePosition = useMousePosition();
-  const mouse = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
-  const containerSize = useRef<{ w: number; h: number }>({ w: 0, h: 0 });
-  const [boxes, setBoxes] = useState<Array<HTMLElement>>([]);
+  const boxesRef = useRef<HTMLElement[]>([]);
+  const boxOffsetsRef = useRef<Array<{ left: number; top: number }>>([]);
+  const pointerFrameRef = useRef<number | null>(null);
+  const childCount = useMemo(() => Children.count(children), [children]);
 
-  useEffect(() => {
-    containerRef.current &&
-      setBoxes(Array.from(containerRef.current.children).map((el) => el as HTMLElement));
+  const measureBoxes = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) {
+      boxesRef.current = [];
+      boxOffsetsRef.current = [];
+      return;
+    }
+
+    boxesRef.current = Array.from(container.children).map((el) => el as HTMLElement);
+    const containerRect = container.getBoundingClientRect();
+
+    boxOffsetsRef.current = boxesRef.current.map((box) => {
+      const rect = box.getBoundingClientRect();
+      return {
+        left: rect.left - containerRect.left,
+        top: rect.top - containerRect.top,
+      };
+    });
   }, []);
 
   useEffect(() => {
-    initContainer();
-    window.addEventListener("resize", initContainer);
+    measureBoxes();
+  }, [measureBoxes, refresh, childCount]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      measureBoxes();
+    };
+
+    window.addEventListener("resize", handleResize);
 
     return () => {
-      window.removeEventListener("resize", initContainer);
+      window.removeEventListener("resize", handleResize);
     };
-  }, []);
+  }, [measureBoxes]);
 
-  const initContainer = useCallback(() => {
-    if (containerRef.current) {
-      containerSize.current.w = containerRef.current.offsetWidth;
-      containerSize.current.h = containerRef.current.offsetHeight;
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === "undefined") {
+      return;
     }
-  }, []);
 
-  const onMouseMove = useCallback(() => {
-    if (containerRef.current) {
-      const rect = containerRef.current.getBoundingClientRect();
-      const { w, h } = containerSize.current;
-      const x = mousePosition.x - rect.left;
-      const y = mousePosition.y - rect.top;
-      const inside = x < w && x > 0 && y < h && y > 0;
-      if (inside) {
-        mouse.current.x = x;
-        mouse.current.y = y;
-        boxes.forEach((box) => {
-          const boxX = -(box.getBoundingClientRect().left - rect.left) + mouse.current.x;
-          const boxY = -(box.getBoundingClientRect().top - rect.top) + mouse.current.y;
+    const observer = new ResizeObserver(() => {
+      measureBoxes();
+    });
+
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [measureBoxes]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (pointerFrameRef.current !== null) {
+        window.cancelAnimationFrame(pointerFrameRef.current);
+      }
+
+      pointerFrameRef.current = window.requestAnimationFrame(() => {
+        const rect = container.getBoundingClientRect();
+        const x = event.clientX - rect.left;
+        const y = event.clientY - rect.top;
+
+        if (x < 0 || y < 0 || x > rect.width || y > rect.height) {
+          pointerFrameRef.current = null;
+          return;
+        }
+
+        boxesRef.current.forEach((box, index) => {
+          const bounds = boxOffsetsRef.current[index];
+          if (!bounds) {
+            return;
+          }
+
+          const boxX = x - bounds.left;
+          const boxY = y - bounds.top;
           box.style.setProperty("--mouse-x", `${boxX}px`);
           box.style.setProperty("--mouse-y", `${boxY}px`);
         });
+
+        pointerFrameRef.current = null;
+      });
+    };
+
+    const handlePointerLeave = () => {
+      if (pointerFrameRef.current !== null) {
+        window.cancelAnimationFrame(pointerFrameRef.current);
+        pointerFrameRef.current = null;
       }
-    }
-  }, [boxes, mousePosition.x, mousePosition.y]);
+    };
 
-  useEffect(() => {
-    onMouseMove();
-  }, [onMouseMove]);
+    container.addEventListener("pointermove", handlePointerMove);
+    container.addEventListener("pointerleave", handlePointerLeave);
 
-  useEffect(() => {
-    if (!refresh) {
-      return;
-    }
-    initContainer();
-  }, [initContainer, refresh]);
+    return () => {
+      container.removeEventListener("pointermove", handlePointerMove);
+      container.removeEventListener("pointerleave", handlePointerLeave);
+      if (pointerFrameRef.current !== null) {
+        window.cancelAnimationFrame(pointerFrameRef.current);
+        pointerFrameRef.current = null;
+      }
+    };
+  }, [childCount]);
 
   return (
     <div className={className} ref={containerRef}>


### PR DESCRIPTION
## Summary
- replace the pricing particle hover tracking with scoped pointer listeners and rAF throttling to stop global mousemove re-renders
- refactor `ShinyCardGroup` to cache card offsets, throttle pointer updates, and refresh metrics on resize for smoother gradients
- document the resolved scroll jank in `WRITE_HERE/FIXES/2025-11-22T2100--smoothed-pricing-scroll-performance.md`

## Plan
- inspect the pricing hover effects to identify the source of scroll lag
- refactor the `Particles` component to update mouse coordinates without React state churn
- update `ShinyCardGroup` to reuse cached measurements and pointermove handlers with resize awareness
- add a FIXES entry and run typecheck/lint/build for regression coverage

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: pre-existing repo lint errors, including legacy form code)*
- `pnpm -w turbo run build --filter=www` *(fails: same lint violations surfaced during Next.js build lint phase)*

------
https://chatgpt.com/codex/tasks/task_e_68d39ce7ae70832aa844a5f28929bddb