### PR TITLE
Filter blog posts by locale language

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-23T1300--blog-language-filtering.md
+++ b/WRITE_HERE/UPDATES/2025-11-23T1300--blog-language-filtering.md
@@ -1,0 +1,5 @@
+# Filtered blog posts by locale language
+- **What:** Added a frontmatter `language` field for project blog posts, introduced helpers to normalize accepted language names, and filtered blog listings and article routes so content only appears for matching locales.
+- **Why:** Ensure Dutch and English blog variants surface in the correct localized experience while keeping unspecified posts visible everywhere.
+- **Files:** `apps/www/content-collections.ts`, `apps/www/lib/blog-language.ts`, `apps/www/app/[locale]/(site)/blog/page.tsx`, `apps/www/app/[locale]/(site)/blog/[slug]/page.tsx`, `apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/Dutch/zo-meten-we-ai-adoptie-per-sector.mdx`, `apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/English/how-we-map-ai-adoption-across-industries.mdx`.
+- **Follow-ups:** Consider extending the alias map when new locales are added so language-based filtering stays accurate.

--- a/apps/www/app/[locale]/(site)/blog/[slug]/page.tsx
+++ b/apps/www/app/[locale]/(site)/blog/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/back
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { MeteorLinesAngular } from "@/components/ui/meteorLines";
 import { authors } from "@/content/blog/authors";
+import { localesForPost, shouldIncludePostForLocale } from "@/lib/blog-language";
 import { cn } from "@/lib/utils";
 import { allPosts } from "content-collections";
 import type { Post } from "content-collections";
@@ -16,17 +17,20 @@ import { notFound } from "next/navigation";
 export const dynamic = "force-static";
 
 export const generateStaticParams = async () =>
