### PR TITLE
Polish TransformAI navigation logo sizing

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-25T1500--transformai-logo-refresh.md
+++ b/WRITE_HERE/UPDATES/2025-11-25T1500--transformai-logo-refresh.md
@@ -1,0 +1,5 @@
+# TransformAI logos swapped into UI
+- **What:** Replaced remaining Unkey-branded logos with the provided TransformAI artwork, updated header/footer components, and switched metadata favicons to the new icon set.
+- **Why:** Align the site visuals with the TransformAI brand after adding the new assets.
+- **Files:** `apps/www/components/footer/footer-svgs.tsx`, `apps/www/components/footer/footer.tsx`, `apps/www/components/footer/wordmark.tsx`, `apps/www/components/navbar/navigation.tsx`, `apps/www/app/select-language/page.tsx`, and Next metadata files pointing at favicons.
+- **Follow-ups:** Capture additional branded assets if any new pages or sections are introduced later.

--- a/WRITE_HERE/UPDATES/2025-11-25T1730--navigation-logo-polish.md
+++ b/WRITE_HERE/UPDATES/2025-11-25T1730--navigation-logo-polish.md
@@ -1,0 +1,5 @@
+# Navigation logo refined
+- **What:** Swapped the header logo to the transparent artwork and relaxed the shared logo component defaults so the assets render at their natural aspect ratio with lossless quality.
+- **Why:** The previous implementation squeezed the artwork and kept the dark variant in the top bar, leading to a compressed look against lighter backgrounds.
+- **Files:** `apps/www/components/navbar/navigation.tsx`, `apps/www/components/footer/footer-svgs.tsx`.
+- **Follow-ups:** Revisit other marketing surfaces if additional logo placements appear in future sections.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -82,7 +82,7 @@ export const metadata = {
     card: "summary_large_image",
   },
   icons: {
-    shortcut: "/images/landing/unkey.png",
+    shortcut: "/images/logos/transformai/purelogo.png",
   },
 };
 

--- a/apps/www/app/[locale]/(site)/blog/[slug]/page.tsx
+++ b/apps/www/app/[locale]/(site)/blog/[slug]/page.tsx
@@ -70,7 +70,7 @@ export function generateMetadata({
       },
     },
     icons: {
-      shortcut: "/images/landing/unkey.png",
+      shortcut: "/images/logos/transformai/purelogo.png",
     },
   };
 }

--- a/apps/www/app/[locale]/(site)/blog/page.tsx
+++ b/apps/www/app/[locale]/(site)/blog/page.tsx
@@ -32,7 +32,7 @@ export const metadata = {
     card: "summary_large_image",
   },
   icons: {
-    shortcut: "/images/landing/unkey.png",
+    shortcut: "/images/logos/transformai/purelogo.png",
   },
 };
 

--- a/apps/www/app/[locale]/(site)/careers/[slug]/page.tsx
+++ b/apps/www/app/[locale]/(site)/careers/[slug]/page.tsx
@@ -213,7 +213,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       creator: "@unkeydev",
     },
     icons: {
-      shortcut: "/images/landing/unkey.png",
+      shortcut: "/images/logos/transformai/purelogo.png",
     },
   };
 }

--- a/apps/www/app/[locale]/(site)/careers/page.tsx
+++ b/apps/www/app/[locale]/(site)/careers/page.tsx
@@ -213,6 +213,6 @@ export const metadata = {
     card: "summary_large_image",
   },
   icons: {
-    shortcut: "/images/landing/unkey.png",
+    shortcut: "/images/logos/transformai/purelogo.png",
   },
 };

--- a/apps/www/app/[locale]/(site)/changelog/page.tsx
+++ b/apps/www/app/[locale]/(site)/changelog/page.tsx
@@ -138,6 +138,6 @@ export const metadata = {
     card: "summary_large_image",
   },
   icons: {
-    shortcut: "/images/landing/unkey.png",
+    shortcut: "/images/logos/transformai/purelogo.png",
   },
 };

