### PR TITLE
Fix nested blog slug regression

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-25T1135--blog-nested-slug-restore.md
+++ b/WRITE_HERE/FIXES/2025-09-25T1135--blog-nested-slug-restore.md
@@ -1,0 +1,5 @@
+# Restored nested blog post slugs
+- **What:** Recomputed blog post slugs from the `_meta.path` basename so nested MDX files render with the same extensionless URLs as top-level entries and adjusted metadata URLs to reuse the generated blog link.
+- **Why:** Switching the slug to the full filename added a `.mdx` suffix, breaking existing slug lookups (e.g., handpicked posts on the About page) and leaving the new research posts hidden even after the collection indexed their folders.
+- **Files:** `apps/www/content-collections.ts`, `apps/www/app/[locale]/(site)/blog/[slug]/page.tsx`.
+- **Follow-ups:** Consider adding a uniqueness safeguard if multiple posts ever share the same basename.

--- a/WRITE_HERE/FIXES/2025-11-23T1000--restored-nested-blog-author-mapping.md
+++ b/WRITE_HERE/FIXES/2025-11-23T1000--restored-nested-blog-author-mapping.md
@@ -1,0 +1,6 @@
+# Restored nested blog posts by matching author keys
+
+- **What:** Normalized the author slug in the new English and Dutch AI adoption posts and removed stray metadata that blocked parsing.
+- **Why:** The blog grid expects lowercase author identifiers defined in `authors.ts`; mismatched casing plus an extra header prevented these posts from rendering.
+- **Files:** `apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/English/how-we-map-ai-adoption-across-industries.mdx`, `apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/Dutch/zo-meten-we-ai-adoptie-per-sector.mdx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/UPDATES/2025-11-23T0900--enabled-nested-blog-posts.md
+++ b/WRITE_HERE/UPDATES/2025-11-23T0900--enabled-nested-blog-posts.md
@@ -1,0 +1,5 @@
+# Enabled nested blog post discovery
+- **What:** Updated the blog content collection to index MDX files recursively and normalize each post slug/url to the file name so entries inside subdirectories surface across the site.
+- **Why:** New project folders under `content/blog` were invisible because only top-level MDX files were collected.
+- **Files:** `apps/www/content-collections.ts`.
+- **Follow-ups:** Consider updating blog metadata URLs to include the `/blog` prefix for consistency.

--- a/WRITE_HERE/UPDATES/2025-11-23T1300--blog-language-filtering.md
+++ b/WRITE_HERE/UPDATES/2025-11-23T1300--blog-language-filtering.md
@@ -1,0 +1,5 @@
+# Filtered blog posts by locale language
+- **What:** Added a frontmatter `language` field for project blog posts, introduced helpers to normalize accepted language names, and filtered blog listings and article routes so content only appears for matching locales.
+- **Why:** Ensure Dutch and English blog variants surface in the correct localized experience while keeping unspecified posts visible everywhere.
+- **Files:** `apps/www/content-collections.ts`, `apps/www/lib/blog-language.ts`, `apps/www/app/[locale]/(site)/blog/page.tsx`, `apps/www/app/[locale]/(site)/blog/[slug]/page.tsx`, `apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/Dutch/zo-meten-we-ai-adoptie-per-sector.mdx`, `apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/English/how-we-map-ai-adoption-across-industries.mdx`.
+- **Follow-ups:** Consider extending the alias map when new locales are added so language-based filtering stays accurate.

--- a/apps/www/app/[locale]/(site)/blog/[slug]/page.tsx
+++ b/apps/www/app/[locale]/(site)/blog/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/back
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { MeteorLinesAngular } from "@/components/ui/meteorLines";
 import { authors } from "@/content/blog/authors";
+import { localesForPost, shouldIncludePostForLocale } from "@/lib/blog-language";
 import { cn } from "@/lib/utils";
 import { allPosts } from "content-collections";
 import type { Post } from "content-collections";
@@ -16,17 +17,20 @@ import { notFound } from "next/navigation";
 export const dynamic = "force-static";
 
 export const generateStaticParams = async () =>
-  allPosts.map((post) => ({
-    slug: post.slug,
-  }));
+  allPosts.flatMap((post) =>
+    localesForPost(post.language).map((locale) => ({
+      locale,
+      slug: post.slug,
+    })),
+  );
 
 export function generateMetadata({
   params,
 }: {
-  params: { slug: string };
+  params: { slug: string; locale: string };
 }): Metadata {
   const post = allPosts.find((post) => post.slug === `${params.slug}`);
-  if (!post) {
+  if (!post || !shouldIncludePostForLocale(post.language, params.locale)) {
     notFound();
   }
   return {
@@ -68,9 +72,13 @@ export function generateMetadata({
   };
 }
 
-const BlogArticleWrapper = async ({ params }: { params: { slug: string } }) => {
-  const post = allPosts.find((post) => post.slug === `${params.slug}`) as Post;
-  if (!post) {
+const BlogArticleWrapper = async ({
+  params,
+}: {
+  params: { slug: string; locale: string };
+}) => {
+  const post = allPosts.find((post) => post.slug === `${params.slug}`) as Post | undefined;
+  if (!post || !shouldIncludePostForLocale(post.language, params.locale)) {
     notFound();
   }
   const author = authors[post.author];

--- a/apps/www/app/[locale]/(site)/blog/[slug]/page.tsx
+++ b/apps/www/app/[locale]/(site)/blog/[slug]/page.tsx
@@ -37,7 +37,7 @@ export function generateMetadata({
       title: `${post.title} | Unkey`,
       description: post.description,
 
-      url: `https://unkey.com/${post._meta.path}`,
+      url: `https://unkey.com${post.url}`,
       siteName: "unkey.com",
       type: "article",
       images: {

--- a/apps/www/app/[locale]/(site)/blog/page.tsx
+++ b/apps/www/app/[locale]/(site)/blog/page.tsx
@@ -4,6 +4,7 @@ import { CTA } from "@/components/cta";
 import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/background-shiny";
 import { MeteorLinesAngular } from "@/components/ui/meteorLines";
 import { authors } from "@/content/blog/authors";
+import { shouldIncludePostForLocale } from "@/lib/blog-language";
 import { type Post, allPosts } from "content-collections";
 import Link from "next/link";
 
@@ -34,8 +35,16 @@ export const metadata = {
   },
 };
 
