### PR TITLE
Restore hero mainboard light animation

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-26T0900--restored-mainboard-light-trails.md
+++ b/WRITE_HERE/FIXES/2025-11-26T0900--restored-mainboard-light-trails.md
@@ -1,0 +1,5 @@
+# Restored hero mainboard light trails
+- **What:** Reintroduced layered light sweep animations over the hero mainboard artwork using Tailwind-friendly utility classes and new global keyframes.
+- **Why:** The background mainboard previously had animated light passes that were lost during the artwork swap, and the user requested the motion back for visual energy.
+- **Files:** `apps/www/components/hero/hero.tsx`, `apps/www/app/globals.css`.
+- **Follow-ups:** Monitor animation performance once deployed; expand the effect to additional hero assets if creative direction calls for it.

--- a/apps/www/app/globals.css
+++ b/apps/www/app/globals.css
@@ -268,6 +268,57 @@ li > p {
   animation: slideGradient 1.5s linear forwards;
 }
 
+.hero-mainboard-lights {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.hero-mainboard-light {
+  position: absolute;
+  top: var(--hero-mainboard-light-top, 40%);
+  height: var(--hero-mainboard-light-height, 24%);
+  width: 220%;
+  left: -70%;
+  opacity: 0.55;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    hsla(var(--feature-9), 0.1) 28%,
+    hsla(var(--feature-11), 0.55) 48%,
+    hsla(var(--feature-10), 0.45) 56%,
+    hsla(var(--feature-11), 0.35) 64%,
+    transparent 100%
+  );
+  filter: blur(14px);
+  animation: hero-mainboard-scan var(--hero-mainboard-light-duration, 10s) linear infinite;
+  animation-delay: var(--hero-mainboard-light-delay, 0s);
+}
+
+.hero-mainboard-light--one {
+  --hero-mainboard-light-top: 28%;
+  --hero-mainboard-light-height: 22%;
+  --hero-mainboard-light-duration: 9s;
+  --hero-mainboard-light-delay: 0s;
+}
+
+.hero-mainboard-light--two {
+  --hero-mainboard-light-top: 46%;
+  --hero-mainboard-light-height: 18%;
+  --hero-mainboard-light-duration: 12s;
+  --hero-mainboard-light-delay: -4s;
+}
+
+.hero-mainboard-light--three {
+  --hero-mainboard-light-top: 64%;
+  --hero-mainboard-light-height: 24%;
+  --hero-mainboard-light-duration: 10.5s;
+  --hero-mainboard-light-delay: -7s;
+}
+
 @keyframes slideGradient {
   from {
     left: -50%;
@@ -275,6 +326,37 @@ li > p {
 
   to {
     left: 0;
+  }
+}
+
+@keyframes hero-mainboard-scan {
+  0% {
+    transform: translate3d(-45%, 0, 0);
+    opacity: 0;
+  }
+
+  15% {
+    opacity: 0.45;
+  }
+
+  50% {
+    opacity: 0.7;
+  }
+
+  85% {
+    opacity: 0.45;
+  }
+
+  100% {
+    transform: translate3d(45%, 0, 0);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-mainboard-light {
+    animation: none;
+    opacity: 0.3;
   }
 }
 

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -46,14 +46,23 @@ export const Hero: React.FC = () => {
         />
       </motion.div>
 
-      <div>
-        <Image
-          src={mainboard}
-          alt="Animated SVG showing computer circuits lighting up"
-          className="absolute hidden xl:right-32 xl:flex -z-10 xl:-top-56"
-          style={{ transform: "scale(2)" }}
-          priority
-        />
+      <div
+        className="absolute hidden xl:flex -z-10 xl:-top-56 xl:right-32"
+        aria-hidden="true"
+      >
+        <div className="relative" style={{ transform: "scale(2)" }}>
+          <Image
+            src={mainboard}
+            alt="Animated SVG showing computer circuits lighting up"
+            className="pointer-events-none select-none"
+            priority
+          />
+          <div className="hero-mainboard-lights">
+            <span className="hero-mainboard-light hero-mainboard-light--one" />
+            <span className="hero-mainboard-light hero-mainboard-light--two" />
+            <span className="hero-mainboard-light hero-mainboard-light--three" />
+          </div>
+        </div>
       </div>
       <SubHeroMainboard className="absolute hidden md:flex left-1/2 -translate-x-[calc(50%+85px)] -bottom-[224px] -z-10" />
     </motion.div>


### PR DESCRIPTION
## Plan
- Reintroduce layered light sweeps over the hero mainboard illustration using existing hero structure.
- Define reusable global styles and keyframes to drive the animated light trails while respecting motion preferences.
- Log the request in the FIXES ledger and verify linting to catch regressions.

## Summary
- Wrapped the hero mainboard artwork with an overlay container and injected three animated light spans to revive the motion effect.
- Added global CSS utilities, keyframes, and prefers-reduced-motion handling for the screen-blended light sweeps.
- Captured the customer request in the FIXES log for continuity.

## Testing
- `pnpm --filter www run lint` *(fails: missing optional dependency `next-intl` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd09427d08832ab1f3aae95d521974