### PR TITLE
Update founder signature to highlight CEO Yergush

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-22T2005--updated-founder-signature.md
+++ b/WRITE_HERE/UPDATES/2025-11-22T2005--updated-founder-signature.md
@@ -1,0 +1,5 @@
+# Updated founder signature to feature CEO Yergush
+- **What:** Replaced the dual founder signature block on the About page with a single profile for CEO Yergush and wired in the current headshot from the NewTeam image set.
+- **Why:** Reflect the leadership request to highlight Yergush as the face of TransformAI and remove references to the legacy Unkey founders.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`.
+- **Follow-ups:** Reconfirm spacing once other About page sections are refreshed and update translations if additional leadership roles change.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -50,8 +50,6 @@ import allison from "@/images/about/investors/allison5.png";
 import liu from "@/images/about/investors/liujiang.jpeg";
 import tim from "@/images/about/investors/tim.png";
 
-import andreas from "@/images/team/andreas.jpeg";
-import james from "@/images/team/james.jpg";
 
 import { ImageWithBlur } from "@/components/image-with-blur";
 import { loadMessages } from "@/i18n/messages";
@@ -324,28 +322,17 @@ export default async function Page({ params }: PageProps) {
             />
             <div className="border-[1px] border-white/10 mt-[78px] leading-8 rounded-[48px] py-[60px] xl:py-[96px] px-8 md:px-[88px] text-white text-center max-w-[1008px] flex flex-col justify-center items-center">
               <p className="about-founders-text-gradient">{founderBody}</p>
-              <div className="flex flex-col mt-12 md:flex-row">
-                <div className="flex md:left-[5px]">
-                  <div className="text-sm text-right">
-                    <p className="font-bold">James Perkins</p>
-                    <p className="text-white/50">Founder and CEO</p>
-                  </div>
-                  <ImageWithBlur
-                    src={james}
-                    className="border-2 border-black ml-4 md:ml-[32px] rounded-full h-[40px] w-[40px]"
-                    alt="CEO James"
-                  />
-                </div>
-                <div className="flex relative mt-4 md:mt-0 lg:left-[-5px]">
-                  <ImageWithBlur
-                    src={andreas}
-                    alt="CTO Andreas"
-                    className="border-2 border-black mr-4 md:mr-[32px] rounded-full h-[40px] w-[40px]"
-                  />
-                  <div className="text-sm text-left">
-                    <p className="font-bold">Andreas Thomas</p>
-                    <p className="text-white/50">Founder and CTO</p>
-                  </div>
+              <div className="mt-12 flex flex-col items-center">
+                <ImageWithBlur
+                  src="/images/NewTeam/gush.JPG"
+                  width={128}
+                  height={128}
+                  alt="CEO Yergush"
+                  className="h-[64px] w-[64px] rounded-full border-2 border-black"
+                />
+                <div className="mt-4 text-center text-sm">
+                  <p className="font-bold">Yergush</p>
+                  <p className="text-white/50">Founder and CEO</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- replace the About page founder signature block with a single entry for CEO Yergush
- remove the legacy Unkey founder image imports and point the signature to the new NewTeam headshot
- log the content refresh in WRITE_HERE/UPDATES for continuity

## Plan
- Update the About page signature layout to reflect the current leadership structure
- Wire the signature image to the provided /images/NewTeam/gush.JPG asset and tidy unused imports
- Capture the content change in WRITE_HERE/UPDATES and run the standard repo checks

## Testing
- pnpm --filter www run typecheck *(fails: repository currently lacks next-intl type declarations; see command output)*
- pnpm --filter www run lint *(fails: existing lint violations in other sections, unchanged by this PR)*
- pnpm -w turbo run build --filter=www *(fails: same lint violations surface during build)*

------
https://chatgpt.com/codex/tasks/task_e_68d40ef4e9e8832aa7c69767ccafd342