### PR TITLE
Add AI integration Pt.1 case studies to homepage carousel

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-24T0900--ai-integration-pt1-case-study-showcase.md
+++ b/WRITE_HERE/UPDATES/2025-11-24T0900--ai-integration-pt1-case-study-showcase.md
@@ -1,0 +1,6 @@
+# Added AI Integration Pt.1 case study showcase
+
+- **What:** Replaced the legacy Typescript tab on the homepage project carousel with an "AI integration pt1" case study group and wired up four new showcase entries with locale-aware imagery and CTA copy.
+- **Why:** Highlight recent AI integration blog posts as part of the case study program and surface them alongside existing research content.
+- **Files:** `apps/www/app/code-examples.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Expand the carousel as new integration case studies publish and align iconography once a dedicated case study glyph is available.

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -10,7 +10,6 @@ import {
   JavaIcon,
   PythonIcon,
   ResearchIcon,
-  TSIcon,
 } from "@/components/svg/lang-icons";
 import { CodeEditor } from "@/components/ui/code-editor";
 import { CopyCodeSnippetButton } from "@/components/ui/copy-code-button";
@@ -73,42 +72,6 @@ const editorTheme = {
   ],
 } satisfies PrismTheme;
 
-const typescriptCodeBlock = `import { verifyKey } from '@unkey/api';
-
-const { result, error } = await verifyKey({
-  apiId: "api_123",
-  key: "xyz_123"
-})
-
-if ( error ) {
-  // handle network error
-}
-
-if ( !result.valid ) {
-  // reject unauthorized request
-}
-
-// handle request`;
-
-const nextJsCodeBlock = `import { withUnkey } from '@unkey/nextjs';
-export const POST = withUnkey(async (req) => {
-  // Process the request here
-  // You have access to the typed verification response using \`req.unkey\`
-  console.log(req.unkey);
-  return new Response('Your API key is valid!');
-});`;
-
-const nuxtCodeBlock = `export default defineEventHandler(async (event) => {
-  if (!event.context.unkey.valid) {
-    throw createError({ statusCode: 403, message: "Invalid API key" })
-  }
-
-  // return authorised information
-  return {
-    // ...
-  };
-});`;
-
 const pythonCodeBlock = `import asyncio
 import os
 import unkey
@@ -157,43 +120,6 @@ async def protected_route(
 if __name__ == "__main__":
     uvicorn.run(app)
 `;
