### PR TITLE
Randomize About page blog showcase

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-25T0900--randomized-about-blog-showcase.md
+++ b/WRITE_HERE/FIXES/2025-11-25T0900--randomized-about-blog-showcase.md
@@ -1,0 +1,5 @@
+# Randomized About page blog showcase
+- **What:** Updated the About page to pull three project blog posts at random per locale, reusing helpers to filter project entries and avoid repeats.
+- **Why:** Previously hard-coded slugs surfaced outdated articles; the new selection keeps the section fresh and aligned with the project blog map.
+- **Files:** `apps/www/app/[locale]/(site)/about/page.tsx`, `apps/www/lib/blog-posts.ts`
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -11,6 +11,7 @@ import type { LucideIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { unstable_noStore as noStore } from "next/cache";
 import { getTranslations } from "next-intl/server";
 
 import { Fragment, type ReactNode } from "react";
@@ -56,6 +57,8 @@ import { ImageWithBlur } from "@/components/image-with-blur";
 import { loadMessages } from "@/i18n/messages";
 import type { Messages } from "@/i18n/messages";
 import { isLocale } from "@/i18n/routing";
+import { shouldIncludePostForLocale } from "@/lib/blog-language";
+import { filterProjectPosts, selectRandomPosts } from "@/lib/blog-posts";
 import { cn } from "@/lib/utils";
 
 export const metadata = {
@@ -99,8 +102,6 @@ const investors = [
   { name: "Zain Allarakhia", firm: "Former CTO @ Pipe", image: zain },
 ];
 
-const SELECTED_POSTS = ["uuid-ux", "why-we-built-unkey", "unkey-raises-1-5-million"];
-
 type PageProps = {
   params: {
     locale: string;
@@ -113,6 +114,8 @@ export default async function Page({ params }: PageProps) {
   if (!isLocale(locale)) {
     notFound();
   }
+
+  noStore();
 
   const t = await getTranslations({ locale, namespace: "About" });
   const messages = await loadMessages(locale);
@@ -227,7 +230,22 @@ export default async function Page({ params }: PageProps) {
   const blogTitle = t("Blog.title");
   const blogBody = t("Blog.body");
 
-  const posts = allPosts.filter((post) => SELECTED_POSTS.includes(post.slug));
+  const projectPosts = filterProjectPosts(allPosts);
+  const localizedPosts = projectPosts.filter((post) =>
+    shouldIncludePostForLocale(post.language, locale),
+  );
+  const initialPosts = selectRandomPosts(
+    localizedPosts,
+    Math.min(3, localizedPosts.length),
+  );
+  const fallbackPosts = projectPosts.filter(
+    (post) => !initialPosts.some((selected) => selected.slug === post.slug),
+  );
+  const supplementalPosts = selectRandomPosts(
+    fallbackPosts,
+    Math.max(3 - initialPosts.length, 0),
+  );
+  const posts = [...initialPosts, ...supplementalPosts];
   return (
     <div>
       <Container>

--- a/apps/www/lib/blog-posts.ts
+++ b/apps/www/lib/blog-posts.ts
@@ -3,3 +3,22 @@ import type { Post } from "content-collections";
 export function filterProjectPosts(posts: Post[]) {
   return posts.filter((post) => post.isProjectPost);
 }
+
+export function selectRandomPosts(posts: Post[], count: number) {
+  if (posts.length <= count) {
+    return [...posts];
+  }
+
+  const shuffled = [...posts];
+
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const randomIndex = Math.floor(Math.random() * (index + 1));
+
+    [shuffled[index], shuffled[randomIndex]] = [
+      shuffled[randomIndex],
+      shuffled[index],
+    ];
+  }
+
+  return shuffled.slice(0, count);
+}


### PR DESCRIPTION
## Summary
- randomize the About page blog section using project MDX entries
- reuse helpers to filter project posts by locale and avoid duplicate selections
- document the fix in the repository log

## Plan
- inspect the About page blog showcase implementation and supporting helpers
- update the selection logic to draw from project posts with locale filtering and random sampling
- add any supporting utilities and repository notes needed for the change

## Testing
- `pnpm --filter www run lint` *(fails: missing dependency \`next-intl\` in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbbb499a44832a8a71f77870af76d8