### PR TITLE
Redesign About page team section

### DIFF
--- a/WRITE_HERE/UPDATES/2025-09-19T1200--compact-team-section-about-page.md
+++ b/WRITE_HERE/UPDATES/2025-09-19T1200--compact-team-section-about-page.md
@@ -1,0 +1,5 @@
+# Rebuilt the About page team section
+- **What:** Replaced the legacy offsite gallery with a compact team grid using the new headshots, added localized copy for each member, and introduced a “join our team” CTA.
+- **Why:** Align the About page with the requested professional team presentation while keeping the layout efficient and bilingual.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -50,21 +50,10 @@ import allison from "@/images/about/investors/allison5.png";
 import liu from "@/images/about/investors/liujiang.jpeg";
 import tim from "@/images/about/investors/tim.png";
 
-import art_intensifies from "@/images/offsite/art_intensifies.jpg";
-import breakfast from "@/images/offsite/breakfast.jpg";
-import cooking_crew from "@/images/offsite/cooking_crew.jpg";
-import cto_prayers_answered from "@/images/offsite/cto_prayers_answered.jpg";
-import dom_thinking from "@/images/offsite/dom_thinking.jpg";
-import doomsday from "@/images/offsite/doomsday.jpg";
-import james_fence from "@/images/offsite/james_fence.jpg";
-import james_thinking from "@/images/offsite/james_thinking.jpg";
-import mike_morning_neck_exercise from "@/images/offsite/mike_morning_neck_exercise.jpg";
-import yardwork from "@/images/offsite/yardwork.jpg";
 import andreas from "@/images/team/andreas.jpeg";
 import james from "@/images/team/james.jpg";
 
 import { ImageWithBlur } from "@/components/image-with-blur";
-import { cn } from "@/lib/utils";
 import { loadMessages } from "@/i18n/messages";
 import type { Messages } from "@/i18n/messages";
 import { isLocale } from "@/i18n/routing";