--- a/apps/www/app/[locale]/(site)/glossary/[slug]/page.tsx
+++ b/apps/www/app/[locale]/(site)/glossary/[slug]/page.tsx
@@ -46,7 +46,7 @@ export function generateMetadata({
       creator: "@unkeydev",
     },
     icons: {
-      shortcut: "/images/landing/unkey.png",
+      shortcut: "/images/logos/transformai/purelogo.png",
     },
   };
 }

--- a/apps/www/app/[locale]/(site)/glossary/page.tsx
+++ b/apps/www/app/[locale]/(site)/glossary/page.tsx
@@ -21,7 +21,7 @@ export const metadata = {
     card: "summary_large_image",
   },
   icons: {
-    shortcut: "/images/landing/unkey.png",
+    shortcut: "/images/logos/transformai/purelogo.png",
   },
 };
 

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -83,7 +83,7 @@ export async function generateMetadata({
       card: "summary_large_image",
     },
     icons: {
-      shortcut: "/unkey.png",
+      shortcut: "/images/logos/transformai/purelogo.png",
     },
   };
 }

--- a/apps/www/app/[locale]/(site)/templates/[slug]/page.tsx
+++ b/apps/www/app/[locale]/(site)/templates/[slug]/page.tsx
@@ -206,7 +206,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       creator: "@unkeydev",
     },
     icons: {
-      shortcut: "/images/landing/unkey.png",
+      shortcut: "/images/logos/transformai/purelogo.png",
     },
   };
 }

--- a/apps/www/app/[locale]/(site)/templates/page.tsx
+++ b/apps/www/app/[locale]/(site)/templates/page.tsx
@@ -22,7 +22,7 @@ export const metadata = {
     card: "summary_large_image",
   },
   icons: {
-    shortcut: "/images/landing/unkey.png",
+    shortcut: "/images/logos/transformai/purelogo.png",
   },
 };
 

