### PR TITLE
Limit unspecified blog posts to the English locale

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-25T1445--blog-language-frontmatter-alias.md
+++ b/WRITE_HERE/FIXES/2025-09-25T1445--blog-language-frontmatter-alias.md
@@ -1,0 +1,5 @@
+# Recognize capitalized language frontmatter in blog posts
+- **What:** Normalized blog collection parsing so posts using `Language:` frontmatter values still populate the `language` field for locale filtering.
+- **Why:** Editors adding `Language: Dutch` or `Language: English` saw posts appear in every locale because the capitalized key was ignored.
+- **Files:** `apps/www/content-collections.ts`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-23T1500--blog-language-defaults.md
+++ b/WRITE_HERE/FIXES/2025-11-23T1500--blog-language-defaults.md
@@ -1,0 +1,5 @@
+# Default unspecified blog language to English
+- **What:** Tightened locale filtering so posts without a language frontmatter only render for the English locale and only generate English static params.
+- **Why:** Template posts lacking a language tag were still visible in Dutch, so the list and article views kept English titles and descriptions when switching locales.
+- **Files:** `apps/www/lib/blog-language.ts`.
+- **Follow-ups:** Audit remaining content and tag each post with the right language as new locales launch.

--- a/apps/www/content-collections.ts
+++ b/apps/www/content-collections.ts
@@ -23,6 +23,15 @@ const posts = defineCollection({
     const mdx = await compileMDX(context, document, {
       remarkPlugins: [remarkGfm, remarkHeading, remarkStructure],
     });
+    const fallbackLanguage = (document as Record<string, unknown>)[
+      "Language"
+    ];
+    const normalizedLanguage =
+      document.language ??
+      (typeof fallbackLanguage === "string" ||
+      Array.isArray(fallbackLanguage)
+        ? (fallbackLanguage as string | string[])
+        : undefined);
     const slugger = new GithubSlugger();
     const regXHeader = /\n(?<flag>#+)\s+(?<content>.+)/g;
     const tableOfContents = Array.from(document.content.matchAll(regXHeader)).map(({ groups }) => {
@@ -39,6 +48,7 @@ const posts = defineCollection({
 
     return {
       ...document,
+      language: normalizedLanguage,
       mdx,
       slug: slugFromPath,
       url: `/blog/${slugFromPath}`,

--- a/apps/www/lib/blog-language.ts
+++ b/apps/www/lib/blog-language.ts
@@ -1,4 +1,4 @@
-import { locales } from "@/i18n/routing";
+import { defaultLocale, locales } from "@/i18n/routing";
 
 type PostLanguage = string | string[] | undefined;
 
@@ -34,12 +34,18 @@ export function shouldIncludePostForLocale(language: PostLanguage, locale?: stri
   const normalizedLanguages = normalizeLanguageValues(language);
 
   if (normalizedLanguages.length === 0) {
-    return true;
+    return normalizedLocale === defaultLocale;
   }
 
   return normalizedLanguages.some((value) => allowedLanguages.has(value));
 }
 
 export function localesForPost(language: PostLanguage) {
+  const normalizedLanguages = normalizeLanguageValues(language);
+
+  if (normalizedLanguages.length === 0) {
+    return [defaultLocale];
+  }
+
   return locales.filter((locale) => shouldIncludePostForLocale(language, locale));
 }


### PR DESCRIPTION
## Summary
- ensure blog language filtering treats posts without a language frontmatter as English-only
- limit static param generation to English for posts missing a language tag and log the fix

## Plan
- update locale filter helper to gate undefined languages to the default locale
- align locale list generation with the new default behaviour
- document the change in the fixes journal

## Testing
- pnpm --filter www run typecheck *(fails: repository missing next-intl type declarations)*
- pnpm --filter www run lint *(fails: repository missing next-intl package during lint config load)*

------
https://chatgpt.com/codex/tasks/task_e_68d554cea31c832a9a22ab5db3cbcdd8