### PR TITLE
Stabilize UTC date rendering to stop hydration errors

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-24T1600--stabilized-footer-year-hydration.md
+++ b/WRITE_HERE/FIXES/2025-11-24T1600--stabilized-footer-year-hydration.md
@@ -1,0 +1,5 @@
+# Stabilized footer copyright year hydration
+- **What:** Passed the server-computed year into the footer and hydrate it with client state so the copyright label updates after mount without mismatching the SSR markup.
+- **Why:** The footer previously called `new Date()` during render, so statically generated pages rendered last year's value on the server and the client calculated the current year, triggering a hydration failure when the values diverged.
+- **Files:** `apps/www/components/footer/footer.tsx`, `apps/www/app/[locale]/layout.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-24T1800--normalized-utc-date-formatting.md
+++ b/WRITE_HERE/FIXES/2025-11-24T1800--normalized-utc-date-formatting.md
@@ -1,0 +1,6 @@
+# Normalized UTC date formatting across client content
+
+- **What:** Added a reusable UTC date formatting helper and updated blog and changelog components to rely on it when rendering dates.
+- **Why:** Client-side hydration was failing because locale-sensitive date strings differed between server-rendered markup and the browser when the viewer's timezone shifted the calendar day.
+- **Files:** `apps/www/lib/date.ts`, `apps/www/app/[locale]/(site)/blog/[slug]/page.tsx`, `apps/www/app/[locale]/(site)/changelog/page.tsx`, `apps/www/components/blog/blog-card.tsx`, `apps/www/components/blog/blog-hero.tsx`, `apps/www/components/blog/suggested-blogs.tsx`, `apps/www/components/changelog/changelog-grid-item.tsx`.
+- **Follow-ups:** Consider migrating remaining utility imports to the shared date helper if new time-sensitive UI appears.

--- a/apps/www/app/[locale]/(site)/blog/[slug]/page.tsx
+++ b/apps/www/app/[locale]/(site)/blog/[slug]/page.tsx
@@ -5,11 +5,11 @@ import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/back
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { MeteorLinesAngular } from "@/components/ui/meteorLines";
 import { authors } from "@/content/blog/authors";
+import { formatDateUtc, formatIsoDateUtc } from "@/lib/date";
 import { localesForPost, shouldIncludePostForLocale } from "@/lib/blog-language";
 import { cn } from "@/lib/utils";
 import { allPosts } from "content-collections";
 import type { Post } from "content-collections";
-import { format, parseISO } from "date-fns";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -50,8 +50,8 @@ export function generateMetadata({
         height: 800,
       },
 
-      publishedTime: format(parseISO(post.date.toString()), "yyyy-MM-dd"),
-      modifiedTime: format(parseISO(post.date.toString()), "yyyy-MM-dd"),
+      publishedTime: formatIsoDateUtc(post.date),
+      modifiedTime: formatIsoDateUtc(post.date),
       tags: post.tags,
     },
     twitter: {
@@ -199,7 +199,11 @@ const BlogArticleWrapper = async ({
                       dateTime={post.date}
                       className="inline-flex items-center text-white text-nowrap"
                     >
-                      {format(parseISO(post.date), "MMM dd, yyyy")}
+                      {formatDateUtc(post.date, {
+                        month: "short",
+                        day: "2-digit",
+                        year: "numeric",
+                      })}
                     </time>
                   </div>
                 </div>
@@ -233,7 +237,11 @@ const BlogArticleWrapper = async ({
                 dateTime={post.date}
                 className="inline-flex items-center h-10 text-white text-nowrap"
               >
-                {format(parseISO(post.date), "MMM dd, yyyy")}
+                {formatDateUtc(post.date, {
+                  month: "short",
+                  day: "2-digit",
+                  year: "numeric",
+                })}
               </time>
             </div>
             {post.tableOfContents?.length !== 0 ? (

--- a/apps/www/app/[locale]/(site)/changelog/page.tsx
+++ b/apps/www/app/[locale]/(site)/changelog/page.tsx
@@ -5,8 +5,8 @@ import { MeteorLines } from "@/components/ui/meteorLines";
 
 import { ChangelogGridItem } from "@/components/changelog/changelog-grid-item";
 import { SideList } from "@/components/changelog/side-list";
+import { formatDateUtc } from "@/lib/date";
 import { allChangelogs } from "content-collections";
-import { formatDate } from "date-fns";
 import { ArrowRight } from "lucide-react";
 type Props = {
   searchParams?: {
@@ -95,7 +95,11 @@ export default async function Changelogs(_props: Props) {
                 <SideList
                   list={changelogs.map((c) => ({
                     href: `/changelog#${c.slug}`,
