### PR TITLE
Fix AI adoption blog author slugs

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-23T1000--restored-nested-blog-author-mapping.md
+++ b/WRITE_HERE/FIXES/2025-11-23T1000--restored-nested-blog-author-mapping.md
@@ -1,0 +1,6 @@
+# Restored nested blog posts by matching author keys
+
+- **What:** Normalized the author slug in the new English and Dutch AI adoption posts and removed stray metadata that blocked parsing.
+- **Why:** The blog grid expects lowercase author identifiers defined in `authors.ts`; mismatched casing plus an extra header prevented these posts from rendering.
+- **Files:** `apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/English/how-we-map-ai-adoption-across-industries.mdx`, `apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/Dutch/zo-meten-we-ai-adoptie-per-sector.mdx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/UPDATES/2025-11-23T0900--enabled-nested-blog-posts.md
+++ b/WRITE_HERE/UPDATES/2025-11-23T0900--enabled-nested-blog-posts.md
@@ -1,0 +1,5 @@
+# Enabled nested blog post discovery
+- **What:** Updated the blog content collection to index MDX files recursively and normalize each post slug/url to the file name so entries inside subdirectories surface across the site.
+- **Why:** New project folders under `content/blog` were invisible because only top-level MDX files were collected.
+- **Files:** `apps/www/content-collections.ts`.
+- **Follow-ups:** Consider updating blog metadata URLs to include the `/blog` prefix for consistency.

--- a/apps/www/content-collections.ts
+++ b/apps/www/content-collections.ts
@@ -9,7 +9,7 @@ import { takeawaysSchema } from "./lib/schemas/takeaways-schema";
 const posts = defineCollection({
   name: "posts",
   directory: "content/blog",
-  include: "*.mdx",
+  include: "**/*.mdx",
   schema: (z) => ({
     title: z.string(),
     description: z.string(),
@@ -36,8 +36,8 @@ const posts = defineCollection({
     return {
       ...document,
       mdx,
-      slug: document._meta.path,
-      url: `/blog/${document._meta.path}`,
+      slug: document._meta.fileName,
+      url: `/blog/${document._meta.fileName}`,
       tableOfContents,
     };
   },

--- a/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/Dutch/zo-meten-we-ai-adoptie-per-sector.mdx
+++ b/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/Dutch/zo-meten-we-ai-adoptie-per-sector.mdx
@@ -1,10 +1,8 @@
-FILENAME: zo-meten-we-ai-adoptie-per-sector.mdx
-
 ---
 date: 2025-09-25
 title: "Zo meten we AI-adoptie per sector"
 description: "Ons onderzoek laat zien waar, hoe snel en hoe diep AI wordt ingevoerd per sector. We kwantificeren resultaten en signaleren trends én afwijkingen met reproduceerbare methoden."
-author: Yergush
+author: yergush
 tags: ["projects","research","ai-adaptation","industry","metrics"]
 image: "/images/blog-images/mdxfilesforprojects/research/ai-adoptation/images/Maindisplay.png"
 ---

--- a/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/English/how-we-map-ai-adoption-across-industries.mdx
+++ b/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/English/how-we-map-ai-adoption-across-industries.mdx
@@ -2,7 +2,7 @@
 date: 2025-09-25
 title: "How We Map AI Adoption Across Industries"
 description: "Our research measures where, how fast, and how deeply AI is adopted across sectors, quantifying outcomes and surfacing trends and anomalies with reproducible methods."
-author: Yergush
+author: yergush
 tags: ["projects","research","ai-adaptation","industry","metrics"]
 image: "/images/blog-images/mdxfilesforprojects/research/ai-adoptation/images/Maindisplay.png"
 ---


### PR DESCRIPTION
## Plan
- Normalize the author identifiers in the new AI adoption blog posts so they match the existing author map.
- Remove stray metadata that prevented the Dutch post frontmatter from parsing cleanly.
- Document the remediation in the FIXES ledger and rerun the standard www checks.

## Summary
- Lowercased the `author` frontmatter in both English and Dutch AI adoption research posts so the blog grid can resolve the correct author profile.
- Removed an extraneous `FILENAME` line ahead of the Dutch post frontmatter to keep the MDX metadata readable.
- Logged the resolved issue in `WRITE_HERE/FIXES` for future traceability.

## Testing
- `pnpm --filter www run typecheck` *(fails: repository baseline is missing `next-intl` type declarations referenced throughout the app)*
- `pnpm --filter www run lint` *(fails: Next.js configuration cannot resolve the `next-intl` package in the baseline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d52066bfa8832ab0908bdb89ae0232