### PR TITLE
Overlay TransformAI logo on animated mainboard

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-25T2300--overlaid-mainboard-logo.md
+++ b/WRITE_HERE/FIXES/2025-11-25T2300--overlaid-mainboard-logo.md
@@ -1,0 +1,6 @@
+# Overlaid hero mainboard logo
+
+- **What:** Layered the new TransformAI logo SVG over the existing animated mainboard art in the hero so the animation stays active while showing the refreshed mark across breakpoints.
+- **Why:** Replacing the original asset removed the circuit animation; overlaying the new logo preserves motion while presenting the updated branding.
+- **Files:** `apps/www/components/hero/hero.tsx`, `apps/www/app/[locale]/(site)/page.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -35,6 +35,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import mainboard from "@/images/mainboard.svg";
+import overlayMainboard from "@/images/logos/transformai/theoverlayone.svg";
 import { DesktopLogoCloud, MobileLogoCloud } from "./(components)/logo-cloud-content";
 import { CodeExamples } from "../../code-examples";
 
@@ -131,7 +132,14 @@ export default async function Landing({
           <Image
             src={mainboard}
             alt="Animated SVG showing computer circuits lighting up"
-            className="absolute inset-x-0 flex  xl:hidden -z-10 scale-[2]"
+            className="absolute inset-x-0 flex xl:hidden -z-20 scale-[2]"
+            priority
+          />
+          <Image
+            src={overlayMainboard}
+            alt=""
+            aria-hidden
+            className="absolute inset-x-0 flex xl:hidden -z-10 scale-[2] pointer-events-none"
             priority
           />
         </div>

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { HeroMainSection } from "./hero-main-section";
 
 import mainboard from "@/images/mainboard.svg";
+import overlayMainboard from "@/images/logos/transformai/theoverlayone.svg";
 import { SubHeroMainboard } from "./hero-sub-mainboard";
 export const Hero: React.FC = () => {
   const hero = useTranslations("Hero");
@@ -50,7 +51,15 @@ export const Hero: React.FC = () => {
         <Image
           src={mainboard}
           alt="Animated SVG showing computer circuits lighting up"
-          className="absolute hidden xl:right-32 xl:flex -z-10 xl:-top-56"
+          className="absolute hidden xl:right-32 xl:flex -z-20 xl:-top-56"
+          style={{ transform: "scale(2)" }}
+          priority
+        />
+        <Image
+          src={overlayMainboard}
+          alt=""
+          aria-hidden
+          className="absolute hidden xl:right-32 xl:flex -z-10 xl:-top-56 pointer-events-none"
           style={{ transform: "scale(2)" }}
           priority
         />


### PR DESCRIPTION
## Summary
- layer the refreshed TransformAI overlay asset on top of the animated mainboard artwork in the hero
- ensure the overlay renders for both desktop and mobile hero variants while leaving the animation intact
- log the change for future reference in the fixes journal

## Plan
- inspect how the hero background SVG is used across desktop and mobile views
- import the new overlay asset and stack it above the animated mainboard artwork without disturbing layout or motion
- document the adjustment in WRITE_HERE/FIXES and rerun the usual verification commands

## Testing
- `pnpm --filter www run typecheck`
- `pnpm --filter www run lint` *(fails: existing lint violations in startups/contact form and related files)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc5b34168832a9a42c7d8a5de6ef0