### PR TITLE
Revamp careers page with pricing-style openings

### DIFF
--- a/WRITE_HERE/UPDATES/2025-09-30T1137--careers-page-refresh.md
+++ b/WRITE_HERE/UPDATES/2025-09-30T1137--careers-page-refresh.md
@@ -1,0 +1,6 @@
+# Refreshed careers openings and CTA linkage
+
+- **What:** Replaced the careers hero copy with the Amsterdam-based message, rebuilt the open roles using pricing-inspired cards with apply buttons, and wired job details through translations.
+- **Why:** Align the careers page and about-page CTA with the requested TransformAI vacancies and remote policy messaging.
+- **Files:** `apps/www/app/[locale]/(site)/careers/page.tsx`, `apps/www/messages/en.json`.
+- **Follow-ups:** Translate the new careers copy for additional locales when available.

--- a/apps/www/app/[locale]/(site)/careers/page.tsx
+++ b/apps/www/app/[locale]/(site)/careers/page.tsx
@@ -1,10 +1,81 @@
+import { PrimaryButton } from "@/components/button";
+import { ShinyCardGroup } from "@/components/shiny-card";
 import { ChangelogLight } from "@/components/svg/changelog";
 import { MeteorLines } from "@/components/ui/meteorLines";
-
-import { allCareers } from "content-collections";
+import { cn } from "@/lib/utils";
+import { getTranslations } from "next-intl/server";
 import Link from "next/link";
 