-export default async function Blog() {
-  const posts = allPosts.sort((a: Post, b: Post) => {
+export default async function Blog({
+  params,
+}: {
+  params: { locale: string };
+}) {
+  const filteredPosts = allPosts.filter((post) =>
+    shouldIncludePostForLocale(post.language, params.locale),
+  );
+
+  const posts = filteredPosts.sort((a: Post, b: Post) => {
     return new Date(b.date).getTime() - new Date(a.date).getTime();
   });
   const featuredPost = posts[0];

--- a/apps/www/content-collections.ts
+++ b/apps/www/content-collections.ts
@@ -16,6 +16,7 @@ const posts = defineCollection({
     author: z.string(),
     date: z.string(),
     tags: z.array(z.string()),
+    language: z.union([z.string(), z.array(z.string())]).optional(),
     image: z.string().optional(),
   }),
   transform: async (document, context) => {

--- a/apps/www/content-collections.ts
+++ b/apps/www/content-collections.ts
@@ -9,7 +9,7 @@ import { takeawaysSchema } from "./lib/schemas/takeaways-schema";
 const posts = defineCollection({
   name: "posts",
   directory: "content/blog",
-  include: "*.mdx",
+  include: "**/*.mdx",
   schema: (z) => ({
     title: z.string(),
     description: z.string(),
@@ -33,11 +33,14 @@ const posts = defineCollection({
         slug: content ? slugger.slug(content) : undefined,
       };
     });
+    const slugFromPath =
+      document._meta.path.split("/").pop() ?? document._meta.fileName.replace(/\.mdx$/i, "");
+
     return {
       ...document,
       mdx,
-      slug: document._meta.path,
-      url: `/blog/${document._meta.path}`,
+      slug: slugFromPath,
+      url: `/blog/${slugFromPath}`,
       tableOfContents,
     };
   },

--- a/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/Dutch/zo-meten-we-ai-adoptie-per-sector.mdx
+++ b/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/Dutch/zo-meten-we-ai-adoptie-per-sector.mdx
@@ -5,6 +5,13 @@ description: "Ons onderzoek laat zien waar, hoe snel en hoe diep AI wordt ingevo
 author: yergush
 tags: ["projects","research","ai-adaptation","industry","metrics"]
 image: "/images/blog-images/mdxfilesforprojects/research/ai-adoptation/images/Maindisplay.png"
+language:
+  - Dutch
+  - dutch
+  - Nederlands
+  - nederlands
+  - Nederland
+  - nederland
 ---
 # Zo meten we AI-adoptie per sector
 

--- a/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/Dutch/zo-meten-we-ai-adoptie-per-sector.mdx
+++ b/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/Dutch/zo-meten-we-ai-adoptie-per-sector.mdx
@@ -1,10 +1,8 @@
-FILENAME: zo-meten-we-ai-adoptie-per-sector.mdx
-
 ---
 date: 2025-09-25
 title: "Zo meten we AI-adoptie per sector"
 description: "Ons onderzoek laat zien waar, hoe snel en hoe diep AI wordt ingevoerd per sector. We kwantificeren resultaten en signaleren trends én afwijkingen met reproduceerbare methoden."
-author: Yergush
+author: yergush
 tags: ["projects","research","ai-adaptation","industry","metrics"]
 image: "/images/blog-images/mdxfilesforprojects/research/ai-adoptation/images/Maindisplay.png"
 ---

--- a/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/English/how-we-map-ai-adoption-across-industries.mdx
+++ b/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/English/how-we-map-ai-adoption-across-industries.mdx
@@ -5,6 +5,9 @@ description: "Our research measures where, how fast, and how deeply AI is adopte
 author: yergush
 tags: ["projects","research","ai-adaptation","industry","metrics"]
 image: "/images/blog-images/mdxfilesforprojects/research/ai-adoptation/images/Maindisplay.png"
+language:
+  - English
+  - english
 ---
 # How We Map AI Adoption Across Industries
 

--- a/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/English/how-we-map-ai-adoption-across-industries.mdx
+++ b/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/English/how-we-map-ai-adoption-across-industries.mdx
@@ -2,7 +2,7 @@
 date: 2025-09-25
 title: "How We Map AI Adoption Across Industries"
 description: "Our research measures where, how fast, and how deeply AI is adopted across sectors, quantifying outcomes and surfacing trends and anomalies with reproducible methods."
-author: Yergush
+author: yergush
 tags: ["projects","research","ai-adaptation","industry","metrics"]
 image: "/images/blog-images/mdxfilesforprojects/research/ai-adoptation/images/Maindisplay.png"
 ---

--- a/apps/www/lib/blog-language.ts
+++ b/apps/www/lib/blog-language.ts
@@ -1,0 +1,45 @@
+import { locales } from "@/i18n/routing";
+
+type PostLanguage = string | string[] | undefined;
+
+const LANGUAGE_ALIASES: Record<string, Set<string>> = {
+  en: new Set(["english"]),
+  nl: new Set(["dutch", "nederlands", "nederland"]),
+};
+
+function normalizeLanguageValues(language: PostLanguage) {
+  if (!language) {
+    return [];
+  }
+
+  const values = Array.isArray(language) ? language : [language];
+
+  return values
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0);
+}
+
+export function shouldIncludePostForLocale(language: PostLanguage, locale?: string) {
+  if (!locale) {
+    return true;
+  }
+
+  const normalizedLocale = locale.trim().toLowerCase();
+  const allowedLanguages = LANGUAGE_ALIASES[normalizedLocale];
+
+  if (!allowedLanguages) {
+    return true;
+  }
+
+  const normalizedLanguages = normalizeLanguageValues(language);
+
+  if (normalizedLanguages.length === 0) {
+    return true;
+  }
+
+  return normalizedLanguages.some((value) => allowedLanguages.has(value));
+}
+
+export function localesForPost(language: PostLanguage) {
+  return locales.filter((locale) => shouldIncludePostForLocale(language, locale));
+}


### PR DESCRIPTION
## Plan
- Revisit the blog content collection transform to derive slugs that work for nested MDX files without breaking existing URLs.
- Update any downstream consumers that relied on the previous slug shape so metadata and links stay canonical.
- Verify the generated content data, run the www quality checks, and document the fix in the repository log.

## Summary
- Recomputed blog post slugs from the `_meta.path` basename so nested MDX files surface with extensionless URLs while preserving compatibility with existing slug lookups. 【F:apps/www/content-collections.ts†L23-L40】
- Pointed blog post metadata to the generated blog URL to keep canonical links intact for nested posts. 【F:apps/www/app/[locale]/(site)/blog/[slug]/page.tsx†L40-L87】
- Logged the regression fix and follow-up in the FIXES ledger for future reference. 【F:WRITE_HERE/FIXES/2025-09-25T1135--blog-nested-slug-restore.md†L1-L5】

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: existing lint violations in the baseline unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d52066bfa8832ab0908bdb89ae0232