### PR TITLE
Filter blog listing to project posts and adjust image ratios

### DIFF
--- a/WRITE_HERE/FIXES/2025-09-30T1010--filtered-project-blogs-and-hero-aspect.md
+++ b/WRITE_HERE/FIXES/2025-09-30T1010--filtered-project-blogs-and-hero-aspect.md
@@ -1,0 +1,6 @@
+# Filtered project blogs and corrected hero aspect ratio
+
+- **What:** Limited blog listings and feeds to MDX project posts via a reusable filter helper and added 3:2 responsive handling for blog imagery.
+- **Why:** Ensure only TransformAI case study content appears across blog surfaces and prevent 1536x1024 assets from being distorted.
+- **Files:** `apps/www/content-collections.ts`, `apps/www/lib/blog-posts.ts`, `apps/www/app/[locale]/(site)/blog/page.tsx`, `apps/www/app/[locale]/(site)/blog/[slug]/page.tsx`, `apps/www/app/feed.xml/route.ts`, `apps/www/app/sitemap.ts`, `apps/www/components/blog/blog-hero.tsx`, `apps/www/components/blog/blog-card.tsx`, `apps/www/components/blog/suggested-blogs.tsx`.
+- **Follow-ups:** Update curated selections on other pages if they should reference the new project-focused articles.

--- a/apps/www/app/[locale]/(site)/blog/[slug]/page.tsx
+++ b/apps/www/app/[locale]/(site)/blog/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { MeteorLinesAngular } from "@/components/ui/meteorLines";
 import { authors } from "@/content/blog/authors";
 import { formatDateUtc, formatIsoDateUtc } from "@/lib/date";
 import { localesForPost, shouldIncludePostForLocale } from "@/lib/blog-language";
+import { filterProjectPosts } from "@/lib/blog-posts";
 import { cn } from "@/lib/utils";
 import { allPosts } from "content-collections";
 import type { Post } from "content-collections";
@@ -16,8 +17,10 @@ import { notFound } from "next/navigation";
 
 export const dynamic = "force-static";
 
+const projectPosts = filterProjectPosts(allPosts);
+
 export const generateStaticParams = async () =>
