### PR TITLE
Refine research showcase tab

### DIFF
--- a/WRITE_HERE/UPDATES/2025-09-25T2220--golang-research-showcase.md
+++ b/WRITE_HERE/UPDATES/2025-09-25T2220--golang-research-showcase.md
@@ -1,0 +1,5 @@
+# Added research showcases to Golang tab
+- **What:** Replaced the Golang code samples with research showcases linked to their blog posts, localized copy, and updated the project showcase component to support translated labels and CTA links.
+- **Why:** Surface recent research articles directly inside the homepage experience and match the layout used for the education platform showcase.
+- **Files:** `apps/www/app/code-examples.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/UPDATES/2025-11-23T1805--refined-research-showcase.md
+++ b/WRITE_HERE/UPDATES/2025-11-23T1805--refined-research-showcase.md
@@ -1,0 +1,5 @@
+# Polished research showcase tab
+- **What:** Replaced the Golang label with a Research tab/icon, hid missing translation fallbacks, and restyled the research sidebar cards for better hierarchy.
+- **Why:** The previous implementation surfaced translation keys, carried the wrong label/icon, and left wrapped titles misaligned.
+- **Files:** `apps/www/app/code-examples.tsx`, `apps/www/components/svg/lang-icons.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -6,9 +6,9 @@ import type { LangIconProps } from "@/components/svg/lang-icons";
 import {
   CurlIcon,
   ElixirIcon,
-  GoIcon,
   JavaIcon,
   PythonIcon,
+  ResearchIcon,
   RustIcon,
   TSIcon,
 } from "@/components/svg/lang-icons";
@@ -20,7 +20,7 @@ import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { ChevronRight } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import type { PrismTheme } from "prism-react-renderer";
 import React, { useEffect } from "react";
 import { useState } from "react";
@@ -193,98 +193,7 @@ async function handler(request) {
 
 }`;
 
-const goVerifyKeyCodeBlock = `package main
 
-import(
-	unkeygo "github.com/unkeyed/unkey-go"
-	"context"
-	"github.com/unkeyed/unkey-go/models/components"
-	"log"
-)
-
-func main() {
-    s := unkeygo.New(
-        unkeygo.WithSecurity("<YOUR_BEARER_TOKEN_HERE>"),
-    )
-
-    ctx := context.Background()
-    res, err := s.Keys.VerifyKey(ctx, components.V1KeysVerifyKeyRequest{
-        APIID: unkeygo.String("api_1234"),
-        Key: "sk_1234",
-        Ratelimits: []components.Ratelimits{
-            components.Ratelimits{
-                Name: "tokens",
-                Limit: unkeygo.Int64(500),
-                Duration: unkeygo.Int64(3600000),
-            },
-            components.Ratelimits{
-                Name: "tokens",
-                Limit: unkeygo.Int64(20000),
-                Duration: unkeygo.Int64(86400000),
-            },
-        },
-    })
-    if err != nil {
-        log.Fatal(err)
-    }
-    if res.V1KeysVerifyKeyResponse != nil {
-        // handle response
-    }
-}`;
-
-const goCreateKeyCodeBlock = `package main
-
-import(
-	unkeygo "github.com/unkeyed/unkey-go"
-	"context"
-	"github.com/unkeyed/unkey-go/models/operations"
-	"log"
-)
-
-func main() {
-    s := unkeygo.New(
-        unkeygo.WithSecurity("<YOUR_BEARER_TOKEN_HERE>"),
-    )
-
-    ctx := context.Background()
-    res, err := s.Keys.CreateKey(ctx, operations.CreateKeyRequestBody{
-        APIID: "api_123",
-        Name: unkeygo.String("my key"),
-        ExternalID: unkeygo.String("team_123"),
-        Meta: map[string]any{
-            "billingTier": "PRO",
-            "trialEnds": "2023-06-16T17:16:37.161Z",
-        },
-        Roles: []string{
-            "admin",
-            "finance",
-        },
-        Permissions: []string{
-            "domains.create_record",
-            "say_hello",
-        },
-        Expires: unkeygo.Int64(1623869797161),
-        Remaining: unkeygo.Int64(1000),
-        Refill: &operations.Refill{
-            Interval: operations.IntervalDaily,
-            Amount: 100,
-        },
-        Ratelimit: &operations.Ratelimit{
-            Type: operations.TypeFast.ToPointer(),
-            Limit: 10,
-            Duration: unkeygo.Int64(60000),
-        },
-        Enabled: unkeygo.Bool(false),
-    })
-    if err != nil {
-        log.Fatal(err)
-    }
-    if res.Object != nil {
-        // handle response
-    }
-}
-
-`;
 
 const curlVerifyCodeBlock = `curl --request POST \\
   --url https://api.unkey.dev/v1/keys.verifyKey \\
