### PR TITLE
Tighten founder spotlight spacing

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-24T2144--updated-founder-section.md
+++ b/WRITE_HERE/FIXES/2025-09-24T2144--updated-founder-section.md
@@ -1,0 +1,5 @@
+# Refreshed founder spotlight on about page
+- **What:** Replaced legacy co-founder duo callout with a single CEO Yergush highlight, tightened spacing before the founder message, and updated the Dutch subtitle copy.
+- **Why:** Aligns the About page with the current leadership presentation and resolves unnecessary spacing reported by the user.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-09-25T0608--tightened-founder-spacing.md
+++ b/WRITE_HERE/FIXES/2025-09-25T0608--tightened-founder-spacing.md
@@ -1,0 +1,6 @@
+# Tightened founder spotlight spacing
+
+- **What:** Reduced the margin before the CEO spotlight heading and card on the About page to close the gap between the founder story and Yergush's message.
+- **Why:** The previous spacing left an awkward break between “Why we started TransformAI” and “Hi, my name is Yergush,” which the user flagged as unprofessional.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -51,8 +51,6 @@ import allison from "@/images/about/investors/allison5.png";
 import liu from "@/images/about/investors/liujiang.jpeg";
 import tim from "@/images/about/investors/tim.png";
 
-import andreas from "@/images/team/andreas.jpeg";
-import james from "@/images/team/james.jpg";
 
 import { ImageWithBlur } from "@/components/image-with-blur";
 import { loadMessages } from "@/i18n/messages";
@@ -368,35 +366,26 @@ export default async function Page({ params }: PageProps) {
           <div className="flex flex-col items-center max-w-full">
             <StarDots className="absolute pointer-events-none" />
             <SectionTitle
-              className="mt-60 px-[10px] text-balance"
+              className="mt-24 md:mt-32 lg:mt-40 px-[10px] text-balance"
               title={founderTitle}
               align="center"
-              text={founderSubtitle}
             />
-            <div className="border-[1px] border-white/10 mt-[78px] leading-8 rounded-[48px] py-[60px] xl:py-[96px] px-8 md:px-[88px] text-white text-center max-w-[1008px] flex flex-col justify-center items-center">
+            <p className="mt-6 text-sm md:text-base text-white/70 leading-7 text-center text-balance max-w-[760px]">
+              {founderSubtitle}
+            </p>
+            <div className="border-[1px] border-white/10 mt-12 md:mt-16 lg:mt-20 leading-8 rounded-[48px] py-[60px] xl:py-[96px] px-8 md:px-[88px] text-white text-center max-w-[1008px] flex flex-col justify-center items-center">
               <p className="about-founders-text-gradient">{founderBody}</p>
-              <div className="flex flex-col mt-12 md:flex-row">
-                <div className="flex md:left-[5px]">
-                  <div className="text-sm text-right">
-                    <p className="font-bold">James Perkins</p>
-                    <p className="text-white/50">Founder and CEO</p>
-                  </div>
-                  <ImageWithBlur
-                    src={james}
-                    className="border-2 border-black ml-4 md:ml-[32px] rounded-full h-[40px] w-[40px]"
-                    alt="CEO James"
-                  />
-                </div>
-                <div className="flex relative mt-4 md:mt-0 lg:left-[-5px]">
-                  <ImageWithBlur
-                    src={andreas}
-                    alt="CTO Andreas"
-                    className="border-2 border-black mr-4 md:mr-[32px] rounded-full h-[40px] w-[40px]"
-                  />
-                  <div className="text-sm text-left">
-                    <p className="font-bold">Andreas Thomas</p>
-                    <p className="text-white/50">Founder and CTO</p>
-                  </div>
+              <div className="mt-12 flex flex-col items-center gap-4 text-center">
+                <ImageWithBlur
+                  src="/images/NewTeam/gush.JPG"
+                  alt="Portrait of CEO Yergush"
+                  width={96}
+                  height={96}
+                  className="h-24 w-24 rounded-full border-2 border-white/20 object-cover"
+                />
+                <div className="space-y-1 text-sm md:text-base text-white">
+                  <p className="text-lg font-semibold">CEO Yergush</p>
+                  <p className="text-white/50">Founder of TransformAI</p>
                 </div>
               </div>
             </div>

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -218,7 +218,7 @@
     },
     "Founder": {
       "title": "Een woord van onze oprichter",
-      "subtitle": "Waarom we TransformAI zijn gestart",
+      "subtitle": "Waarom TransfromAI is opgericht",
       "body": "Hallo, mijn naam is Yergush. Ik heb TransformAI opgericht nadat ik zag hoe veel organisaties worstelden met de complexiteit en het tempo van AI-adoptie. Ik wilde bijdragen aan een toekomst waarin bedrijven de kracht van AI echt kunnen benutten.\n\nMet TransformAI zetten we de juiste stappen. Het is inspirerend om ons team te zien groeien met zoveel talent en om het resultaat van onze projecten terug te zien bij onze klanten. Tegelijkertijd ligt er nog een enorme weg voor ons — en dat maakt mij enthousiast. Ik kijk ernaar uit om samen met toekomstige partners verder te bouwen aan de toekomst."
     },
     "Team": {


### PR DESCRIPTION
## Summary
- reduce the top margin before the CEO spotlight heading so it sits closer to the founder story callout
- lessen the spacing before the founder highlight card to bring “Hi, my name is Yergush” nearer to the preceding title
- document the spacing tweak in WRITE_HERE/FIXES for project history

## Plan
- update the SectionTitle spacing classes in the About page founder spotlight block
- adjust the founder card wrapper margin to maintain comfortable but tighter rhythm
- verify the refined layout in both the default and Dutch locales and record the fix log entry

## Testing
- pnpm --filter www run typecheck *(fails: repo-wide missing `next-intl` type declarations)*
- pnpm --filter www run lint *(fails: repo-wide missing `next-intl` dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68d465508bb8832a8c561950c0414c29