-  allPosts.flatMap((post) =>
+  projectPosts.flatMap((post) =>
     localesForPost(post.language).map((locale) => ({
       locale,
       slug: post.slug,
@@ -29,7 +32,7 @@ export function generateMetadata({
 }: {
   params: { slug: string; locale: string };
 }): Metadata {
-  const post = allPosts.find((post) => post.slug === `${params.slug}`);
+  const post = projectPosts.find((post) => post.slug === `${params.slug}`);
   if (!post || !shouldIncludePostForLocale(post.language, params.locale)) {
     notFound();
   }
@@ -77,7 +80,7 @@ const BlogArticleWrapper = async ({
 }: {
   params: { slug: string; locale: string };
 }) => {
-  const post = allPosts.find((post) => post.slug === `${params.slug}`) as Post | undefined;
+  const post = projectPosts.find((post) => post.slug === `${params.slug}`) as Post | undefined;
   if (!post || !shouldIncludePostForLocale(post.language, params.locale)) {
     notFound();
   }

--- a/apps/www/app/[locale]/(site)/blog/page.tsx
+++ b/apps/www/app/[locale]/(site)/blog/page.tsx
@@ -5,6 +5,7 @@ import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/back
 import { MeteorLinesAngular } from "@/components/ui/meteorLines";
 import { authors } from "@/content/blog/authors";
 import { shouldIncludePostForLocale } from "@/lib/blog-language";
+import { filterProjectPosts } from "@/lib/blog-posts";
 import { type Post, allPosts } from "content-collections";
 import Link from "next/link";
 
@@ -40,7 +41,8 @@ export default async function Blog({
 }: {
   params: { locale: string };
 }) {
-  const filteredPosts = allPosts.filter((post) =>
+  const projectPosts = filterProjectPosts(allPosts);
+  const filteredPosts = projectPosts.filter((post) =>
     shouldIncludePostForLocale(post.language, params.locale),
   );
 

--- a/apps/www/app/feed.xml/route.ts
+++ b/apps/www/app/feed.xml/route.ts
@@ -1,4 +1,5 @@
 import { authors } from "@/content/blog/authors";
+import { filterProjectPosts } from "@/lib/blog-posts";
 import { type Post, allPosts } from "content-collections";
 import RSS from "rss";
 const feed = new RSS({
@@ -11,7 +12,7 @@ const feed = new RSS({
   pubDate: new Date(),
 });
 
-const posts = allPosts.sort((a: Post, b: Post) => {
+const posts = filterProjectPosts([...allPosts]).sort((a: Post, b: Post) => {
   return new Date(b.date).getTime() - new Date(a.date).getTime();
 });
 

--- a/apps/www/app/sitemap.ts
+++ b/apps/www/app/sitemap.ts
@@ -1,10 +1,11 @@
+import { filterProjectPosts } from "@/lib/blog-posts";
 import { allChangelogs, allGlossaries, allPolicies, allPosts } from "content-collections";
 import type { Changelog, Glossary, Policy, Post } from "content-collections";
 import type { MetadataRoute } from "next";
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = "https://www.unkey.com";
 
-  const posts: MetadataRoute.Sitemap = allPosts.map((post: Post) => ({
+  const posts: MetadataRoute.Sitemap = filterProjectPosts(allPosts).map((post: Post) => ({
     url: `${baseUrl}/blog/${post.slug}`,
     lastModified: post.date,
   }));

--- a/apps/www/components/blog/blog-card.tsx
+++ b/apps/www/components/blog/blog-card.tsx
@@ -33,13 +33,13 @@ export function BlogCard({
     >
       <div className="w-full rounded-2xl bg-clip-border">
         <Frame size="sm">
-          <div className="relative aspect-video">
+          <div className="relative aspect-[3/2]">
             <ImageWithBlur
               placeholder="blur"
               blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8+e1bKQAJMQNc5W2CQwAAAABJRU5ErkJggg=="
               src={imageUrl!}
               alt="Hero Image"
-              className="object-center w-full overflow-hidden"
+              className="object-cover object-center w-full h-full overflow-hidden"
               fill={true}
             />
           </div>

--- a/apps/www/components/blog/blog-hero.tsx
+++ b/apps/www/components/blog/blog-hero.tsx
@@ -51,9 +51,10 @@ export function BlogHero({
             placeholder="blur"
             blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8+e1bKQAJMQNc5W2CQwAAAABJRU5ErkJggg=="
             src={imageUrl!}
-            width={1920}
-            height={1080}
+            width={1536}
+            height={1024}
             alt="Hero Image"
+            className="h-full w-full object-cover"
           />
         </Frame>
       </div>

--- a/apps/www/components/blog/suggested-blogs.tsx
+++ b/apps/www/components/blog/suggested-blogs.tsx
@@ -1,4 +1,5 @@
 import { formatDateUtc } from "@/lib/date";
+import { filterProjectPosts } from "@/lib/blog-posts";
 import { cn } from "@/lib/utils";
 import { type Post, allPosts } from "content-collections";
 import Link from "next/link";
@@ -11,7 +12,9 @@ type BlogListProps = {
 };
 
 export function SuggestedBlogs({ className, currentPostSlug }: BlogListProps): JSX.Element {
-  const posts = allPosts.filter((post: Post, _i) => post.url !== currentPostSlug).slice(0, 3);
+  const posts = filterProjectPosts(allPosts)
+    .filter((post: Post) => post.url !== currentPostSlug)
+    .slice(0, 3);
   if (posts.length === 0) {
     return <></>;
   }

--- a/apps/www/content-collections.ts
+++ b/apps/www/content-collections.ts
@@ -6,6 +6,8 @@ import { categoryEnum } from "./app/[locale]/(site)/glossary/data";
 import { faqSchema } from "./lib/schemas/faq-schema";
 import { takeawaysSchema } from "./lib/schemas/takeaways-schema";
 
+const PROJECT_POST_PREFIX = "mdxfilesforprojects/";
+
 const posts = defineCollection({
   name: "posts",
   directory: "content/blog",
@@ -43,13 +45,17 @@ const posts = defineCollection({
         slug: content ? slugger.slug(content) : undefined,
       };
     });
+    const sourcePath = document._meta.path;
     const slugFromPath =
-      document._meta.path.split("/").pop() ?? document._meta.fileName.replace(/\.mdx$/i, "");
+      sourcePath.split("/").pop() ?? document._meta.fileName.replace(/\.mdx$/i, "");
+    const isProjectPost = sourcePath.startsWith(PROJECT_POST_PREFIX);
 
     return {
       ...document,
       language: normalizedLanguage,
       mdx,
+      sourcePath,
+      isProjectPost,
       slug: slugFromPath,
       url: `/blog/${slugFromPath}`,
       tableOfContents,

--- a/apps/www/lib/blog-posts.ts
+++ b/apps/www/lib/blog-posts.ts
@@ -1,0 +1,5 @@
+import type { Post } from "content-collections";
+
+export function filterProjectPosts(posts: Post[]) {
+  return posts.filter((post) => post.isProjectPost);
+}


### PR DESCRIPTION
## Plan
- Tag blog entries from the mdx project directory within the content collection metadata.
- Filter blog listings, feeds, and suggested content so only project posts surface.
- Update blog card/hero media handling to respect the 1536×1024 aspect ratio.

## Summary
- Added project path metadata in the blog content collection plus a helper to filter qualifying posts.
- Limited blog index, article routes, sitemap, feed, and suggestions to project posts only.
- Matched hero and card imagery to the 3:2 aspect ratio used by 1536×1024 assets.

## Testing
- `pnpm --filter www run lint` *(fails: missing optional dependency `next-intl` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbab9bb6fc832a9fca6c89f4785315