### PR TITLE
Add footer bottom padding for breathing room

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-26T1200--footer-wordmark-removed.md
+++ b/WRITE_HERE/FIXES/2025-11-26T1200--footer-wordmark-removed.md
@@ -1,0 +1,5 @@
+# Remove footer wordmark logo
+- **What:** Removed the oversized TransformAI wordmark block from the footer so the logo no longer repeats beneath the navigation columns.
+- **Why:** The user reported the large logo beneath the footer header looked overwhelming and requested it be removed.
+- **Files:** `apps/www/components/footer/footer.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-26T1230--footer-bottom-breathing-room.md
+++ b/WRITE_HERE/FIXES/2025-11-26T1230--footer-bottom-breathing-room.md
@@ -1,0 +1,5 @@
+# Add breathing room beneath footer content
+- **What:** Introduced responsive bottom padding to the footer container so the logo, tagline, and nav columns have comfortable space before the page edge.
+- **Why:** The user noted the footer felt claustrophobic after removing the oversized wordmark, so we restored visual balance by adding spacing where the image used to sit.
+- **Files:** `apps/www/components/footer/footer.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/components/footer/footer.tsx
+++ b/apps/www/components/footer/footer.tsx
@@ -4,7 +4,6 @@ import { cn } from "@/lib/utils";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { TransformAILogo } from "./footer-svgs";
-import { Wordmark } from "./wordmark";
 
 type NavLink = {
   titleKey: string;
@@ -119,7 +118,7 @@ export function Footer({ initialYear }: { initialYear: number }) {
 
   return (
     <div className="border-t border-white/20 blog-footer-radial-gradient">
-      <footer className="container relative grid grid-cols-2 gap-8 pt-8 mx-auto overflow-hidden lg:gap-16 sm:grid-cols-3 xl:grid-cols-5 sm:pt-12 md:pt-16 lg:pt-24 xl:pt-32">
+      <footer className="container relative grid grid-cols-2 gap-8 pt-8 pb-12 mx-auto overflow-hidden lg:gap-16 sm:grid-cols-3 xl:grid-cols-5 sm:pt-12 sm:pb-16 md:pt-16 md:pb-20 lg:pt-24 lg:pb-24 xl:pt-32 xl:pb-32">
         <div className="flex flex-col items-center col-span-2 sm:items-start sm:col-span-3 xl:col-span-1">
           <TransformAILogo className="h-12 w-auto" sizes="(max-width: 768px) 160px, 220px" />
           <div className="mt-8 text-sm font-normal leading-6 text-white/60">
@@ -134,9 +133,6 @@ export function Footer({ initialYear }: { initialYear: number }) {
           <Column key={titleKey} titleKey={titleKey} links={links} className="col-span-1 " />
         ))}
       </footer>
-      <div className="container mt-8 h-[100px]">
-        <Wordmark className="flex w-full" />
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add responsive bottom padding to the footer container to restore breathing room beneath the content
- log the spacing tweak in the fixes notebook for continuity

## Testing
- pnpm --filter www run lint *(fails: missing `next-intl` dependency in this environment)*

## Plan
- inspect the footer layout to identify where to reintroduce spacing now that the wordmark is gone
- apply responsive padding tokens so the footer breathes at every breakpoint
- record the resolved user request in WRITE_HERE/FIXES for future reference
- run the lint command and capture any environment blockers

------
https://chatgpt.com/codex/tasks/task_e_68dccd5f03b8832a8192e666d5df6080