### PR TITLE
Include nested blog posts in content collection

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-23T0900--enabled-nested-blog-posts.md
+++ b/WRITE_HERE/UPDATES/2025-11-23T0900--enabled-nested-blog-posts.md
@@ -1,0 +1,5 @@
+# Enabled nested blog post discovery
+- **What:** Updated the blog content collection to index MDX files recursively and normalize each post slug/url to the file name so entries inside subdirectories surface across the site.
+- **Why:** New project folders under `content/blog` were invisible because only top-level MDX files were collected.
+- **Files:** `apps/www/content-collections.ts`.
+- **Follow-ups:** Consider updating blog metadata URLs to include the `/blog` prefix for consistency.

--- a/apps/www/content-collections.ts
+++ b/apps/www/content-collections.ts
@@ -9,7 +9,7 @@ import { takeawaysSchema } from "./lib/schemas/takeaways-schema";
 const posts = defineCollection({
   name: "posts",
   directory: "content/blog",
-  include: "*.mdx",
+  include: "**/*.mdx",
   schema: (z) => ({
     title: z.string(),
     description: z.string(),
@@ -36,8 +36,8 @@ const posts = defineCollection({
     return {
       ...document,
       mdx,
-      slug: document._meta.path,
-      url: `/blog/${document._meta.path}`,
+      slug: document._meta.fileName,
+      url: `/blog/${document._meta.fileName}`,
       tableOfContents,
     };
   },


### PR DESCRIPTION
## Plan
- Expand the blog content collection glob so nested folders are indexed.
- Normalize generated slugs/URLs to remain compatible with the existing single-segment blog route.
- Document the content change in the updates log and run the usual www checks.

## Summary
- Allow the blog content collector to include MDX files in subdirectories while keeping per-post metadata intact.
- Derive blog slugs/URLs from each file name so nested entries still map onto the `/blog/[slug]` route.
- Logged the repository change in WRITE_HERE/UPDATES for project continuity.

## Testing
- `pnpm --filter www run typecheck` *(fails: missing `next-intl` type declarations in the baseline project)*
- `pnpm --filter www run lint` *(fails: baseline cannot resolve the `next-intl` package referenced from Next config)*

------
https://chatgpt.com/codex/tasks/task_e_68d52066bfa8832ab0908bdb89ae0232