### PR TITLE
Fix blog language frontmatter for custom models post

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-23T1600--blog-language-frontmatter-case.md
+++ b/WRITE_HERE/FIXES/2025-11-23T1600--blog-language-frontmatter-case.md
@@ -1,0 +1,5 @@
+# Corrected blog language frontmatter casing
+- **What:** Updated the English and Dutch versions of the "Custom Models" research post to use the `language` frontmatter key and fixed the malformed English tags list.
+- **Why:** The uppercase `Language` key was dropped during content collection, so the Dutch metadata appeared for every locale; the broken tags array also prevented consistent parsing.
+- **Files:** `apps/www/content/blog/mdxfilesforprojects/research/LLM-Predictive-Capabilities/posts/English/when-off-the-shelf-ai-falls-short-training-custom-models.mdx`, `apps/www/content/blog/mdxfilesforprojects/research/LLM-Predictive-Capabilities/posts/Dutch/wanneercustom.mdx`.
+- **Follow-ups:** None.

--- a/apps/www/content/blog/mdxfilesforprojects/research/LLM-Predictive-Capabilities/posts/Dutch/wanneercustom.mdx
+++ b/apps/www/content/blog/mdxfilesforprojects/research/LLM-Predictive-Capabilities/posts/Dutch/wanneercustom.mdx
@@ -3,9 +3,9 @@ date: 2025-03-23
 title: "Het trainen van Custom Modellen"
 description: "Generieke AI modellen zijn krachtig, maar niet universeel. Hier lees je wanneer maatwerktraining zinvol is, hoe we haalbaarheid en ROI beoordelen, en welke technieken we inzetten om doelen voor kwaliteit, snelheid en kosten te halen"
 author: chiHueng
-tags: ["ai","research","fine-tuning"]
+tags: ["ai", "research", "fine-tuning"]
 image: "/images/blog-images/mdxfilesforprojects/research/LLM-Predictive-Capabilities/images/Custommodel.png"
-Language: Dutch
+language: Dutch
 ---
 # Het trainen van Custom Modellen voor bedrijven
 

--- a/apps/www/content/blog/mdxfilesforprojects/research/LLM-Predictive-Capabilities/posts/English/when-off-the-shelf-ai-falls-short-training-custom-models.mdx
+++ b/apps/www/content/blog/mdxfilesforprojects/research/LLM-Predictive-Capabilities/posts/English/when-off-the-shelf-ai-falls-short-training-custom-models.mdx
@@ -3,9 +3,9 @@ date: 2025-03-23
 title: "When Off-the-Shelf AI Falls Short: Training Custom Models"
 description: "General models are powerful but not universal. Here’s when custom training makes sense, how we evaluate feasibility and ROI, and the lightweight techniques we use to hit quality, speed, and cost goals."
 author: chiHueng
-tags: ["ai","Research,"fine-tuning"]
+tags: ["ai", "research", "fine-tuning"]
 image: "/images/blog-images/mdxfilesforprojects/research/LLM-Predictive-Capabilities/images/Custommodel.png"
-Language: English
+language: English
 ---
 # When Off-the-Shelf AI Falls Short: Training Custom Models
 


### PR DESCRIPTION
## Plan
- Inspect the research post MDX files to confirm how language metadata is exposed to the content collection.
- Normalize the language frontmatter keys and address any malformed metadata that could prevent parsing.
- Regenerate the collection, verify locale filtering in the blog grid, and document the fix.

## Summary
- Switched the Dutch and English Custom Models research posts to use the lowercase `language` frontmatter key so locale filtering can detect each variant correctly.
- Corrected the malformed English tags array to ensure the content collection parses metadata without falling back to Dutch copy.
- Logged the fix in WRITE_HERE to capture the root cause and resolution for future reference.

## Testing
- pnpm --filter www run typecheck
- pnpm --filter www run lint *(fails: numerous pre-existing lint errors in unrelated files)*

## Screenshots
- ![English blog grid after fix](browser:/invocations/urihluca/artifacts/artifacts/blog-en.png)
- ![Dutch blog grid after fix](browser:/invocations/lmydxuhb/artifacts/artifacts/blog-nl.png)


------
https://chatgpt.com/codex/tasks/task_e_68d568a36e28832ab2e3cd15b9df858d