-export default async function Careers() {
+type CareersPageProps = {
+  params: {
+    locale: string;
+  };
+};
+
+export default async function Careers({ params }: CareersPageProps) {
+  const { locale } = params;
+  const t = await getTranslations({ locale, namespace: "Careers" });
+
+  const detailsLabels = {
+    focus: t("details.focus"),
+    experience: t("details.experience"),
+    portfolio: t("details.portfolio"),
+    evaluation: t("details.evaluation"),
+    salary: t("details.salary"),
+  } as const;
+
+  const emailBase = "mailto:careers@transformai.ai";
+
+  const positions = [
+    {
+      key: "socialMediaMarketingManager",
+      title: t("positions.socialMediaMarketingManager.title"),
+      summary: t("positions.socialMediaMarketingManager.summary"),
+      details: [
+        { label: detailsLabels.focus, value: t("positions.socialMediaMarketingManager.focus") },
+        { label: detailsLabels.experience, value: t("positions.socialMediaMarketingManager.experience") },
+        { label: detailsLabels.portfolio, value: t("positions.socialMediaMarketingManager.portfolio") },
+        { label: detailsLabels.salary, value: t("positions.socialMediaMarketingManager.salary") },
+      ],
+      href: `${emailBase}?subject=${encodeURIComponent(
+        t("positions.socialMediaMarketingManager.emailSubject"),
+      )}`,
+      accent: "from-white/30 via-white/10 to-transparent",
+    },
+    {
+      key: "aiIntegrationExpert",
+      title: t("positions.aiIntegrationExpert.title"),
+      summary: t("positions.aiIntegrationExpert.summary"),
+      details: [
+        { label: detailsLabels.focus, value: t("positions.aiIntegrationExpert.focus") },
+        { label: detailsLabels.evaluation, value: t("positions.aiIntegrationExpert.evaluation") },
+        { label: detailsLabels.salary, value: t("positions.aiIntegrationExpert.salary") },
+      ],
+      href: `${emailBase}?subject=${encodeURIComponent(
+        t("positions.aiIntegrationExpert.emailSubject"),
+      )}`,
+      accent: "from-[#FFD600]/30 via-[#FFD600]/15 to-transparent",
+    },
+    {
+      key: "juniorDataAnalyst",
+      title: t("positions.juniorDataAnalyst.title"),
+      summary: t("positions.juniorDataAnalyst.summary"),
+      details: [
+        { label: detailsLabels.focus, value: t("positions.juniorDataAnalyst.focus") },
+        { label: detailsLabels.experience, value: t("positions.juniorDataAnalyst.experience") },
+        { label: detailsLabels.salary, value: t("positions.juniorDataAnalyst.salary") },
+      ],
+      href: `${emailBase}?subject=${encodeURIComponent(
+        t("positions.juniorDataAnalyst.emailSubject"),
+      )}`,
+      accent: "from-[#9D72FF]/30 via-[#9D72FF]/15 to-transparent",
+    },
+  ] as const;
+
+  const heroTitle = t("hero.title");
+  const heroSubtitle = t("hero.subtitle");
+  const applyLabel = t("apply.label");
+
   return (
     <>
       <div className="container mt-48 text-white/60">
@@ -59,35 +130,62 @@ export default async function Careers() {
             />
           </div>
         </div>
-        <div>
-          <div className="flex flex-row text-center">
-            <div className="mx-auto flex-flex-col ">
-              <h2 className="blog-heading-gradient text-6xl font-medium mt-12">Open Positions</h2>
-              <p className="mt-6 font-normal leading-7 text-balance">
-                Unkey is 100% remote. We currently live in Germany, Turkey and the United States.
-              </p>
-            </div>
+        <div className="relative z-10">
+          <div className="text-center max-w-3xl mx-auto">
+            <h2 className="blog-heading-gradient text-6xl font-medium mt-12 text-balance">{heroTitle}</h2>
+            <p className="mt-6 font-normal leading-7 text-balance text-white/70">{heroSubtitle}</p>
           </div>
 
-          <div className="flex flex-row mt-[5.5rem] mb-20 w-full mx-auto container">
-            <div className="flex flex-col w-full sm:overflow-hidden gap-16">
-              {allCareers
-                .filter((c) => c.visible)
-                .map((c) => (
-                  <Link
-                    href={`/careers/${c.slug}`}
-                    id={c.slug}
-                    key={c.slug}
-                    className="w-full flex flex-col gap-2"
-                  >
-                    <h3 className="font-display text-4xl font-medium blog-heading-gradient ">
-                      {c.title}
-                    </h3>
-                    <p className="text-lg font-normal">{c.description}</p>
-                  </Link>
-                ))}
-            </div>
-          </div>
+          <ShinyCardGroup className="mt-[5.5rem] mb-20 grid w-full gap-8 lg:grid-cols-3">
+            {positions.map((position) => (
+              <article key={position.key} className="group">
+                <div className="relative flex h-full flex-col overflow-hidden rounded-[32px] border border-white/10 bg-black/80 p-[1px]">
+                  <div className="relative flex h-full flex-col overflow-hidden rounded-[32px] bg-black/90 p-8">
+                    <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
+                      <div
+                        className={cn(
+                          "absolute inset-x-6 -top-32 h-64 rounded-full blur-3xl",
+                          "opacity-60",
+                          "bg-gradient-to-br",
+                          position.accent,
+                        )}
+                      />
+                      <div
+                        className={cn(
+                          "absolute inset-0 rounded-[32px] border border-white/5",
+                          "opacity-30",
+                        )}
+                      />
+                    </div>
+
+                    <div className="relative z-10 flex h-full flex-col">
+                      <h3 className="text-3xl font-semibold text-transparent bg-gradient-to-br from-white via-white to-white/60 bg-clip-text">
+                        {position.title}
+                      </h3>
+                      <p className="mt-4 text-base text-white/70">{position.summary}</p>
+
+                      <dl className="mt-8 flex flex-col gap-4 text-sm text-white/70">
+                        {position.details.map((detail) => (
+                          <div key={detail.label} className="flex flex-col gap-1 rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+                            <dt className="text-xs font-semibold uppercase tracking-[0.18em] text-white/50">
+                              {detail.label}
+                            </dt>
+                            <dd className="text-base text-white/90">{detail.value}</dd>
+                          </div>
+                        ))}
+                      </dl>
+
+                      <div className="mt-10 pt-6 border-t border-white/10">
+                        <Link href={position.href} className="inline-flex">
+                          <PrimaryButton shiny label={applyLabel} />
+                        </Link>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </ShinyCardGroup>
         </div>
       </div>
     </>
@@ -95,13 +193,13 @@ export default async function Careers() {
 }
 
 export const metadata = {
-  title: "Careers | Unkey",
+  title: "Careers | TransformAI",
   description: "Join us.",
   openGraph: {
-    title: "Careers | Unkey",
+    title: "Careers | TransformAI",
     description: "Join us.",
-    url: "https://unkey.com/careers",
-    siteName: "unkey.com",
+    url: "https://transformai.ai/careers",
+    siteName: "transformai.ai",
     images: [
       {
         url: "https://unkey.com/og",
@@ -111,7 +209,7 @@ export const metadata = {
     ],
   },
   twitter: {
-    title: "Careers | Unkey",
+    title: "Careers | TransformAI",
     card: "summary_large_image",
   },
   icons: {

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -326,6 +326,49 @@
       "body": "Explore insights, tips, and updates directly from our team members"
     }
   },
+  "Careers": {
+    "hero": {
+      "title": "Open positions",
+      "subtitle": "Based in Amsterdam, the Netherlands — working remote is also discussable."
+    },
+    "apply": {
+      "label": "Apply here"
+    },
+    "details": {
+      "focus": "Focus",
+      "experience": "Experience",
+      "portfolio": "Portfolio",
+      "evaluation": "Evaluation",
+      "salary": "Salary"
+    },
+    "positions": {
+      "socialMediaMarketingManager": {
+        "title": "Social Media Marketing Manager",
+        "summary": "Grow TransformAI’s voice across every social channel and translate product stories into measurable brand momentum.",
+        "focus": "Lead strategic campaigns, collaborate with founders on storytelling, and keep our community engaged with fresh, insight-driven content.",
+        "experience": "+3 years shaping social media marketing programs with proven growth metrics.",
+        "portfolio": "Share a portfolio that highlights campaign creativity, performance data, and content craft.",
+        "salary": "€4,500+ net per month.",
+        "emailSubject": "Application – Social Media Marketing Manager"
+      },
+      "aiIntegrationExpert": {
+        "title": "AI Integration Expert",
+        "summary": "Design and deliver AI-driven workflows for clients ready to operationalise advanced automation.",
+        "focus": "Architect integrations that blend strategy, technical execution, and change management for Dutch enterprises.",
+        "evaluation": "An interview test covering technical depth, AI integration insights, and a personality assessment will determine fit.",
+        "salary": "€12,500 net per month.",
+        "emailSubject": "Application – AI Integration Expert"
+      },
+      "juniorDataAnalyst": {
+        "title": "Junior Data Analyst",
+        "summary": "Accelerate how we analyse AI programme data and keep our internal CRM intelligence sharp.",
+        "focus": "Automate reporting pipelines, organise experiment results, and support the insights team across active engagements.",
+        "experience": "No prior experience required — bring curiosity and a willingness to learn.",
+        "salary": "€6,750+ net per month.",
+        "emailSubject": "Application – Junior Data Analyst"
+      }
+    }
+  },
   "LogoCloud": {
     "label": "Partners"
   },


### PR DESCRIPTION
## Summary
- replace the careers hero copy with the Amsterdam remote policy messaging and move strings into `next-intl`
- rebuild the careers listings as pricing-inspired cards with translated details and mailto-based apply buttons
- log the change in WRITE_HERE/UPDATES for continuity

## Plan
- Refresh hero copy to match the requested messaging
- Replace the MDX-driven listings with styled, translated vacancy cards
- Capture the update in the repository change log

## Testing
- `pnpm --filter www run lint` *(fails: existing lint violations in unrelated startup/template pages)*

------
https://chatgpt.com/codex/tasks/task_e_68dbbf91ad24832a83131a42732b197f