### PR TITLE
Fix footer hydration mismatch by stabilizing copyright year

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-24T1600--stabilized-footer-year-hydration.md
+++ b/WRITE_HERE/FIXES/2025-11-24T1600--stabilized-footer-year-hydration.md
@@ -1,0 +1,5 @@
+# Stabilized footer copyright year hydration
+- **What:** Passed the server-computed year into the footer and hydrate it with client state so the copyright label updates after mount without mismatching the SSR markup.
+- **Why:** The footer previously called `new Date()` during render, so statically generated pages rendered last year's value on the server and the client calculated the current year, triggering a hydration failure when the values diverged.
+- **Files:** `apps/www/components/footer/footer.tsx`, `apps/www/app/[locale]/layout.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/layout.tsx
+++ b/apps/www/app/[locale]/layout.tsx
@@ -119,7 +119,7 @@ export default async function LocaleLayout({
             </div>
           ) : null}
         </div>
-        <Footer />
+        <Footer initialYear={new Date().getUTCFullYear()} />
       </ConsentManagerProvider>
     </NextIntlClientProvider>
   );

--- a/apps/www/components/footer/footer.tsx
+++ b/apps/www/components/footer/footer.tsx
@@ -2,6 +2,7 @@
 import { Link } from "@/i18n/navigation";
 import { cn } from "@/lib/utils";
 import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
 import { UnkeyLogo } from "./footer-svgs";
 import { Wordmark } from "./wordmark";
 
@@ -105,8 +106,17 @@ const Column: React.FC<{
   );
 };
 
-export function Footer() {
+export function Footer({ initialYear }: { initialYear: number }) {
   const t = useTranslations("Footer");
+  const [year, setYear] = useState(initialYear);
+
+  useEffect(() => {
+    const currentYear = new Date().getUTCFullYear();
+    if (currentYear !== year) {
+      setYear(currentYear);
+    }
+  }, [year]);
+
   return (
     <div className="border-t border-white/20 blog-footer-radial-gradient">
       <footer className="container relative grid grid-cols-2 gap-8 pt-8 mx-auto overflow-hidden lg:gap-16 sm:grid-cols-3 xl:grid-cols-5 sm:pt-12 md:pt-16 lg:pt-24 xl:pt-32">
@@ -116,7 +126,7 @@ export function Footer() {
             {t("tagline")}
           </div>
           <div className="text-sm font-normal leading-6 text-white/40">
-            {t("copyright", { year: new Date().getUTCFullYear() })}
+            {t("copyright", { year })}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- pass the server-rendered year into the footer component and hydrate it after mount to avoid SSR/client mismatches
- document the hydration fix in WRITE_HERE/FIXES

## Plan
- inspect globally shared layout/footer for non-deterministic date usage
- thread a stable year prop from the layout into the footer and update it on the client if the calendar year advanced
- verify typechecking and linting outcomes while recording the fix log entry

## Testing
- pnpm --filter www run typecheck
- pnpm --filter www run lint *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d7849517b8832aaf28ca4b241811c7