@@ -112,23 +101,6 @@ const investors = [
 
 const SELECTED_POSTS = ["uuid-ux", "why-we-built-unkey", "unkey-raises-1-5-million"];
 
-const offsiteImages = [
-  { src: breakfast, label: "Cooking breakfast" },
-  { src: art_intensifies, label: "Art intensifies" },
-  { src: dom_thinking, label: "Hard at work" },
-  { src: cooking_crew, label: "Lunch refuel" },
-  { src: cto_prayers_answered, label: "Golden hour" },
-  { src: doomsday, label: "Escape room W" },
-  { src: james_fence, label: "James recruiting" },
-  { src: james_thinking, label: "Deep in thought", className: "object-left" },
-  {
-    src: mike_morning_neck_exercise,
-    label: "CEO + CTO",
-    className: "object-left",
-  },
-  { src: yardwork, label: "Caffeinated" },
-];
-
 type PageProps = {
   params: {
     locale: string;
@@ -150,6 +122,9 @@ export default async function Page({ params }: PageProps) {
   const founderStoryTitle = t("FounderStory.title");
   const founderTitle = t("Founder.title");
   const founderSubtitle = t("Founder.subtitle");
+  const teamTitle = t("Team.title");
+  const teamIntro = t("Team.intro");
+  const teamCtaLabel = t("Team.cta");
 
   const fallbackMessages = locale === "en" ? undefined : await loadMessages("en");
 
@@ -171,6 +146,22 @@ export default async function Page({ params }: PageProps) {
 
   const founderStoryBody = formatFounderBody(founderStoryBodyCopy ?? "");
   const founderBody = formatFounderBody(founderBodyCopy ?? "");
+  const teamMembersData = [
+    { key: "yergush", image: "/images/NewTeam/gush.JPG" },
+    { key: "david", image: "/images/NewTeam/david.png" },
+    { key: "tim", image: "/images/NewTeam/tim.png" },
+    { key: "sara", image: "/images/NewTeam/sara.png" },
+    { key: "jasper", image: "/images/NewTeam/jasper.png" },
+    { key: "chiHueng", image: "/images/NewTeam/Chi-hueng.png" },
+    { key: "aiAgents", image: "/images/NewTeam/Aiagents.png" },
+  ] as const;
+
+  const teamMembers = teamMembersData.map(({ key, image }) => ({
+    key,
+    image,
+    name: t(`Team.members.${key}.name` as Parameters<typeof t>[0]),
+    description: t(`Team.members.${key}.description` as Parameters<typeof t>[0]),
+  }));
 
   const values = [
     {
@@ -277,27 +268,25 @@ export default async function Page({ params }: PageProps) {
             </div>
           </div>
           <SectionTitle
-            className="mt-80"
+            className="mt-60"
             align="center"
-            title="Meet the team"
-            text="Although we collaborate as a fully remote team, we like to unite for regular offsites. Here are a few moments from our most recent:"
+            title={teamTitle}
+            text={teamIntro}
           />
-          <div className="grid about-image-grid grid-cols-1 md:grid-cols-3 xl:grid-cols-5 gap-4 mt-[62px] w-full xl:w-[calc(100dvw-10rem)]">
-            {offsiteImages.map(({ src, label, className }) => {
-              return (
-                <div key={label} className="image w-full h-[400px] rounded-lg relative">
-                  <PhotoLabel
-                    className="absolute bottom-[40px] left-1/2 transform -translate-x-1/2"
-                    text={label}
-                  />
-                  <ImageWithBlur
-                    src={src}
-                    alt={label}
-                    className={cn("object-cover w-full h-full rounded-lg", className)}
-                  />
-                </div>
-              );
-            })}
+          <div className="mt-12 grid w-full gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {teamMembers.map((member) => (
+              <TeamMemberCard
+                key={member.key}
+                name={member.name}
+                description={member.description}
+                image={member.image}
+              />
+            ))}
+          </div>
+          <div className="mt-10 flex justify-center">
+            <Link href={`/${locale}/careers`}>
+              <RainbowDarkButton label={teamCtaLabel} />
+            </Link>
           </div>
 
           <div className="relative w-screen max-w-full">
@@ -549,15 +538,28 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function PhotoLabel({ text, className }: { text: string; className: string }) {
+type TeamMemberCardProps = {
+  name: string;
+  description: string;
+  image: string;
+};
+
+function TeamMemberCard({ name, description, image }: TeamMemberCardProps) {
   return (
-    <div
-      className={cn(
-        className,
-        "bg-gradient-to-r from-black/70 to-black/40 px-4 py-1.5 rounded-[6px] backdrop-blur-md border-[0.75px] border-white/20 min-w-[140px] flex justify-center",
-      )}
-    >
-      <p className="text-xs text-white">{text}</p>
+    <div className="group flex flex-col gap-4 rounded-3xl border border-white/10 bg-white/[0.04] p-6 transition-all duration-300 hover:-translate-y-1 hover:border-white/20 hover:bg-white/[0.08]">
+      <div className="flex items-center gap-4">
+        <div className="relative h-16 w-16 overflow-hidden rounded-2xl border border-white/15 bg-white/10">
+          <Image
+            src={image}
+            alt={name}
+            width={64}
+            height={64}
+            className="h-full w-full object-cover"
+          />
+        </div>
+        <h3 className="text-lg font-semibold text-white">{name}</h3>
+      </div>
+      <p className="text-sm leading-6 text-white/70">{description}</p>
     </div>
   );
 }

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -221,6 +221,41 @@
       "subtitle": "Why we started TransformAI",
       "body": "Hi, my name is Yergush. I founded TransformAI after seeing how many organizations struggled with the complexity and pace of AI adoption. I wanted to help build a future where businesses can truly harness the power of AI.\n\nWith TransformAI, we’re heading in the right direction. It’s inspiring to see our team grow with such talented people and to witness the impact of the projects we’ve already delivered. At the same time, there is still so much more to achieve — and that excites me. I look forward to working with future partners to keep building the future, together."
     },
+    "Team": {
+      "title": "Meet our team",
+      "intro": "The compactness of this team is our biggest strength, we are able to ship super fast and with excellent quality. Our team members have 10x higher productivity than employees in similar jobs who use AI, and 52x higher productivity compared to fellows who don’t use AI. Everybody is super all-round, and also specialized in certain areas at the same time, creating a high-performance environment on which I am super proud. — Yergush",
+      "members": {
+        "yergush": {
+          "name": "Yergush",
+          "description": "The founder of the company who ensures that the value is retained within the organisation, and makes sure that the quality delivered is nothing less than excellent. Besides managing, his primary focus is on improving current products and services."
+        },
+        "david": {
+          "name": "David",
+          "description": "The lead in exploring AI capabilities. David is constantly testing and collecting resources on the capabilities of AI systems. David also focuses on testing and creating custom integrations for companies."
+        },
+        "tim": {
+          "name": "Tim",
+          "description": "Tim has prior experience in working in transforming corporate organisations. His knowledge is essential in finding practical solutions for companies → real world use cases. He is specialised in integrating transformation into businesses."
+        },
+        "sara": {
+          "name": "Sara",
+          "description": "Sara is the head of Branding and Marketing. She is responsible for branding TransformAI. In the process she uses primarily AI, and this practical knowledge of implementing AI in everyday workflows especially branding and marketing makes her an essential part of the team."
+        },
+        "jasper": {
+          "name": "Jasper",
+          "description": "Jasper is the head of engineering and data analysis. He is an expert in handling complex engineering cases including the ones regarding data processing. He is a master in leveraging AI into software engineering tasks."
+        },
+        "chiHueng": {
+          "name": "Chi-hueng",
+          "description": "Chi-hueng is our head of the research department, researching both creating new AI use cases using custom models, and together with Jasper he handles the data analysis part of both processes and other research like sector adaptation by AI. Automating most pipelines."
+        },
+        "aiAgents": {
+          "name": "AI AGENTS",
+          "description": "Having AI as employees is a quite new phenomenon, and although they cannot handle most things autonomously yet, they are a valuable asset to the company and therefore worth mentioning. We have created systems powered by AI, which act as an employee and make our workflow so efficient meaning we can keep a compact team."
+        }
+      },
+      "cta": "Want to join our team?"
+    },
     "FAQ": {
       "q1": {
         "title": "What’s your goal with TransformAI?",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -221,6 +221,41 @@
       "subtitle": "Waarom we TransformAI zijn gestart",
       "body": "Hallo, mijn naam is Yergush. Ik heb TransformAI opgericht nadat ik zag hoe veel organisaties worstelden met de complexiteit en het tempo van AI-adoptie. Ik wilde bijdragen aan een toekomst waarin bedrijven de kracht van AI echt kunnen benutten.\n\nMet TransformAI zetten we de juiste stappen. Het is inspirerend om ons team te zien groeien met zoveel talent en om het resultaat van onze projecten terug te zien bij onze klanten. Tegelijkertijd ligt er nog een enorme weg voor ons — en dat maakt mij enthousiast. Ik kijk ernaar uit om samen met toekomstige partners verder te bouwen aan de toekomst."
     },
+    "Team": {
+      "title": "Ontmoet ons team",
+      "intro": "De compactheid van dit team is onze grootste kracht: we kunnen supersnel leveren met uitstekende kwaliteit. Onze teamleden zijn 10x productiever dan werknemers in soortgelijke functies die AI gebruiken, en 52x productiever dan collega’s die geen AI gebruiken. Iedereen is veelzijdig en tegelijkertijd gespecialiseerd in bepaalde gebieden, wat een high-performance omgeving creëert waar ik enorm trots op ben. — Yergush",
+      "members": {
+        "yergush": {
+          "name": "Yergush",
+          "description": "De oprichter van het bedrijf die ervoor zorgt dat de waarde binnen de organisatie behouden blijft en dat de kwaliteit van het geleverde niets minder dan uitstekend is. Naast managen richt hij zich primair op het verbeteren van de huidige producten en diensten."
+        },
+        "david": {
+          "name": "David",
+          "description": "De leider in het verkennen van AI-mogelijkheden. David test en verzamelt voortdurend bronnen over de capaciteiten van AI-systemen. Hij richt zich ook op het testen en creëren van maatwerk-integraties voor bedrijven."
+        },
+        "tim": {
+          "name": "Tim",
+          "description": "Tim heeft eerdere ervaring in het transformeren van grote organisaties. Zijn kennis is essentieel om praktische oplossingen voor bedrijven te vinden → echte use cases. Hij is gespecialiseerd in het integreren van transformatie in bedrijfsprocessen."
+        },
+        "sara": {
+          "name": "Sara",
+          "description": "Sara is hoofd Branding en Marketing. Zij is verantwoordelijk voor de branding van TransformAI. Daarbij maakt zij vooral gebruik van AI, en haar praktische kennis van het implementeren van AI in dagelijkse workflows – vooral branding en marketing – maakt haar een essentieel onderdeel van het team."
+        },
+        "jasper": {
+          "name": "Jasper",
+          "description": "Jasper is hoofd engineering en data-analyse. Hij is expert in het omgaan met complexe technische vraagstukken, waaronder dataverwerking. Hij is meester in het inzetten van AI voor software-engineering taken."
+        },
+        "chiHueng": {
+          "name": "Chi-hueng",
+          "description": "Chi-hueng is hoofd van de onderzoeksafdeling. Hij onderzoekt zowel nieuwe AI use cases met custom modellen, als samen met Jasper de data-analyse van beide processen. Daarnaast doet hij ander onderzoek zoals sectoradaptatie door AI. Het meeste wordt geautomatiseerd."
+        },
+        "aiAgents": {
+          "name": "AI AGENTS",
+          "description": "Het hebben van AI als werknemers is een vrij nieuw fenomeen, en hoewel ze nog niet alles autonoom aankunnen, zijn ze een waardevolle aanwinst voor het bedrijf. Wij hebben systemen gecreëerd die door AI worden aangestuurd en die functioneren als een medewerker, waardoor onze workflow zo efficiënt is dat we een compact team kunnen behouden."
+        }
+      },
+      "cta": "Wil je ons team versterken?"
+    },
     "FAQ": {
       "q1": {
         "title": "Wat is jullie doel met TransformAI?",


### PR DESCRIPTION
## Summary
- replace the legacy offsite photo gallery with a compact translated team section on the About page
- add localized copy for every team member plus the CTA button that routes to the careers page
- store the new English and Dutch strings and log the change in WRITE_HERE/UPDATES

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: existing lint violations unrelated to this change)*
- `pnpm -w turbo run build --filter=www` *(fails: existing lint violations unrelated to this change)*

## Plan
- audit the current About page implementation and remove the offsite gallery block
- add a responsive grid that uses the provided headshots and localized descriptions
- wire up new translation keys for English and Dutch and surface the CTA button
- verify layout responsiveness and run the standard www typecheck/lint/build commands

------
https://chatgpt.com/codex/tasks/task_e_68d3ff188c74832abb6994f4cdac0dc6