-  allPosts.map((post) => ({
-    slug: post.slug,
-  }));
+  allPosts.flatMap((post) =>
+    localesForPost(post.language).map((locale) => ({
+      locale,
+      slug: post.slug,
+    })),
+  );
 
 export function generateMetadata({
   params,
 }: {
-  params: { slug: string };
+  params: { slug: string; locale: string };
 }): Metadata {
   const post = allPosts.find((post) => post.slug === `${params.slug}`);
-  if (!post) {
+  if (!post || !shouldIncludePostForLocale(post.language, params.locale)) {
     notFound();
   }
   return {
@@ -68,9 +72,13 @@ export function generateMetadata({
   };
 }
 
-const BlogArticleWrapper = async ({ params }: { params: { slug: string } }) => {
-  const post = allPosts.find((post) => post.slug === `${params.slug}`) as Post;
-  if (!post) {
+const BlogArticleWrapper = async ({
+  params,
+}: {
+  params: { slug: string; locale: string };
+}) => {
+  const post = allPosts.find((post) => post.slug === `${params.slug}`) as Post | undefined;
+  if (!post || !shouldIncludePostForLocale(post.language, params.locale)) {
     notFound();
   }
   const author = authors[post.author];

--- a/apps/www/app/[locale]/(site)/blog/page.tsx
+++ b/apps/www/app/[locale]/(site)/blog/page.tsx
@@ -4,6 +4,7 @@ import { CTA } from "@/components/cta";
 import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/background-shiny";
 import { MeteorLinesAngular } from "@/components/ui/meteorLines";
 import { authors } from "@/content/blog/authors";
+import { shouldIncludePostForLocale } from "@/lib/blog-language";
 import { type Post, allPosts } from "content-collections";
 import Link from "next/link";
 
@@ -34,8 +35,16 @@ export const metadata = {
   },
 };
 
-export default async function Blog() {
-  const posts = allPosts.sort((a: Post, b: Post) => {
+export default async function Blog({
+  params,
+}: {
+  params: { locale: string };
+}) {
+  const filteredPosts = allPosts.filter((post) =>
+    shouldIncludePostForLocale(post.language, params.locale),
+  );
+
+  const posts = filteredPosts.sort((a: Post, b: Post) => {
     return new Date(b.date).getTime() - new Date(a.date).getTime();
   });
   const featuredPost = posts[0];

--- a/apps/www/content-collections.ts
+++ b/apps/www/content-collections.ts
@@ -16,6 +16,7 @@ const posts = defineCollection({
     author: z.string(),
     date: z.string(),
     tags: z.array(z.string()),
+    language: z.union([z.string(), z.array(z.string())]).optional(),
     image: z.string().optional(),
   }),
   transform: async (document, context) => {

--- a/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/Dutch/zo-meten-we-ai-adoptie-per-sector.mdx
+++ b/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/Dutch/zo-meten-we-ai-adoptie-per-sector.mdx
@@ -5,6 +5,13 @@ description: "Ons onderzoek laat zien waar, hoe snel en hoe diep AI wordt ingevo
 author: yergush
 tags: ["projects","research","ai-adaptation","industry","metrics"]
 image: "/images/blog-images/mdxfilesforprojects/research/ai-adoptation/images/Maindisplay.png"
+language:
+  - Dutch
+  - dutch
+  - Nederlands
+  - nederlands
+  - Nederland
+  - nederland
 ---
 # Zo meten we AI-adoptie per sector
 

--- a/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/English/how-we-map-ai-adoption-across-industries.mdx
+++ b/apps/www/content/blog/mdxfilesforprojects/research/ai-adoptation/posts/English/how-we-map-ai-adoption-across-industries.mdx
@@ -5,6 +5,9 @@ description: "Our research measures where, how fast, and how deeply AI is adopte
 author: yergush
 tags: ["projects","research","ai-adaptation","industry","metrics"]
 image: "/images/blog-images/mdxfilesforprojects/research/ai-adoptation/images/Maindisplay.png"
+language:
+  - English
+  - english
 ---
 # How We Map AI Adoption Across Industries
 

--- a/apps/www/lib/blog-language.ts
+++ b/apps/www/lib/blog-language.ts
@@ -1,0 +1,45 @@
+import { locales } from "@/i18n/routing";
+
+type PostLanguage = string | string[] | undefined;
+
+const LANGUAGE_ALIASES: Record<string, Set<string>> = {
+  en: new Set(["english"]),
+  nl: new Set(["dutch", "nederlands", "nederland"]),
+};
+
+function normalizeLanguageValues(language: PostLanguage) {
+  if (!language) {
+    return [];
+  }
+
+  const values = Array.isArray(language) ? language : [language];
+
+  return values
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0);
+}
+
+export function shouldIncludePostForLocale(language: PostLanguage, locale?: string) {
+  if (!locale) {
+    return true;
+  }
+
+  const normalizedLocale = locale.trim().toLowerCase();
+  const allowedLanguages = LANGUAGE_ALIASES[normalizedLocale];
+
+  if (!allowedLanguages) {
+    return true;
+  }
+
+  const normalizedLanguages = normalizeLanguageValues(language);
+
+  if (normalizedLanguages.length === 0) {
+    return true;
+  }
+
+  return normalizedLanguages.some((value) => allowedLanguages.has(value));
+}
+
+export function localesForPost(language: PostLanguage) {
+  return locales.filter((locale) => shouldIncludePostForLocale(language, locale));
+}


### PR DESCRIPTION
## Summary
- add optional language metadata to blog posts and populate values for the Dutch and English AI adoption articles
- introduce a locale-aware helper that normalizes accepted language aliases and reuse it in blog listing and detail routes
- filter blog content by the current locale so localized pages surface the correct variant and log the change in WRITE_HERE

## Plan
- extend the blog content collection schema to accept language metadata
- capture the locale-to-language alias mapping in a shared utility
- apply the helper to filter the blog index and article routes by locale while updating MDX frontmatter
- record the work in WRITE_HERE/UPDATES for project visibility

## Testing
- pnpm --filter www run lint *(fails: existing lint errors in unrelated files)*
- pnpm --filter www run typecheck


------
https://chatgpt.com/codex/tasks/task_e_68d53cd6cfd4832aaa754c664a408e9c