### PR TITLE
Remove blur from language selector backdrop

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-24T1500--language-selection-overlay-refresh.md
+++ b/WRITE_HERE/UPDATES/2025-11-24T1500--language-selection-overlay-refresh.md
@@ -1,0 +1,5 @@
+# Refreshed language selection overlay
+- **What:** Replaced the standalone language picker with a blurred preview of the English homepage behind a pricing-inspired glass card, added the Unkey logo with the TransformAI origin line, and restyled the locale buttons with gradient accents.
+- **Why:** Align the language selection step with the rest of the site so it feels integrated instead of a separate screen while reflecting the TransformAI brand story.
+- **Files:** `apps/www/app/select-language/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Verify the blurred iframe background behaves well once additional locales or animations land on the homepage.

--- a/WRITE_HERE/UPDATES/2025-11-24T1730--language-preview-lightened.md
+++ b/WRITE_HERE/UPDATES/2025-11-24T1730--language-preview-lightened.md
@@ -1,0 +1,5 @@
+# Softened language preview veil
+- **What:** Brightened the select-language backdrop by reducing blur, easing the gradient scrim, and reusing the saved locale cookie to preview the matching homepage in the iframe.
+- **Why:** Let visitors recognize the TransformAI site instantly while assuring them the locale they pick reflects the experience they are about to enter.
+- **Files:** `apps/www/app/select-language/page.tsx`.
+- **Follow-ups:** Confirm the lighter treatment still meets contrast guidelines once light mode art direction is finalized.

--- a/WRITE_HERE/UPDATES/2025-11-24T2000--language-preview-clarified.md
+++ b/WRITE_HERE/UPDATES/2025-11-24T2000--language-preview-clarified.md
@@ -1,0 +1,7 @@
+# Clarified language preview backdrop
+- **What:** Softened the blur and eased the dark gradient over the homepage preview on the language selection screen so the Engl
+ish site remains clearly visible behind the locale modal.
+- **Why:** Ensure visitors immediately recognize the TransformAI homepage while still guiding them to confirm their language.
+- **Files:** `apps/www/app/select-language/page.tsx`.
+- **Follow-ups:** Capture updated visuals in the design system once the locale selector art direction is finalized across light
+mode.

--- a/WRITE_HERE/UPDATES/2025-11-24T2130--language-preview-unblurred.md
+++ b/WRITE_HERE/UPDATES/2025-11-24T2130--language-preview-unblurred.md
@@ -1,0 +1,5 @@
+# Removed language screen blur
+- **What:** Let the homepage render crisply behind the language selector by removing the dark scrim and blur from the preview iframe.
+- **Why:** Align with the request to make the selector feel like part of the main page so visitors instantly trust the experience.
+- **Files:** `apps/www/app/select-language/page.tsx`.
+- **Follow-ups:** Capture refreshed screenshots once the dev server can run with the missing dependencies resolved.

--- a/apps/www/app/select-language/page.tsx
+++ b/apps/www/app/select-language/page.tsx
@@ -1,5 +1,7 @@
-import { locales, type Locale, defaultLocale } from "@/i18n/routing";
+import { UnkeyLogo } from "@/components/footer/footer-svgs";
+import { type Locale, defaultLocale, isLocale } from "@/i18n/routing";
 import { createTranslator } from "next-intl";
+import { cookies } from "next/headers";
 
 type LanguageOption = {
   locale: Locale;
@@ -7,6 +9,8 @@ type LanguageOption = {
 };
 
 export default async function SelectLanguagePage() {
+  const cookieLocale = cookies().get("NEXT_LOCALE")?.value;
+  const previewLocale = cookieLocale && isLocale(cookieLocale) ? cookieLocale : defaultLocale;
   const messages = (await import("@/messages/en.json")).default;
   const t = createTranslator({
     locale: defaultLocale,
@@ -20,22 +24,58 @@ export default async function SelectLanguagePage() {
   ];
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-black px-6 py-24 text-white">
-      <div className="max-w-md w-full space-y-8 text-center">
-        <h1 className="text-3xl font-semibold tracking-tight">{t("selectTitle")}</h1>
-        <form action="/api/select-language" method="post" className="grid gap-4">
-          {options.map(({ locale, label }) => (
-            <button
-              key={locale}
-              type="submit"
-              name="locale"
-              value={locale}
-              className="w-full rounded-lg border border-white/20 bg-white/5 px-4 py-3 text-base font-medium transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
-            >
-              {label}
-            </button>
-          ))}
-        </form>
+    <div className="relative min-h-screen overflow-hidden text-white">
+      <div aria-hidden className="absolute inset-0 -z-10">
+        <iframe
+          src={`/${previewLocale}`}
+          title="TransformAI preview"
+          loading="lazy"
+          tabIndex={-1}
+          aria-hidden={true}
+          className="h-full w-full border-0 pointer-events-none"
+        />
+      </div>
+
+      <div className="relative z-10 flex min-h-screen items-center justify-center px-6 py-16 sm:py-24">
+        <div className="relative w-full max-w-xl">
+          <div className="pointer-events-none absolute inset-0 -z-10 rounded-[32px] bg-gradient-to-r from-sky-500/25 via-blue-500/15 to-fuchsia-500/30 opacity-80 blur-3xl" />
+          <div className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/[0.03] px-8 py-12 text-center shadow-[0_32px_140px_rgba(15,23,42,0.55)] backdrop-blur-xl sm:px-12 sm:py-14">
+            <div className="pointer-events-none absolute inset-0 -z-10">
+              <div className="absolute inset-x-8 -top-40 h-56 rounded-full bg-gradient-to-r from-sky-400/40 via-blue-500/15 to-fuchsia-500/45 blur-3xl" />
+              <div className="absolute left-1/2 top-1/2 h-[420px] w-[420px] -translate-x-1/2 -translate-y-1/2 bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.25),_rgba(15,23,42,0))]" />
+            </div>
+
+            <div className="flex flex-col items-center gap-6">
+              <UnkeyLogo className="h-10 w-auto" />
+              <p className="text-sm text-white/70">{t("tagline")}</p>
+              <h1 className="text-balance text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                {t("selectTitle")}
+              </h1>
+              <form action="/api/select-language" method="post" className="mt-4 grid w-full gap-4 text-left">
+                {options.map(({ locale, label }) => (
+                  <button
+                    key={locale}
+                    type="submit"
+                    name="locale"
+                    value={locale}
+                    className="group relative flex w-full items-center justify-between overflow-hidden rounded-2xl border border-white/15 bg-white/[0.04] px-6 py-4 text-base font-semibold text-white transition hover:border-white/25 hover:bg-white/[0.06] focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                  >
+                    <span className="relative z-10">{label}</span>
+                    <span
+                      aria-hidden
+                      className="absolute inset-0 z-0 opacity-0 transition duration-300 group-hover:opacity-100 group-focus-visible:opacity-100"
+                    >
+                      <span className="absolute inset-0 bg-gradient-to-r from-sky-500/30 via-blue-500/15 to-fuchsia-500/35" />
+                    </span>
+                    <span className="relative z-10 text-sm font-medium uppercase tracking-[0.2em] text-white/60">
+                      {locale.toUpperCase()}
+                    </span>
+                  </button>
+                ))}
+              </form>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -796,6 +796,7 @@
   },
   "Language": {
     "selectTitle": "Select language",
+    "tagline": "TransformAI founded in 2025 in Amsterdam, The Netherlands.",
     "english": "English",
     "dutch": "Nederlands",
     "submit": "Continue"

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -753,6 +753,7 @@
   },
   "Language": {
     "selectTitle": "Selecteer taal",
+    "tagline": "TransformAI opgericht in 2025 in Amsterdam, Nederland.",
     "english": "Engels",
     "dutch": "Nederlands",
     "submit": "Doorgaan"


### PR DESCRIPTION
## Summary
- render the English homepage sharply behind the language selector by removing the dark scrim and blur from the preview iframe
- keep the gradient glass card styling while letting the background show through so the selector feels native to the page
- document the unblurred treatment in WRITE_HERE/UPDATES for project continuity

## Plan
- strip the iframe blur and gradient overlay so the real homepage is visible as soon as the selector mounts
- ensure the selector card still sits above the live backdrop without additional wrappers or backgrounds
- log the refinement in WRITE_HERE/UPDATES with context and follow-ups

## Testing
- pnpm --filter www run lint *(fails: workspace is missing the `next-intl` dependency required by Next.js tooling)*
- pnpm --filter www dev *(fails: workspace is missing the `next-intl` dependency required by Next.js tooling)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc29d9100832aa4d454594c48fbf5