--- a/apps/www/app/[locale]/layout.tsx
+++ b/apps/www/app/[locale]/layout.tsx
@@ -64,7 +64,7 @@ export async function generateMetadata({
       card: "summary_large_image",
     },
     icons: {
-      shortcut: "/unkey.png",
+      shortcut: "/images/logos/transformai/purelogo.png",
     },
     alternates: {
       languages: languageAlternates,

--- a/apps/www/app/select-language/page.tsx
+++ b/apps/www/app/select-language/page.tsx
@@ -1,4 +1,4 @@
-import { UnkeyLogo } from "@/components/footer/footer-svgs";
+import { TransformAILogo } from "@/components/footer/footer-svgs";
 import { type Locale, defaultLocale, isLocale } from "@/i18n/routing";
 import { createTranslator } from "next-intl";
 import { cookies } from "next/headers";
@@ -47,7 +47,7 @@ export default async function SelectLanguagePage() {
             </div>
 
             <div className="flex flex-col items-center gap-6">
-              <UnkeyLogo className="h-10 w-auto" />
+              <TransformAILogo className="h-12 w-auto" variant="transparent" sizes="200px" />
               <p className="text-sm text-white/70">{t("tagline")}</p>
               <h1 className="text-balance text-3xl font-semibold tracking-tight text-white sm:text-4xl">
                 {t("selectTitle")}

--- a/apps/www/components/footer/footer-svgs.tsx
+++ b/apps/www/components/footer/footer-svgs.tsx
@@ -1,30 +1,47 @@
-export const UnkeyLogo: React.FC<{ className?: string }> = ({ className }) => {
-  return (
-    <svg
-      width="75"
-      height="32"
-      viewBox="0 0 75 32"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      className={className}
-    >
-      <path
-        d="M8.64 24.24C3.84 24.24 1.104 21.696 1.104 17.328V7.92H3.672V17.16C3.672 20.4 5.112 21.744 8.64 21.744C12.168 21.744 13.608 20.4 13.608 17.16V7.92H16.2V17.328C16.2 21.696 13.464 24.24 8.64 24.24ZM21.0889 24H18.4969V12.072H20.8729V15.768H21.0409C21.4009 13.752 22.9849 11.832 26.0089 11.832C29.3209 11.832 30.9529 14.064 30.9529 16.824V24H28.3609V17.52C28.3609 15.288 27.3529 14.16 24.8809 14.16C22.2649 14.16 21.0889 15.504 21.0889 18.096V24ZM35.8545 24H33.2625V7.92H35.8545V16.8H39.2625L42.8385 12.072H45.8625L41.3745 17.808L45.8385 24H42.7905L39.2625 19.128H35.8545V24ZM53.1375 24.24C49.2255 24.24 46.6575 22.032 46.6575 18.048C46.6575 14.328 49.2015 11.832 53.0895 11.832C56.7855 11.832 59.3055 13.872 59.3055 17.496C59.3055 17.928 59.2815 18.264 59.2095 18.624H49.0815C49.1775 20.928 50.3055 22.152 53.0655 22.152C55.5615 22.152 56.5935 21.336 56.5935 19.92V19.728H59.1855V19.944C59.1855 22.488 56.6895 24.24 53.1375 24.24ZM53.0415 13.872C50.4015 13.872 49.2495 15.048 49.1055 17.184H56.8575V17.136C56.8575 14.928 55.5855 13.872 53.0415 13.872ZM63.1669 28.08H61.4629V25.728H63.7909C64.8469 25.728 65.2789 25.44 65.6389 24.624L65.9269 24L60.0469 12.072H62.9509L65.9989 18.408L67.1749 21.264H67.3669L68.4949 18.384L71.3029 12.072H74.1589L67.9429 25.296C66.9589 27.432 65.6149 28.08 63.1669 28.08Z"
-        fill="url(#paint0_radial_830_5752)"
-      />
-      <defs>
-        <radialGradient
-          id="paint0_radial_830_5752"
-          cx="0"
-          cy="0"
-          r="1"
-          gradientUnits="userSpaceOnUse"
-          gradientTransform="rotate(23.1063) scale(81.5414 80.9709)"
-        >
-          <stop offset="0.26875" stopColor="white" />
-          <stop offset="0.904454" stopColor="white" stopOpacity="0.5" />
-        </radialGradient>
-      </defs>
-    </svg>
-  );
+import Image from "next/image";
+
+import { cn } from "@/lib/utils";
+
+type LogoVariant = "dark" | "transparent";
+
+const LOGO_ASSETS: Record<LogoVariant, { src: string; width: number; height: number }> = {
+  dark: {
+    src: "/images/logos/transformai/Darklogoenhanced.png",
+    width: 1684,
+    height: 769,
+  },
+  transparent: {
+    src: "/images/logos/transformai/logotransparant.png",
+    width: 1506,
+    height: 650,
+  },
 };
+
+type TransformAILogoProps = {
+  className?: string;
+  variant?: LogoVariant;
+  priority?: boolean;
+  sizes?: string;
+};
+
+export function TransformAILogo({
+  className,
+  variant = "dark",
+  priority,
+  sizes = "(max-width: 768px) 140px, 200px",
+}: TransformAILogoProps) {
+  const asset = LOGO_ASSETS[variant];
+
+  return (
+    <Image
+      src={asset.src}
+      alt="TransformAI logo"
+      width={asset.width}
+      height={asset.height}
+      priority={priority}
+      sizes={sizes}
+      quality={100}
+      className={cn("h-auto w-auto", className)}
+    />
+  );
+}

--- a/apps/www/components/footer/footer.tsx
+++ b/apps/www/components/footer/footer.tsx
@@ -3,7 +3,7 @@ import { Link } from "@/i18n/navigation";
 import { cn } from "@/lib/utils";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
-import { UnkeyLogo } from "./footer-svgs";
+import { TransformAILogo } from "./footer-svgs";
 import { Wordmark } from "./wordmark";
 
 type NavLink = {
@@ -121,7 +121,7 @@ export function Footer({ initialYear }: { initialYear: number }) {
     <div className="border-t border-white/20 blog-footer-radial-gradient">
       <footer className="container relative grid grid-cols-2 gap-8 pt-8 mx-auto overflow-hidden lg:gap-16 sm:grid-cols-3 xl:grid-cols-5 sm:pt-12 md:pt-16 lg:pt-24 xl:pt-32">
         <div className="flex flex-col items-center col-span-2 sm:items-start sm:col-span-3 xl:col-span-1">
-          <UnkeyLogo />
+          <TransformAILogo className="h-12 w-auto" sizes="(max-width: 768px) 160px, 220px" />
           <div className="mt-8 text-sm font-normal leading-6 text-white/60">
             {t("tagline")}
           </div>

--- a/apps/www/components/footer/wordmark.tsx
+++ b/apps/www/components/footer/wordmark.tsx
@@ -1,133 +1,58 @@
 "use client";
 
+import Image from "next/image";
 import { motion, useReducedMotion } from "framer-motion";
-import type React from "react";
+import type { ReactNode } from "react";
 
-function FadeInStagger({ ...props }) {
+import { cn } from "@/lib/utils";
+
+type FadeInStaggerProps = {
+  className?: string;
+  children: ReactNode;
+};
+
+function FadeInStagger({ className, children }: FadeInStaggerProps) {
   return (
     <motion.div
       initial="hidden"
       whileInView="visible"
       viewport={{ once: false, margin: "0px 0px 0px 0px" }}
       transition={{ staggerChildren: 0.15 }}
-      {...props}
-    />
+      className={cn("flex justify-center", className)}
+    >
+      {children}
+    </motion.div>
   );
 }
-export const Wordmark: React.FC<{ className?: string }> = ({ className }) => {
+
+type WordmarkProps = {
+  className?: string;
+};
+
+export function Wordmark({ className }: WordmarkProps) {
   const shouldReduceMotion = useReducedMotion();
 
   const variants = {
     hidden: { opacity: 0, y: shouldReduceMotion ? 0 : 64 },
     visible: { opacity: 1, y: 0 },
   };
-  const transition = {
-    duration: 0.05,
-    ease: "easeOut",
-    type: "spring",
-    stiffness: 200,
-    damping: 50,
-  };
 
   return (
     <FadeInStagger className={className}>
-      <svg
-        width="1376"
-        height="248"
-        viewBox="0 0 1376 248"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
+      <motion.div
+        variants={variants}
+        transition={{ duration: 0.5, ease: "easeOut" }}
+        className="w-full max-w-4xl"
       >
-        <motion.path
-          variants={variants}
-          transition={transition}
-          d="M0 177.333C0 259.667 51.533 307.619 141.942 307.619C232.803 307.619 284.336 259.667 284.336 177.333V0H235.515V174.167C235.515 235.238 208.392 260.572 141.942 260.572C75.4913 260.572 48.3687 235.238 48.3687 174.167V0H0V177.333Z"
-          fill="url(#paint4_linear_830_5782)"
+        <Image
+          src="/images/logos/transformai/Darklogoenhanced.png"
+          alt="TransformAI wordmark"
+          width={1684}
+          height={769}
+          sizes="(max-width: 1024px) 80vw, 1024px"
+          className="h-auto w-full"
         />
-        <motion.path
-          variants={variants}
-          transition={transition}
-          d="M376.418 303.095H327.598V78.2618H372.35V147.929H375.514C382.295 109.928 412.13 73.738 469.087 73.738C531.469 73.738 562.208 115.809 562.208 167.833V303.095H513.388V180.952C513.388 138.881 494.402 117.619 447.841 117.619C398.568 117.619 376.418 142.952 376.418 191.81V303.095Z"
-          fill="url(#paint3_linear_830_5782)"
-        />
-        <motion.path
-          variants={variants}
-          transition={transition}
-          d="M605.71 303.095H654.531V211.262H718.721L785.172 303.095H842.581L758.501 186.381L843.034 78.262H786.076L718.721 167.381H654.531V0H605.71V303.095Z"
-          fill="url(#paint0_linear_830_5782)"
-        />
-        <motion.path
-          variants={variants}
-          transition={transition}
-          fillRule="evenodd"
-          clipRule="evenodd"
-          d="M980.059 307.619C906.376 307.619 858.007 266 858.007 190.905C858.007 120.786 905.924 73.738 979.155 73.738C1048.77 73.738 1096.23 112.19 1096.23 180.5C1096.23 188.643 1095.78 194.976 1094.43 201.762H903.664C905.472 245.19 926.718 268.262 978.703 268.262C1025.72 268.262 1045.15 252.881 1045.15 226.19V222.571H1093.97V226.643C1093.97 274.595 1046.96 307.619 980.059 307.619ZM978.251 112.19C928.526 112.19 906.828 134.357 904.116 174.619H1050.13V173.714C1050.13 132.095 1026.17 112.19 978.251 112.19Z"
-          fill="url(#paint2_linear_830_5782)"
-        />
-        <motion.path
-          variants={variants}
-          transition={transition}
-          d="M1136.87 380H1168.96C1215.07 380 1240.39 367.786 1258.92 327.524L1376 78.2617H1322.21L1269.32 197.238L1248.07 251.524H1244.46L1222.31 197.69L1164.9 78.2617H1110.2L1220.95 303.095L1215.52 314.857C1208.74 330.238 1200.61 335.667 1180.72 335.667H1136.87V380Z"
-          fill="url(#paint1_linear_830_5782)"
-        />
-        <defs>
-          <linearGradient
-            id="paint0_linear_830_5782"
-            x1="-243.049"
-            y1="-228.123"
-            x2="-150.186"
-            y2="402.501"
-            gradientUnits="userSpaceOnUse"
-          >
-            <stop stopColor="white" stopOpacity="0.4" />
-            <stop offset="0.693236" stopColor="white" stopOpacity="0.1" />
-          </linearGradient>
-          <linearGradient
-            id="paint1_linear_830_5782"
-            x1="-243.049"
-            y1="-228.123"
-            x2="-150.186"
-            y2="402.501"
-            gradientUnits="userSpaceOnUse"
-          >
-            <stop stopColor="white" stopOpacity="0.4" />
-            <stop offset="0.693236" stopColor="white" stopOpacity="0.1" />
-          </linearGradient>
-          <linearGradient
-            id="paint2_linear_830_5782"
-            x1="-243.049"
-            y1="-228.123"
-            x2="-150.186"
-            y2="402.501"
-            gradientUnits="userSpaceOnUse"
-          >
-            <stop stopColor="white" stopOpacity="0.4" />
-            <stop offset="0.693236" stopColor="white" stopOpacity="0.1" />
-          </linearGradient>
-          <linearGradient
-            id="paint3_linear_830_5782"
-            x1="-243.049"
-            y1="-228.123"
-            x2="-150.186"
-            y2="402.501"
-            gradientUnits="userSpaceOnUse"
-          >
-            <stop stopColor="white" stopOpacity="0.4" />
-            <stop offset="0.693236" stopColor="white" stopOpacity="0.1" />
-          </linearGradient>
-          <linearGradient
-            id="paint4_linear_830_5782"
-            x1="-243.049"
-            y1="-228.123"
-            x2="-150.186"
-            y2="402.501"
-            gradientUnits="userSpaceOnUse"
-          >
-            <stop stopColor="white" stopOpacity="0.4" />
-            <stop offset="0.693236" stopColor="white" stopOpacity="0.1" />
-          </linearGradient>
-        </defs>
-      </svg>
+      </motion.div>
     </FadeInStagger>
   );
-};
+}

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { LanguageSwitcher } from "@/components/language-switcher";
+import { TransformAILogo } from "@/components/footer/footer-svgs";
 import {
   Drawer,
   DrawerContent,
@@ -61,7 +62,7 @@ export function Navigation() {
       <div className="container flex items-center justify-between">
         <div className="flex items-center justify-between w-full sm:w-auto sm:gap-12 lg:gap-20">
           <Link href="/" aria-label={t("ariaHome")}>
-            <Logo className="min-w-[50px]" />
+            <Logo />
           </Link>
           <MobileLinks className="lg:hidden" />
           <DesktopLinks className="hidden lg:flex" />
@@ -204,7 +205,7 @@ function MobileLinks({ className }: { className?: string }) {
   );
 }
 
-const DesktopLinks: React.FC<{ className: string }> = ({ className }) => {
+function DesktopLinks({ className }: { className: string }) {
   const t = useTranslations("Navigation");
 
   return (
@@ -232,32 +233,15 @@ const DesktopLinks: React.FC<{ className: string }> = ({ className }) => {
       </li>
     </ul>
   );
-};
+}
 
-const Logo: React.FC<{ className?: string }> = ({ className }) => (
-  <svg
-    className={className}
-    xmlns="http://www.w3.org/2000/svg"
-    width="93"
-    height="40"
-    viewBox="0 0 93 40"
-  >
-    <path
-      d="M10.8 30.3C4.8 30.3 1.38 27.12 1.38 21.66V9.9H4.59V21.45C4.59 25.5 6.39 27.18 10.8 27.18C15.21 27.18 17.01 25.5 17.01 21.45V9.9H20.25V21.66C20.25 27.12 16.83 30.3 10.8 30.3ZM26.3611 30H23.1211V15.09H26.0911V19.71H26.3011C26.7511 17.19 28.7311 14.79 32.5111 14.79C36.6511 14.79 38.6911 17.58 38.6911 21.03V30H35.4511V21.9C35.4511 19.11 34.1911 17.7 31.1011 17.7C27.8311 17.7 26.3611 19.38 26.3611 22.62V30ZM44.8181 30H41.5781V9.9H44.8181V21H49.0781L53.5481 15.09H57.3281L51.7181 22.26L57.2981 30H53.4881L49.0781 23.91H44.8181V30ZM66.4219 30.3C61.5319 30.3 58.3219 27.54 58.3219 22.56C58.3219 17.91 61.5019 14.79 66.3619 14.79C70.9819 14.79 74.1319 17.34 74.1319 21.87C74.1319 22.41 74.1019 22.83 74.0119 23.28H61.3519C61.4719 26.16 62.8819 27.69 66.3319 27.69C69.4519 27.69 70.7419 26.67 70.7419 24.9V24.66H73.9819V24.93C73.9819 28.11 70.8619 30.3 66.4219 30.3ZM66.3019 17.34C63.0019 17.34 61.5619 18.81 61.3819 21.48H71.0719V21.42C71.0719 18.66 69.4819 17.34 66.3019 17.34ZM78.9586 35.1H76.8286V32.16H79.7386C81.0586 32.16 81.5986 31.8 82.0486 30.78L82.4086 30L75.0586 15.09H78.6886L82.4986 23.01L83.9686 26.58H84.2086L85.6186 22.98L89.1286 15.09H92.6986L84.9286 31.62C83.6986 34.29 82.0186 35.1 78.9586 35.1Z"
-      fill="url(#paint0_radial_301_76)"
+function Logo({ className }: { className?: string }) {
+  return (
+    <TransformAILogo
+      variant="transparent"
+      className={cn("h-11 w-auto sm:h-12", className)}
+      priority
+      sizes="(max-width: 640px) 160px, (max-width: 1024px) 200px, 232px"
     />
-    <defs>
-      <radialGradient
-        id="paint0_radial_301_76"
-        cx="0"
-        cy="0"
-        r="1"
-        gradientUnits="userSpaceOnUse"
-        gradientTransform="rotate(23.2729) scale(101.237 101.088)"
-      >
-        <stop offset="0.26875" stopColor="white" />
-        <stop offset="0.904454" stopColor="white" stopOpacity="0.5" />
-      </radialGradient>
-    </defs>
-  </svg>
-);
+  );
+}


### PR DESCRIPTION
## Plan
- Relax the shared TransformAI logo helper so images render at natural proportions with full fidelity.
- Swap the navigation header to the transparent logo variant the user requested.
- Record the refinement in the updates log and verify key pages manually.

## Summary
- Updated `TransformAILogo` to opt into quality 100 rendering and drop the forced height so placements keep their natural aspect ratios.
- Pointed the navigation logo at the transparent artwork with tailored responsive sizing so it no longer appears compressed atop the hero.
- Logged the touch-up in `WRITE_HERE/UPDATES`.

## Testing
- `pnpm --filter www run typecheck` *(fails: repository still missing next-intl packages for TS resolution)*
- `pnpm --filter www run lint` *(fails: same missing next-intl dependency breaks Next lint)*

------
https://chatgpt.com/codex/tasks/task_e_68dbedfbd0cc832abcf4e40b0d2887bc