### PR TITLE
Normalize blog language frontmatter

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-25T1445--blog-language-frontmatter-alias.md
+++ b/WRITE_HERE/FIXES/2025-09-25T1445--blog-language-frontmatter-alias.md
@@ -1,0 +1,5 @@
+# Recognize capitalized language frontmatter in blog posts
+- **What:** Normalized blog collection parsing so posts using `Language:` frontmatter values still populate the `language` field for locale filtering.
+- **Why:** Editors adding `Language: Dutch` or `Language: English` saw posts appear in every locale because the capitalized key was ignored.
+- **Files:** `apps/www/content-collections.ts`.
+- **Follow-ups:** None.

--- a/apps/www/content-collections.ts
+++ b/apps/www/content-collections.ts
@@ -23,6 +23,15 @@ const posts = defineCollection({
     const mdx = await compileMDX(context, document, {
       remarkPlugins: [remarkGfm, remarkHeading, remarkStructure],
     });
+    const fallbackLanguage = (document as Record<string, unknown>)[
+      "Language"
+    ];
+    const normalizedLanguage =
+      document.language ??
+      (typeof fallbackLanguage === "string" ||
+      Array.isArray(fallbackLanguage)
+        ? (fallbackLanguage as string | string[])
+        : undefined);
     const slugger = new GithubSlugger();
     const regXHeader = /\n(?<flag>#+)\s+(?<content>.+)/g;
     const tableOfContents = Array.from(document.content.matchAll(regXHeader)).map(({ groups }) => {
@@ -39,6 +48,7 @@ const posts = defineCollection({
 
     return {
       ...document,
+      language: normalizedLanguage,
       mdx,
       slug: slugFromPath,
       url: `/blog/${slugFromPath}`,


### PR DESCRIPTION
## Summary
- normalize blog collection parsing so Language frontmatter is captured in the language field
- ensure locale filtering and static param generation respect the normalized language value
- log the fix in WRITE_HERE/FIXES

## Testing
- pnpm --filter www run typecheck
- pnpm --filter www run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d554cea31c832a9a22ab5db3cbcdd8