### PR TITLE
Overlay TransformAI logo on mainboard background

### DIFF
--- a/WRITE_HERE/FIXES/2025-10-01T0641--transformai-mainboard-overlay.md
+++ b/WRITE_HERE/FIXES/2025-10-01T0641--transformai-mainboard-overlay.md
@@ -1,0 +1,5 @@
+# TransformAI mainboard overlay
+- **What:** Added a shared mainboard artwork component that layers the transparent TransformAI logo atop the circuit board asset and wired it into the hero and landing page instances so the Unkey mark is covered on all breakpoints.
+- **Why:** The hero background still exposed the Unkey logo baked into the SVG; overlaying our transparent wordmark masks the original branding without losing the board effect the user liked.
+- **Files:** `apps/www/components/hero/hero.tsx`, `apps/www/components/hero/mainboard-artwork.tsx`, `apps/www/app/[locale]/(site)/page.tsx`.
+- **Follow-ups:** Verify overlay alignment once the dev environment includes the required `next-intl` dependency so the site can run locally.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -5,6 +5,7 @@ import { CTA } from "@/components/cta";
 import { FeatureGrid } from "@/components/feature/feature-grid";
 import { HashedKeysBento } from "@/components/hashed-keys-bento";
 import { Hero } from "@/components/hero/hero";
+import { MainboardArtwork } from "@/components/hero/mainboard-artwork";
 import { ImageWithBlur } from "@/components/image-with-blur";
 import { IpWhitelistingBento } from "@/components/ip-whitelisting-bento";
 import { LatencyBento } from "@/components/latency-bento";
@@ -29,12 +30,10 @@ import {
   Sprout,
   Zap,
 } from "lucide-react";
-import Image from "next/image";
 import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
-import mainboard from "@/images/mainboard.svg";
 import { DesktopLogoCloud, MobileLogoCloud } from "./(components)/logo-cloud-content";
 import { CodeExamples } from "../../code-examples";
 
@@ -128,11 +127,9 @@ export default async function Landing({
       <TopLeftShiningLight />
       <div className="relative w-full pt-6 overflow-hidden">
         <div className="container relative mx-auto">
-          <Image
-            src={mainboard}
-            alt="Animated SVG showing computer circuits lighting up"
-            className="absolute inset-x-0 flex  xl:hidden -z-10 scale-[2]"
+          <MainboardArtwork
             priority
+            className="absolute inset-x-0 flex xl:hidden -z-10 scale-[2]"
           />
         </div>
         <div className="container relative flex flex-col mx-auto space-y-16 md:space-y-32">

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -1,11 +1,10 @@
 "use client";
 import { motion } from "framer-motion";
-import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { HeroMainSection } from "./hero-main-section";
 
-import mainboard from "@/images/mainboard.svg";
 import { SubHeroMainboard } from "./hero-sub-mainboard";
+import { MainboardArtwork } from "./mainboard-artwork";
 export const Hero: React.FC = () => {
   const hero = useTranslations("Hero");
   const cta = useTranslations("CTA");
@@ -46,15 +45,11 @@ export const Hero: React.FC = () => {
         />
       </motion.div>
 
-      <div>
-        <Image
-          src={mainboard}
-          alt="Animated SVG showing computer circuits lighting up"
-          className="absolute hidden xl:right-32 xl:flex -z-10 xl:-top-56"
-          style={{ transform: "scale(2)" }}
-          priority
-        />
-      </div>
+      <MainboardArtwork
+        priority
+        className="absolute hidden xl:flex -z-10 xl:right-32 xl:-top-56"
+        style={{ transform: "scale(2)" }}
+      />
       <SubHeroMainboard className="absolute hidden md:flex left-1/2 -translate-x-[calc(50%+85px)] -bottom-[224px] -z-10" />
     </motion.div>
   );

--- a/apps/www/components/hero/mainboard-artwork.tsx
+++ b/apps/www/components/hero/mainboard-artwork.tsx
@@ -1,0 +1,42 @@
+import type { CSSProperties } from "react";
+
+import Image from "next/image";
+
+import { TransformAILogo } from "@/components/footer/footer-svgs";
+import mainboard from "@/images/mainboard.svg";
+import { cn } from "@/lib/utils";
+
+type MainboardArtworkProps = {
+  className?: string;
+  priority?: boolean;
+  style?: CSSProperties;
+};
+
+export function MainboardArtwork({
+  className,
+  priority = false,
+  style,
+}: MainboardArtworkProps) {
+  return (
+    <div
+      aria-hidden
+      className={cn("pointer-events-none", className)}
+      style={style}
+    >
+      <div className="relative h-auto w-auto">
+        <Image
+          src={mainboard}
+          alt="Circuit board background with TransformAI overlays"
+          priority={priority}
+          className="h-auto w-auto"
+        />
+        <TransformAILogo
+          variant="transparent"
+          priority={priority}
+          className="absolute left-[982px] top-[262px] w-[210px] max-w-none"
+          sizes="210px"
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Plan
- Build a shared mainboard artwork wrapper that layers the transparent TransformAI wordmark over the existing SVG.
- Swap the hero and landing page instances to use the shared artwork across desktop and mobile breakpoints.
- Document the adjustment in WRITE_HERE/FIXES and run lint/typecheck (known to be blocked by the missing `next-intl` dependency).

## Summary
- Added a reusable `MainboardArtwork` component that renders the mainboard SVG with the TransformAI logo overlay positioned over the old branding.
- Updated the hero and landing page backgrounds to consume the new component so the overlay appears on both xl and mobile layouts.
- Logged the fix in `WRITE_HERE/FIXES` for project history and follow-up on restoring local dev once `next-intl` is available.

## Testing
- pnpm --filter www run lint *(blocked by missing `next-intl` dependency)*
- pnpm --filter www run typecheck *(blocked by missing `next-intl` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68dccc333254832aba5eb4ab476faf3d