### PR TITLE
Remove footer wordmark block

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-26T1200--footer-wordmark-removed.md
+++ b/WRITE_HERE/FIXES/2025-11-26T1200--footer-wordmark-removed.md
@@ -1,0 +1,5 @@
+# Remove footer wordmark logo
+- **What:** Removed the oversized TransformAI wordmark block from the footer so the logo no longer repeats beneath the navigation columns.
+- **Why:** The user reported the large logo beneath the footer header looked overwhelming and requested it be removed.
+- **Files:** `apps/www/components/footer/footer.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/components/footer/footer.tsx
+++ b/apps/www/components/footer/footer.tsx
@@ -4,7 +4,6 @@ import { cn } from "@/lib/utils";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { TransformAILogo } from "./footer-svgs";
-import { Wordmark } from "./wordmark";
 
 type NavLink = {
   titleKey: string;
@@ -134,9 +133,6 @@ export function Footer({ initialYear }: { initialYear: number }) {
           <Column key={titleKey} titleKey={titleKey} links={links} className="col-span-1 " />
         ))}
       </footer>
-      <div className="container mt-8 h-[100px]">
-        <Wordmark className="flex w-full" />
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove the oversized footer wordmark block so the footer only shows the primary logo and navigation
- document the footer change in the fixes log for traceability

## Testing
- pnpm --filter www run lint *(fails: missing `next-intl` dependency in this environment)*

## Plan
- inspect the footer component to locate the wordmark usage beneath the navigation
- remove the redundant wordmark import and markup from the footer layout
- capture the user-facing change in a new FIXES entry
- run the lint command to verify (or record blocking issues)


------
https://chatgpt.com/codex/tasks/task_e_68dccd5f03b8832a8192e666d5df6080