-                    label: formatDate(c.date, "MMMM dd, yyyy"),
+                    label: formatDateUtc(c.date, {
+                      month: "long",
+                      day: "2-digit",
+                      year: "numeric",
+                    }),
                   }))}
                 />
               </div>

--- a/apps/www/app/[locale]/layout.tsx
+++ b/apps/www/app/[locale]/layout.tsx
@@ -119,7 +119,7 @@ export default async function LocaleLayout({
             </div>
           ) : null}
         </div>
-        <Footer />
+        <Footer initialYear={new Date().getUTCFullYear()} />
       </ConsentManagerProvider>
     </NextIntlClientProvider>
   );

--- a/apps/www/components/blog/blog-card.tsx
+++ b/apps/www/components/blog/blog-card.tsx
@@ -1,6 +1,6 @@
 import type { Author } from "@/content/blog/authors";
+import { formatDateUtc } from "@/lib/date";
 import { cn } from "@/lib/utils";
-import { format } from "date-fns";
 import { Frame } from "../frame";
 import { ImageWithBlur } from "../image-with-blur";
 import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
@@ -73,7 +73,11 @@ export function BlogCard({
               </Avatar>
               <p className="pt-3 ml-4 text-sm font-medium text-white">{author.name}</p>
               <p className="pt-3 ml-6 text-sm font-normal text-white/50">
-                {format(new Date(publishDate!), "MMM dd, yyyy")}
+                {formatDateUtc(publishDate, {
+                  month: "short",
+                  day: "2-digit",
+                  year: "numeric",
+                })}
               </p>
             </div>
           </div>

--- a/apps/www/components/blog/blog-hero.tsx
+++ b/apps/www/components/blog/blog-hero.tsx
@@ -1,7 +1,7 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { Author } from "@/content/blog/authors";
+import { formatDateUtc } from "@/lib/date";
 import { cn } from "@/lib/utils";
-import { format } from "date-fns";
 import { Frame } from "../frame";
 import { ImageWithBlur } from "../image-with-blur";
 export function QuestionCircle({ className }: { className?: string }) {
@@ -93,7 +93,11 @@ export function BlogHero({
               <span className="text-sm text-white/50">Published on</span>
               <div>
                 <span className="pt-2 text-sm text-white">
-                  {format(new Date(publishDate!), "MMM dd, yyyy")}
+                  {formatDateUtc(publishDate, {
+                    month: "short",
+                    day: "2-digit",
+                    year: "numeric",
+                  })}
                 </span>
               </div>
             </div>

--- a/apps/www/components/blog/suggested-blogs.tsx
+++ b/apps/www/components/blog/suggested-blogs.tsx
@@ -1,6 +1,6 @@
+import { formatDateUtc } from "@/lib/date";
 import { cn } from "@/lib/utils";
 import { type Post, allPosts } from "content-collections";
-import { format } from "date-fns";
 import Link from "next/link";
 import { Frame } from "../frame";
 import { ImageWithBlur } from "../image-with-blur";
@@ -32,7 +32,11 @@ export function SuggestedBlogs({ className, currentPostSlug }: BlogListProps): J
                 </Frame>
                 <p className="text-white">{post?.title}</p>
                 <p className="text-sm text-white/50">
-                  {format(new Date(post?.date!), "MMM dd, yyyy")}
+                  {formatDateUtc(post?.date, {
+                    month: "short",
+                    day: "2-digit",
+                    year: "numeric",
+                  })}
                 </p>
               </div>
             </div>

--- a/apps/www/components/changelog/changelog-grid-item.tsx
+++ b/apps/www/components/changelog/changelog-grid-item.tsx
@@ -1,5 +1,6 @@
 import { MDX } from "@/components/mdx-content";
 import { Separator } from "@/components/ui/separator";
+import { formatDateUtc } from "@/lib/date";
 import { cn } from "@/lib/utils";
 import type { Changelog } from "content-collections";
 import Link from "next/link";
@@ -20,10 +21,10 @@ export async function ChangelogGridItem({ className, changelog }: Props) {
     <div id={changelog.slug} className={cn("w-full", className)}>
       <div>
         <div className="flex flex-col sm:flex-row pb-10 gap-4 font-medium">
-          {new Date(changelog.date).toLocaleDateString("en-US", {
-            year: "numeric",
+          {formatDateUtc(changelog.date, {
             month: "long",
             day: "numeric",
+            year: "numeric",
           })}
           <div className="flex flex-row gap-x-3">
             {changelog.tags?.map((tag) => (

--- a/apps/www/components/footer/footer.tsx
+++ b/apps/www/components/footer/footer.tsx
@@ -2,6 +2,7 @@
 import { Link } from "@/i18n/navigation";
 import { cn } from "@/lib/utils";
 import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
 import { UnkeyLogo } from "./footer-svgs";
 import { Wordmark } from "./wordmark";
 
@@ -105,8 +106,17 @@ const Column: React.FC<{
   );
 };
 
-export function Footer() {
+export function Footer({ initialYear }: { initialYear: number }) {
   const t = useTranslations("Footer");
+  const [year, setYear] = useState(initialYear);
+
+  useEffect(() => {
+    const currentYear = new Date().getUTCFullYear();
+    if (currentYear !== year) {
+      setYear(currentYear);
+    }
+  }, [year]);
+
   return (
     <div className="border-t border-white/20 blog-footer-radial-gradient">
       <footer className="container relative grid grid-cols-2 gap-8 pt-8 mx-auto overflow-hidden lg:gap-16 sm:grid-cols-3 xl:grid-cols-5 sm:pt-12 md:pt-16 lg:pt-24 xl:pt-32">
@@ -116,7 +126,7 @@ export function Footer() {
             {t("tagline")}
           </div>
           <div className="text-sm font-normal leading-6 text-white/40">
-            {t("copyright", { year: new Date().getUTCFullYear() })}
+            {t("copyright", { year })}
           </div>
         </div>
 

--- a/apps/www/lib/date.ts
+++ b/apps/www/lib/date.ts
@@ -1,0 +1,37 @@
+export type DateInput = Date | string | number | null | undefined;
+
+function toDate(value: DateInput): Date | null {
+  if (value == null) {
+    return null;
+  }
+
+  const date = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date;
+}
+
+export function formatDateUtc(
+  value: DateInput,
+  options: Intl.DateTimeFormatOptions,
+  locale: string = "en-US",
+): string {
+  const date = toDate(value);
+  if (!date) {
+    return "";
+  }
+
+  return new Intl.DateTimeFormat(locale, { timeZone: "UTC", ...options }).format(date);
+}
+
+export function formatIsoDateUtc(value: DateInput): string {
+  const date = toDate(value);
+  if (!date) {
+    return "";
+  }
+
+  return date.toISOString().split("T")[0] ?? "";
+}


### PR DESCRIPTION
## Summary
- add a shared UTC-aware date formatting helper for consistent SSR/client output
- switch blog and changelog UI (cards, hero, suggestions, metadata) to the helper so rendered dates no longer drift by timezone
- document the hydration fix in WRITE_HERE/FIXES for future reference

## Plan
- audit date formatting across shared blog and changelog surfaces for timezone-sensitive output
- replace locale-dependent `date-fns` usage with the new UTC formatter helper
- update metadata and logging to reflect the stable date handling
- run typecheck and capture existing lint debt that is unrelated to this change

## Testing
- pnpm --filter www run typecheck
- pnpm --filter www run lint *(fails: pre-existing lint issues in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7849517b8832aaf28ca4b241811c7