-
-const honoCodeBlock = `import { Hono } from "hono"
-import { UnkeyContext, unkey } from "@unkey/hono";
-
-const app = new Hono<{ Variables: { unkey: UnkeyContext } }>();
-app.use("*", unkey());
-
-app.get("/somewhere", (c) => {
-  // access the unkey response here to get metadata of the key etc
-  const unkey = c.get("unkey")
- return c.text("yo")
-})`;
-
-const tsRatelimitCodeBlock = `import { Ratelimit } from "@unkey/ratelimit"
-
-const unkey = new Ratelimit({
-  rootKey: process.env.UNKEY_ROOT_KEY,
-  namespace: "my-app",
-  limit: 10,
-  duration: "30s",
-  async: true
-})
-
-// elsewhere
-async function handler(request) {
-  const identifier = request.getUserId() // or ip or anything else you want
-
-  const ratelimit = await unkey.limit(identifier)
-  if (!ratelimit.success){
-    return new Response("try again later", { status: 429 })
-  }
-
-  // handle the request here
-
-}`;
-
-
 
 const curlVerifyCodeBlock = `curl --request POST \\
   --url https://api.unkey.dev/v1/keys.verifyKey \\
@@ -347,36 +273,90 @@ const resolveProjectMessage = (
 };
 
 const languagesList = {
-  Typescript: [
+  "AI integration pt1": [
     {
-      name: "Typescript",
-      Icon: TSIcon,
-      codeBlock: typescriptCodeBlock,
-      editorLanguage: "tsx",
+      name: "HR researcher",
+      Icon: ResearchIcon,
+      image: {
+        src: "/images/blog-images/mdxfilesforprojects/aiintegrationpt1/hrfinderai/images/hrcoverim.png",
+        alt: "Case study cover showing an AI-assisted HR research dashboard",
+        width: 1536,
+        height: 1024,
+        locale: {
+          nl: {
+            src: "/images/blog-images/mdxfilesforprojects/aiintegrationpt1/hrfinderai/images/hrcoverimnl.png",
+            alt: "Casestudycover met AI-ondersteunde HR-research",
+          },
+        },
+      },
+      contentKey: "aiIntegrationHrResearcher",
+      href: {
+        en: "/blog/ai-solutions-for-hr-finding-the-right-people-faster",
+        nl: "/blog/ai-oplossingen-voor-hr-sneller-de-juiste-mensen-vinden",
+      },
     },
     {
-      name: "Next.js",
-      Icon: TSIcon,
-      codeBlock: nextJsCodeBlock,
-      editorLanguage: "tsx",
+      name: "Email responder",
+      Icon: ResearchIcon,
+      image: {
+        src: "/images/blog-images/mdxfilesforprojects/aiintegrationpt1/emailai/images/coveremail.png",
+        alt: "AI email responder platform interface",
+        width: 1536,
+        height: 1024,
+        locale: {
+          nl: {
+            src: "/images/blog-images/mdxfilesforprojects/aiintegrationpt1/emailai/images/coveremailnl.png",
+            alt: "AI e-mailworkflowplatform interface",
+          },
+        },
+      },
+      contentKey: "aiIntegrationEmailResponder",
+      href: {
+        en: "/blog/ai-email-workflows-from-best-tool-to-the-right-solution",
+        nl: "/blog/ai-emailworkflows-van-beste-tool-naar-de-juiste-oplossing",
+      },
     },
     {
-      name: "Nuxt",
-      codeBlock: nuxtCodeBlock,
-      Icon: TSIcon,
-      editorLanguage: "tsx",
+      name: "Custom local model",
+      Icon: ResearchIcon,
+      image: {
+        src: "/images/blog-images/mdxfilesforprojects/aiintegrationpt1/custommodel/images/covermodel.png",
+        alt: "Visualization of a custom on-premise AI model",
+        width: 1536,
+        height: 1024,
+        locale: {
+          nl: {
+            src: "/images/blog-images/mdxfilesforprojects/aiintegrationpt1/custommodel/images/covermodelnl.png",
+            alt: "Visualisatie van een lokaal maatwerk AI-model",
+          },
+        },
+      },
+      contentKey: "aiIntegrationCustomLocalModel",
+      href: {
+        en: "/blog/custom-models-for-confidential-high-precision-classification",
+        nl: "/blog/custom-modellen-voor-vertrouwelijke-precisieclassificatie-on-prem",
+      },
     },
     {
-      name: "Hono",
-      Icon: TSIcon,
-      codeBlock: honoCodeBlock,
-      editorLanguage: "tsx",
-    },
-    {
-      name: "Ratelimiting",
-      Icon: TSIcon,
-      codeBlock: tsRatelimitCodeBlock,
-      editorLanguage: "tsx",
+      name: "AI image workflow",
+      Icon: ResearchIcon,
+      image: {
+        src: "/images/blog-images/mdxfilesforprojects/aiintegrationpt1/imagegenworkflow/images/imagegenwork.png",
+        alt: "Workflow dashboard for large-scale AI image generation",
+        width: 1536,
+        height: 1024,
+        locale: {
+          nl: {
+            src: "/images/blog-images/mdxfilesforprojects/aiintegrationpt1/imagegenworkflow/images/imagegenworknl.png",
+            alt: "Workflowdashboard voor grootschalige AI-visuals",
+          },
+        },
+      },
+      contentKey: "aiIntegrationImageWorkflow",
+      href: {
+        en: "/blog/production-grade-visuals-at-scale-from-20-hours-to-45-minutes",
+        nl: "/blog/productieklare-visuals-op-schaal-van-20-uur-naar-45-minuten",
+      },
     },
   ],
   Python: [
@@ -600,7 +580,7 @@ type Props = {
   className?: string;
 };
 type Language =
-  | "Typescript"
+  | "AI integration pt1"
   | "Python"
   | "Education"
   | "Research"
@@ -612,7 +592,7 @@ type LanguagesList = {
   Icon: React.FC<LangIconProps>;
 };
 const languages = [
-  { name: "Typescript", Icon: TSIcon },
+  { name: "AI integration pt1", Icon: ResearchIcon },
   { name: "Python", Icon: PythonIcon },
   { name: "Education", Icon: EducationIcon },
   { name: "Research", Icon: ResearchIcon },
@@ -645,9 +625,9 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
   const t = useTranslations("CodeExamples");
   const cta = useTranslations("CTA");
   const projectCopy = useTranslations("CodeExamples.projects");
-  const [language, setLanguage] = useState<Language>("Typescript");
-  const [framework, setFramework] = useState<FrameworkName>("Typescript");
-  const [languageHover, setLanguageHover] = useState("Typescript");
+  const [language, setLanguage] = useState<Language>("AI integration pt1");
+  const [framework, setFramework] = useState<FrameworkName>("HR researcher");
+  const [languageHover, setLanguageHover] = useState("AI integration pt1");
   const frameworksForLanguage: Framework[] = languagesList[language];
   const currentFrameworkData: Framework | undefined =
     frameworksForLanguage.find((f) => f.name === framework) ??
@@ -823,7 +803,11 @@ function ProjectShowcase({
             height={imageHeight}
             className="h-full w-full object-contain"
             sizes="(min-width: 1280px) 720px, (min-width: 640px) 70vw, 90vw"
-            priority={language === "Education" || language === "Research"}
+            priority={
+              language === "Education" ||
+              language === "Research" ||
+              language === "AI integration pt1"
+            }
           />
         </div>
       </div>

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -405,6 +405,42 @@
         "description": "Stay current with a weekly roundup of what’s new in AI—beginner and advanced explanations, use cases, reviews, and on-request follow-up information so every team can act on what matters.",
         "cta": "Read more"
       },
+      "aiIntegrationHrResearcher": {
+        "label": "HR researcher",
+        "field": "Research",
+        "name": "HR researcher",
+        "title": "12× Faster Candidate Sourcing with AI",
+        "description": "How an AI-powered HR researcher helped a client find suitable candidates 1200% faster, surfaced more complete lists, and reduced hiring costs—so teams reach shortlists sooner.",
+        "result": "Part of our AI Integration Pt.1 case study series.",
+        "cta": "Read more"
+      },
+      "aiIntegrationEmailResponder": {
+        "label": "Email responder",
+        "field": "AI integration",
+        "name": "Email responder",
+        "title": "AI email responder case study",
+        "description": "Custom AI responders trimmed daily email work by 75%+ and lifted reply rates by 50%+. We’re also building a more universal solution informed by these projects.",
+        "result": "Part of our AI Integration Pt.1 case study series.",
+        "cta": "Read more"
+      },
+      "aiIntegrationCustomLocalModel": {
+        "label": "Custom local model",
+        "field": "Research",
+        "name": "Custom local model",
+        "title": "Custom local deployed model",
+        "description": "In our case study, a custom AI classifier reached 79% vs 80% human correctness while cutting effort from 24h to 1h (>95% calculated cost savings), meeting strict format and confidentiality requirements.",
+        "result": "Part of our AI Integration Pt.1 case study series.",
+        "cta": "Read more"
+      },
+      "aiIntegrationImageWorkflow": {
+        "label": "AI image workflow",
+        "field": "AI integration",
+        "name": "Optimized AI foto workflow",
+        "title": "From 20h to 45m: Scalable AI Image Workflows",
+        "description": "How a custom platform with parallel generations and prompt memory cut labor from 20 hours (manual) and 7 hours (normal AI) to 45 minutes for the same-quality image.",
+        "result": "Part of our AI Integration Pt.1 case study series.",
+        "cta": "Read more"
+      },
       "researchAiAdoption": {
         "label": "AI adoption",
         "field": "Research",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -405,6 +405,42 @@
         "description": "Blijf op de hoogte met een wekelijkse samenvatting over wat nieuw is in AI: uitleg voor beginners en gevorderden, use cases, reviews en follow-upinformatie op aanvraag—zodat elke laag in het bedrijf gericht kan handelen.",
         "cta": "Lees meer"
       },
+      "aiIntegrationHrResearcher": {
+        "label": "HR researcher",
+        "field": "Onderzoek",
+        "name": "HR researcher",
+        "title": "AI-recruiter: 12× sneller naar de juiste kandidaten",
+        "description": "In dit project vonden we 1200% sneller kandidaten, met completere longlists en lagere wervingskosten—waardoor hiringteams sneller en met meer vertrouwen keuzes maken.",
+        "result": "Onderdeel van onze AI-integratie Pt.1 casestudyreeks.",
+        "cta": "Lees meer"
+      },
+      "aiIntegrationEmailResponder": {
+        "label": "Email responder",
+        "field": "AI-integratie",
+        "name": "Email responder",
+        "title": "AI e-mailworkflow case study",
+        "description": "Onze maatwerkoplossingen verlaagden de dagelijkse e-mailtijd met 75%+ en verhoogden de respons met 50%+. Een bredere, universele variant is in ontwikkeling.",
+        "result": "Onderdeel van onze AI-integratie Pt.1 casestudyreeks.",
+        "cta": "Lees meer"
+      },
+      "aiIntegrationCustomLocalModel": {
+        "label": "Custom local model",
+        "field": "Onderzoek",
+        "name": "Custom local model",
+        "title": "Lokaal custom model",
+        "description": "In onze test haalde een LLM (AI) classifier 79% versus 80% mens, met 1 uur i.p.v. 24 uur werk (>95% berekende kostenbesparing) en strikt format + vertrouwelijkheid geborgd.",
+        "result": "Onderdeel van onze AI-integratie Pt.1 casestudyreeks.",
+        "cta": "Lees meer"
+      },
+      "aiIntegrationImageWorkflow": {
+        "label": "AI image workflow",
+        "field": "AI-integratie",
+        "name": "Optimized AI foto workflow",
+        "title": "Van 20u naar 45m: schaalbare AI-visuals",
+        "description": "Met parallelle generaties en een promptbibliotheek verkortte een custom platform de arbeidstijd van 20 uur (handmatig) en 7 uur (standaard AI) naar 45 minuten voor dezelfde kwaliteit.",
+        "result": "Onderdeel van onze AI-integratie Pt.1 casestudyreeks.",
+        "cta": "Lees meer"
+      },
       "researchAiAdoption": {
         "label": "AI-adoptie",
         "field": "Onderzoek",


### PR DESCRIPTION
## Summary
- replace the legacy Typescript tab in the homepage code examples carousel with an "AI integration pt1" case study group covering four recent projects
- add English and Dutch copy plus localized imagery references for the new showcase cards so both locales surface the correct assets
- document the content update in WRITE_HERE/UPDATES for continuity

## Plan
- replace the Typescript carousel tab with an AI integration Pt.1 showcase referencing the new blog posts
- add localized messaging and image variants for each case study entry
- log the content refresh in WRITE_HERE/UPDATES

## Testing
- `pnpm --filter www run lint` *(fails: missing next-intl dependency in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d786df3d48832a9491664790de34f6