### PR TITLE
Fix hydration mismatch in code examples

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-24T1000--stabilized-code-example-expiration.md
+++ b/WRITE_HERE/FIXES/2025-11-24T1000--stabilized-code-example-expiration.md
@@ -1,0 +1,5 @@
+# Stabilized code example expiration timestamp
+- **What:** Replaced the dynamic `Date.now()` usage in the code examples curl snippet with a deterministic timestamp constant.
+- **Why:** The server-rendered page and client bundle produced different values for the snippet, causing a hydration failure on initial load.
+- **Files:** `apps/www/app/code-examples.tsx`.
+- **Follow-ups:** Audit other examples for runtime-generated values that could desynchronize server and client output.

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -203,6 +203,8 @@ const curlVerifyCodeBlock = `curl --request POST \\
     "key": "sk_1234",
   }'`;
 
+const exampleKeyExpiration = new Date("2025-01-01T00:00:00Z").getTime();
+
 const curlCreateKeyCodeBlock = `curl --request POST \\
   --url https://api.unkey.dev/v1/keys.createKey \\
   --header 'Authorization: Bearer <UNKEY_ROOT_KEY>' \\
@@ -210,7 +212,7 @@ const curlCreateKeyCodeBlock = `curl --request POST \\
   --data '{
     "apiId": "api_123",
     "ownerId": "user_123",
-    "expires": ${Date.now() + 7 * 24 * 60 * 60 * 1000},
+    "expires": ${exampleKeyExpiration},
     "ratelimit": {
       "type": "fast",
       "limit": 10,


### PR DESCRIPTION
## Plan
- trace hydration error back to client-side code examples module
- replace non-deterministic timestamp usage with a deterministic constant
- document the fix and verify the landing page hydrates without errors

## Summary
- replace the Date.now()-based expiration example with a fixed timestamp so SSR and CSR output match
- add a FIXES log entry describing the hydration mismatch resolution

## Testing
- pnpm --filter www run typecheck
- pnpm --filter www run lint *(fails: pre-existing lint violations across careers/startups templates)*
- pnpm --filter www build *(fails: same lint violations as above)*

------
https://chatgpt.com/codex/tasks/task_e_68d678fb1c20832aba876f5468edb161