@@ -393,9 +302,37 @@ type Framework = {
     height: number;
   };
   contentKey?: string;
+  href?: Record<string, string>;
 };
 
 type ProjectCopyFormatter = (key: string) => string;
+
+const projectsNamespace = "CodeExamples.projects";
+
+const resolveProjectMessage = (
+  projectCopy: ProjectCopyFormatter,
+  contentKey: string | undefined,
+  suffix: string,
+) => {
+  if (!contentKey) {
+    return undefined;
+  }
+
+  const messageKey = `${contentKey}.${suffix}`;
+
+  try {
+    const value = projectCopy(messageKey);
+    const fallbackKey = `${projectsNamespace}.${messageKey}`;
+
+    if (value === messageKey || value === fallbackKey) {
+      return undefined;
+    }
+
+    return value;
+  } catch (error) {
+    return undefined;
+  }
+};
 
 const languagesList = {
   Typescript: [
@@ -444,18 +381,66 @@ const languagesList = {
       editorLanguage: "python",
     },
   ],
-  Golang: [
+  Research: [
     {
-      name: "Verify key",
-      Icon: GoIcon,
-      codeBlock: goVerifyKeyCodeBlock,
-      editorLanguage: "go",
+      name: "AI adoption",
+      Icon: ResearchIcon,
+      image: {
+        src: "/images/blog-images/mdxfilesforprojects/research/ai-adoptation/images/Maindisplay.png",
+        alt: "Research dashboard illustrating AI adoption insights",
+        width: 1200,
+        height: 800,
+      },
+      contentKey: "researchAiAdoption",
+      href: {
+        en: "/blog/how-we-map-ai-adoption-across-industries",
+        nl: "/blog/zo-meten-we-ai-adoptie-per-sector",
+      },
     },
     {
-      name: "Create key",
-      Icon: GoIcon,
-      codeBlock: goCreateKeyCodeBlock,
-      editorLanguage: "go",
+      name: "Custom models",
+      Icon: ResearchIcon,
+      image: {
+        src: "/images/blog-images/mdxfilesforprojects/research/LLM-Predictive-Capabilities/images/Custommodel.png",
+        alt: "Graph visualizing return on investment for custom AI models",
+        width: 1200,
+        height: 800,
+      },
+      contentKey: "researchCustomModels",
+      href: {
+        en: "/blog/when-off-the-shelf-ai-falls-short-training-custom-models",
+        nl: "/blog/wanneercustom",
+      },
+    },
+    {
+      name: "Time series",
+      Icon: ResearchIcon,
+      image: {
+        src: "/images/blog-images/mdxfilesforprojects/research/aipredictions/images/coverpredict.png",
+        alt: "Forecast chart generated by transformer models",
+        width: 1200,
+        height: 800,
+      },
+      contentKey: "researchTimeSeries",
+      href: {
+        en: "/blog/can-llms-forecast-time-exploring-ai-time-series-prediction",
+        nl: "/blog/kunnen-llms-de-tijd-voorspellen-ai-voor-tijdreeksprognoses",
+      },
+    },
+    {
+      name: "AI ranking",
+      Icon: ResearchIcon,
+      image: {
+        src: "/images/blog-images/mdxfilesforprojects/research/Chatbotranking/images/screenshotofchat.png",
+        alt: "Chat interface ranking products within AI assistants",
+        width: 1200,
+        height: 800,
+      },
+      contentKey: "researchRanking",
+      href: {
+        en: "/blog/winning-the-model-ranking-higher-in-ai-recommendations",
+        nl: "/blog/de-modelrace-winnen-hoger-scoren-in-ai-aanbevelingen",
+      },
     },
   ],
   Java: [
@@ -535,7 +520,14 @@ const languagesList = {
 type Props = {
   className?: string;
 };
-type Language = "Typescript" | "Python" | "Rust" | "Golang" | "Curl" | "Elixir" | "Java";
+type Language =
+  | "Typescript"
+  | "Python"
+  | "Rust"
+  | "Research"
+  | "Curl"
+  | "Elixir"
+  | "Java";
 type LanguagesList = {
   name: Language;
   Icon: React.FC<LangIconProps>;
@@ -544,7 +536,7 @@ const languages = [
   { name: "Typescript", Icon: TSIcon },
   { name: "Python", Icon: PythonIcon },
   { name: "Rust", Icon: RustIcon },
-  { name: "Golang", Icon: GoIcon },
+  { name: "Research", Icon: ResearchIcon },
   { name: "Curl", Icon: CurlIcon },
   { name: "Elixir", Icon: ElixirIcon },
   { name: "Java", Icon: JavaIcon },
@@ -652,6 +644,7 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
             frameworks={frameworksForLanguage}
             currentFramework={framework}
             setFramework={setFramework}
+            projectCopy={projectCopy}
           />
           <div
             className={cn(
@@ -667,6 +660,7 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
                 contentKey={currentFrameworkData.contentKey}
                 language={language}
                 projectCopy={projectCopy}
+                hrefs={currentFrameworkData.href}
               />
             ) : (
               <>
@@ -708,18 +702,30 @@ function ProjectShowcase({
   contentKey,
   language,
   projectCopy,
+  hrefs,
 }: {
   image: NonNullable<Framework["image"]>;
   contentKey?: string;
   language: Language;
   projectCopy: ProjectCopyFormatter;
+  hrefs?: Framework["href"];
 }) {
-  const title = contentKey ? projectCopy(`${contentKey}.title`) : undefined;
-  const description = contentKey
-    ? projectCopy(`${contentKey}.description`)
+  const locale = useLocale();
+
+  const title = resolveProjectMessage(projectCopy, contentKey, "title");
+  const description = resolveProjectMessage(
+    projectCopy,
+    contentKey,
+    "description",
+  );
+  const result = resolveProjectMessage(projectCopy, contentKey, "result");
+  const cta = resolveProjectMessage(projectCopy, contentKey, "cta");
+  const field = resolveProjectMessage(projectCopy, contentKey, "field");
+  const name = resolveProjectMessage(projectCopy, contentKey, "name");
+
+  const href = hrefs
+    ? hrefs[locale] ?? hrefs.en ?? Object.values(hrefs)[0]
     : undefined;
-  const result = contentKey ? projectCopy(`${contentKey}.result`) : undefined;
-  const cta = contentKey ? projectCopy(`${contentKey}.cta`) : undefined;
 
   return (
     <div className="flex flex-col w-full gap-8 lg:flex-row lg:items-center">
@@ -732,12 +738,26 @@ function ProjectShowcase({
             height={image.height}
             className="h-full w-full object-contain"
             sizes="(min-width: 1280px) 720px, (min-width: 640px) 70vw, 90vw"
-            priority={language === "Rust"}
+            priority={language === "Rust" || language === "Research"}
           />
         </div>
       </div>
       {(title || description || result || cta) && (
         <div className="flex flex-col justify-center gap-4 text-white/80 lg:max-w-sm">
+          {field || name ? (
+            <div className="flex flex-col gap-1">
+              {field ? (
+                <span className="text-xs font-semibold uppercase tracking-[0.2em] text-white/40">
+                  {field}
+                </span>
+              ) : null}
+              {name ? (
+                <span className="text-sm font-medium text-white/70">
+                  {name}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
           {title ? (
             <h3 className="text-2xl font-semibold leading-tight text-white sm:text-3xl">
               {title}
@@ -754,12 +774,18 @@ function ProjectShowcase({
             </p>
           ) : null}
           {cta ? (
-            <button
-              type="button"
-              className="inline-flex items-center justify-center self-start px-5 py-2 text-sm font-semibold text-black transition-colors duration-200 bg-white rounded-lg shadow-sm hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
-            >
-              {cta}
-            </button>
+            href ? (
+              <Link
+                href={href}
+                className="inline-flex items-center justify-center self-start px-5 py-2 text-sm font-semibold text-black transition-colors duration-200 bg-white rounded-lg shadow-sm hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              >
+                {cta}
+              </Link>
+            ) : (
+              <span className="inline-flex items-center justify-center self-start px-5 py-2 text-sm font-semibold text-black transition-colors duration-200 bg-white rounded-lg shadow-sm">
+                {cta}
+              </span>
+            )
           ) : null}
         </div>
       )}
@@ -771,14 +797,27 @@ function FrameworkSwitcher({
   frameworks,
   currentFramework,
   setFramework,
+  projectCopy,
 }: {
   frameworks: Framework[];
   currentFramework: FrameworkName;
   setFramework: React.Dispatch<React.SetStateAction<FrameworkName>>;
+  projectCopy: ProjectCopyFormatter;
 }) {
+  const getLabel = (framework: Framework) => {
+    return (
+      resolveProjectMessage(projectCopy, framework.contentKey, "label") ??
+      framework.name
+    );
+  };
+
+  const getField = (framework: Framework) => {
+    return resolveProjectMessage(projectCopy, framework.contentKey, "field");
+  };
+
   return (
-    <div className="flex flex-col justify-between sm:w-[216px] text-white text-sm pt-6 px-4 font-mono md:border-r md:border-white/10">
-      <div className="flex items-center space-x-2 sm:flex-col sm:space-x-0 sm:space-y-2">
+    <div className="flex flex-col border-b border-white/5 px-4 py-5 text-white sm:w-[232px] sm:border-b-0 sm:border-r sm:border-white/10">
+      <div className="flex gap-3 overflow-x-auto pb-1 sm:flex-col sm:gap-2 sm:overflow-visible">
         {frameworks.map((framework) => (
           <button
             key={framework.name}
@@ -787,14 +826,27 @@ function FrameworkSwitcher({
               setFramework(framework.name as FrameworkName);
             }}
             className={cn(
-              "flex items-center cursor-pointer hover:bg-white/10 py-1 px-2 rounded-lg w-[184px] ",
+              "group flex min-w-[200px] flex-1 cursor-pointer flex-col items-start gap-1 rounded-xl border border-transparent bg-white/0 px-4 py-3 text-left text-sm transition duration-200 sm:min-w-0",
               {
-                "bg-white/10 text-white": currentFramework === framework.name,
-                "text-white/40": currentFramework !== framework.name,
+                "bg-white/10 text-white shadow-[0_18px_40px_rgba(0,0,0,0.45)] border-white/20":
+                  currentFramework === framework.name,
+                "text-white/40 hover:border-white/15 hover:bg-white/5":
+                  currentFramework !== framework.name,
               },
             )}
           >
-            <div>{framework.name}</div>
+            {(() => {
+              const field = getField(framework);
+
+              return field ? (
+                <span className="text-[10px] font-semibold uppercase tracking-[0.24em] text-white/30">
+                  {field}
+                </span>
+              ) : null;
+            })()}
+            <span className="text-sm font-medium leading-snug text-inherit">
+              {getLabel(framework)}
+            </span>
           </button>
         ))}
       </div>

--- a/apps/www/components/svg/lang-icons.tsx
+++ b/apps/www/components/svg/lang-icons.tsx
@@ -133,3 +133,37 @@ export const GoIcon: React.FC<LangIconProps> = ({ active }) => (
     />
   </svg>
 );
+
+export const ResearchIcon: React.FC<LangIconProps> = ({ active }) => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g opacity={active ? 1 : 0.3}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M11 3C6.58172 3 3 6.58172 3 11C3 15.4183 6.58172 19 11 19C12.7538 19 14.3745 18.4101 15.6873 17.4085L18.4087 20.13C18.7992 20.5205 19.4324 20.5205 19.8229 20.13C20.2134 19.7395 20.2134 19.1063 19.8229 18.7158L17.1015 15.9944C18.1044 14.6815 18.6944 13.0609 18.6944 11.3069C18.6944 6.88861 15.1127 3.3069 10.6944 3.3069C10.7947 3.10231 10.8936 3 11 3ZM11 5C7.68629 5 5 7.68629 5 11C5 14.3137 7.68629 17 11 17C14.3137 17 17 14.3137 17 11C17 7.68629 14.3137 5 11 5Z"
+        fill={active ? "url(#paint0_linear_research)" : "white"}
+      />
+      <path
+        d="M10.75 7.5C10.3358 7.5 10 7.83579 10 8.25V11.25C10 11.6642 10.3358 12 10.75 12H13.75C14.1642 12 14.5 11.6642 14.5 11.25C14.5 10.8358 14.1642 10.5 13.75 10.5H11.5V8.25C11.5 7.83579 11.1642 7.5 10.75 7.5Z"
+        fill={active ? "url(#paint0_linear_research)" : "white"}
+      />
+      <path
+        d="M8 11.75C8 11.3358 8.33579 11 8.75 11H9.25C9.66421 11 10 11.3358 10 11.75V15.25C10 15.6642 9.66421 16 9.25 16H8.75C8.33579 16 8 15.6642 8 15.25V11.75Z"
+        fill={active ? "url(#paint0_linear_research)" : "white"}
+      />
+    </g>
+    <defs>
+      <linearGradient
+        id="paint0_linear_research"
+        x1="4"
+        y1="2"
+        x2="18.5"
+        y2="21"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="white" stopOpacity="0.4" />
+        <stop offset="1" stopColor="white" />
+      </linearGradient>
+    </defs>
+  </svg>
+);

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -373,9 +373,44 @@
     },
     "projects": {
       "platform": {
+        "label": "Education platform",
+        "field": "Education",
+        "name": "TransformAI academy",
         "title": "Education platform for using AI.",
         "description": "We created an education platform that makes it fun and interactive to learn how to use AI within a company. We design custom modules based on each partner’s needs.",
         "result": "This platform has delivered massive AI productivity gains across the company.",
+        "cta": "Read more"
+      },
+      "researchAiAdoption": {
+        "label": "AI adoption",
+        "field": "Research",
+        "name": "AI adoption.",
+        "title": "Research in AI adoption by companies",
+        "description": "We’re conducting research into how industries adopt AI—where it’s used, how fast it’s spreading, how deeply it’s integrated, and what results it delivers. Using surveys and AI-assisted evidence gathering, we compile clear sector snapshots with trends and notable anomalies. These findings help teams prioritize next steps and reduce risk.",
+        "cta": "Read more"
+      },
+      "researchCustomModels": {
+        "label": "Custom AI models",
+        "field": "Research",
+        "name": "Training custom models",
+        "title": "We Research when to Train Custom AI Models",
+        "description": "Not every task fits a general model. In this study, we test where custom training actually pays off—measuring quality, latency, and cost against real business value. We compare strong baselines (prompts + RAG) to fine-tuned and distilled models, and share the decision rules we use to pick the cheapest reliable path.",
+        "cta": "Read more"
+      },
+      "researchTimeSeries": {
+        "label": "Time-series prediction",
+        "field": "Research",
+        "name": "AI time-series prediction",
+        "title": "Can LLMs forecast?",
+        "description": "We explore whether transformer LLMs can forecast variables over time—testing how semantic labels, model size, and light fine-tuning affect accuracy and stability. A spotlight on “From Tokens to Temperatures” shows sizable gains when inputs carry meaning, with outliers sharply reduced.",
+        "cta": "Read more"
+      },
+      "researchRanking": {
+        "label": "AI recommendation ranking",
+        "field": "Research",
+        "name": "Influencing AI output",
+        "title": "Ranking in AI model recommendations",
+        "description": "We study how AI assistants decide which products and services to include—and in what order. Our benchmark tests across multiple providers examine signals like evidence clarity, third-party corroboration, and policy alignment. Early results show relative lifts of ~72%, 89%, and 75% in inclusion and visibility.",
         "cta": "Read more"
       }
     },

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -373,9 +373,44 @@
     },
     "projects": {
       "platform": {
+        "label": "Educatieplatform",
+        "field": "Educatie",
+        "name": "TransformAI academy",
         "title": "Educatieplatform voor het gebruik van AI.",
         "description": "We hebben een educatieplatform gebouwd dat het leuk en interactief maakt om binnen een bedrijf te leren werken met AI. We ontwikkelen modules op maat op basis van de behoeften van elke partner.",
         "result": "Dit platform heeft geleid tot enorme productiviteitswinsten met AI binnen het bedrijf.",
+        "cta": "Lees meer"
+      },
+      "researchAiAdoption": {
+        "label": "AI-adoptie",
+        "field": "Onderzoek",
+        "name": "AI-adoptie.",
+        "title": "Onderzoek in AI adaptatie van bedrijven",
+        "description": "Wij doen onderzoek naar hoe sectoren AI inzetten—waar het wordt gebruikt, hoe snel het zich verspreidt, hoe diep het is geïntegreerd en welke resultaten het oplevert. Met enquêtes en AI-ondersteunde bewijs maken we heldere sectorschetsen met trends en opvallende afwijkingen. Deze inzichten helpen teams hun volgende stappen te prioriteren en risico’s te beperken.",
+        "cta": "Lees meer"
+      },
+      "researchCustomModels": {
+        "label": "Custom AI-modellen",
+        "field": "Onderzoek",
+        "name": "Training op maat",
+        "title": "Wij onderzoeken wanneer : “kies je voor een custom AI-model”?",
+        "description": "Niet elke taak past bij een generiek model. In dit onderzoek testen we wanneer maatwerktraining echt loont—meten we kwaliteit, latentie en kosten tegenover concrete businesswaarde. Wij vergelijken sterke baselines (prompts + RAG) met fijn-getunede en gedistilleerde modellen, en vinden de beslisregels voor het goedkoopste betrouwbare pad bedrijven in situaties kunnen nemen.",
+        "cta": "Lees meer"
+      },
+      "researchTimeSeries": {
+        "label": "Voorspellen met AI",
+        "field": "Onderzoek",
+        "name": "AI-tijdreeksvoorspelling",
+        "title": "Kunnen LLM’s voorspellen?",
+        "description": "Wij onderzoeken of transformer-LLM’s variabelen door de tijd kunnen voorspellen—en hoe semantische labels, modelgrootte en lichte fine-tuning de nauwkeurigheid en stabiliteit beïnvloeden. In “From Tokens to Temperatures” zien we duidelijke winst wanneer inputs betekenisvol gelabeld zijn en uitbijters sterk afnemen.",
+        "cta": "Lees meer"
+      },
+      "researchRanking": {
+        "label": "AI-aanbevelingen",
+        "field": "Onderzoek",
+        "name": "Zichtbaarheid in AI",
+        "title": "Zichtbaarheid in AI-aanbevelingen",
+        "description": "Wij onderzoeken hoe AI-assistants bepalen welke producten en diensten ze opnemen—en in welke volgorde. In benchmarks over meerdere providers analyseren we signalen zoals helderheid van evidentie, derde-partijcorroboratie en policy-afstemming. Vroege resultaten tonen relatieve lifts van ~72%, 89% en 75% in inclusie en zichtbaarheid.",
         "cta": "Lees meer"
       }
     },


### PR DESCRIPTION
## Summary
- rename the Golang showcase tab to Research with a bespoke icon and refreshed language list wiring
- guard research translation lookups and restyle the sidebar cards so wrapped labels stay aligned and highlight the field metadata
- log the follow-up in WRITE_HERE/UPDATES for continuity

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: repository already contains lint violations outside this change)*


------
https://chatgpt.com/codex/tasks/task_e_68d5be6eeaa4832a973403de660be247