### PR TITLE
Restore animated lighting on the hero mainboard

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-26T0900--restored-hero-mainboard-light-trails.md
+++ b/WRITE_HERE/FIXES/2025-11-26T0900--restored-hero-mainboard-light-trails.md
@@ -1,0 +1,5 @@
+# Restored hero mainboard light trails
+- **What:** Added a reusable overlay with animated light passes for the hero mainboard, wiring it into both desktop and mobile renders and introducing dedicated Tailwind keyframes for the motion.
+- **Why:** The refreshed mainboard asset dropped the dynamic lighting effect the homepage previously showcased.
+- **Files:** `apps/www/components/hero/hero-mainboard-lights.tsx`, `apps/www/components/hero/hero.tsx`, `apps/www/app/[locale]/(site)/page.tsx`, `apps/www/tailwind.config.ts`.
+- **Follow-ups:** Validate the animation speed once the final mainboard artwork is locked to ensure the trails align with key circuit traces.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -5,6 +5,7 @@ import { CTA } from "@/components/cta";
 import { FeatureGrid } from "@/components/feature/feature-grid";
 import { HashedKeysBento } from "@/components/hashed-keys-bento";
 import { Hero } from "@/components/hero/hero";
+import { HeroMainboardLights } from "@/components/hero/hero-mainboard-lights";
 import { ImageWithBlur } from "@/components/image-with-blur";
 import { IpWhitelistingBento } from "@/components/ip-whitelisting-bento";
 import { LatencyBento } from "@/components/latency-bento";
@@ -128,12 +129,17 @@ export default async function Landing({
       <TopLeftShiningLight />
       <div className="relative w-full pt-6 overflow-hidden">
         <div className="container relative mx-auto">
-          <Image
-            src={mainboard}
-            alt="Animated SVG showing computer circuits lighting up"
-            className="absolute inset-x-0 flex  xl:hidden -z-10 scale-[2]"
-            priority
-          />
+          <div className="absolute inset-x-0 -z-10 flex justify-center xl:hidden">
+            <div className="relative scale-[2]">
+              <Image
+                src={mainboard}
+                alt="Animated SVG showing computer circuits lighting up"
+                className="h-auto w-full"
+                priority
+              />
+              <HeroMainboardLights />
+            </div>
+          </div>
         </div>
         <div className="container relative flex flex-col mx-auto space-y-16 md:space-y-32">
           <Section>

--- a/apps/www/components/hero/hero-mainboard-lights.tsx
+++ b/apps/www/components/hero/hero-mainboard-lights.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@/lib/utils";
+
+type HeroMainboardLightsProps = {
+  className?: string;
+};
+
+export function HeroMainboardLights({ className }: HeroMainboardLightsProps) {
+  return (
+    <div
+      className={cn(
+        "pointer-events-none absolute inset-0 overflow-hidden mix-blend-screen",
+        className,
+      )}
+      aria-hidden="true"
+    >
+      <div
+        className="absolute left-[-40%] top-[18%] h-px w-[180%] bg-gradient-to-r from-transparent via-white/70 to-transparent opacity-70 blur-[1px] motion-safe:animate-mainboard-light-horizontal"
+        style={{ animationDelay: "0s", animationDuration: "6s" }}
+      />
+      <div
+        className="absolute left-[-35%] top-[52%] h-[2px] w-[190%] bg-gradient-to-r from-transparent via-white/60 to-transparent opacity-80 blur-[2px] motion-safe:animate-mainboard-light-horizontal"
+        style={{ animationDelay: "2.25s", animationDuration: "7.5s" }}
+      />
+      <div
+        className="absolute left-[-45%] top-[78%] h-px w-[200%] bg-gradient-to-r from-transparent via-white/50 to-transparent opacity-60 blur-[1px] motion-safe:animate-mainboard-light-horizontal"
+        style={{ animationDelay: "4.5s", animationDuration: "8s" }}
+      />
+      <div
+        className="absolute left-[-30%] top-[-10%] h-[2px] w-[200%] rotate-[-12deg] bg-gradient-to-r from-transparent via-white/55 to-transparent opacity-70 blur-[2px] motion-safe:animate-mainboard-light-diagonal"
+        style={{ animationDelay: "1.5s", animationDuration: "9s" }}
+      />
+      <div
+        className="absolute top-[-35%] left-[48%] h-[170%] w-px bg-gradient-to-b from-transparent via-white/50 to-transparent opacity-60 blur-[2px] motion-safe:animate-mainboard-light-vertical"
+        style={{ animationDelay: "3s", animationDuration: "7s" }}
+      />
+    </div>
+  );
+}

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { HeroMainSection } from "./hero-main-section";
 
 import mainboard from "@/images/mainboard.svg";
+import { HeroMainboardLights } from "./hero-mainboard-lights";
 import { SubHeroMainboard } from "./hero-sub-mainboard";
 export const Hero: React.FC = () => {
   const hero = useTranslations("Hero");
@@ -46,14 +47,16 @@ export const Hero: React.FC = () => {
         />
       </motion.div>
 
-      <div>
-        <Image
-          src={mainboard}
-          alt="Animated SVG showing computer circuits lighting up"
-          className="absolute hidden xl:right-32 xl:flex -z-10 xl:-top-56"
-          style={{ transform: "scale(2)" }}
-          priority
-        />
+      <div className="absolute hidden xl:flex -z-10 xl:right-32 xl:-top-56">
+        <div className="relative scale-[2]">
+          <Image
+            src={mainboard}
+            alt="Animated SVG showing computer circuits lighting up"
+            className="h-auto w-full"
+            priority
+          />
+          <HeroMainboardLights />
+        </div>
       </div>
       <SubHeroMainboard className="absolute hidden md:flex left-1/2 -translate-x-[calc(50%+85px)] -bottom-[224px] -z-10" />
     </motion.div>

--- a/apps/www/tailwind.config.ts
+++ b/apps/www/tailwind.config.ts
@@ -63,6 +63,9 @@ const config = {
         "fade-in-up": "fade-in-up 1s ease-out forwards",
         "fade-in-down": "fade-in-down 1s ease-out forwards",
         "logo-cloud": "logo-cloud 18s linear infinite",
+        "mainboard-light-horizontal": "mainboard-light-horizontal 7s linear infinite",
+        "mainboard-light-diagonal": "mainboard-light-diagonal 9s linear infinite",
+        "mainboard-light-vertical": "mainboard-light-vertical 8s linear infinite",
       },
       keyframes: {
         shine: {
@@ -147,6 +150,24 @@ const config = {
             transform: "rotate(270deg) translateX(-500px)",
             opacity: "0",
           },
+        },
+        "mainboard-light-horizontal": {
+          "0%": { transform: "translateX(-45%)", opacity: "0" },
+          "15%": { opacity: "0.65" },
+          "60%": { opacity: "0.3" },
+          "100%": { transform: "translateX(45%)", opacity: "0" },
+        },
+        "mainboard-light-diagonal": {
+          "0%": { transform: "translate3d(-60%, -20%, 0)", opacity: "0" },
+          "20%": { opacity: "0.6" },
+          "70%": { opacity: "0.25" },
+          "100%": { transform: "translate3d(60%, 20%, 0)", opacity: "0" },
+        },
+        "mainboard-light-vertical": {
+          "0%": { transform: "translateY(-40%)", opacity: "0" },
+          "20%": { opacity: "0.55" },
+          "75%": { opacity: "0.25" },
+          "100%": { transform: "translateY(40%)", opacity: "0" },
         },
       },
     },


### PR DESCRIPTION
## Summary
- add a dedicated `HeroMainboardLights` overlay with horizontal, vertical, and diagonal trails to recreate the moving light effect
- mount the animated overlay on both desktop and mobile hero mainboard renders so the glow returns across breakpoints
- extend Tailwind with reusable mainboard light keyframes/animations and document the fix in WRITE_HERE

## Plan
- inspect the hero layout to pinpoint where the mainboard image is rendered for desktop and mobile
- build a reusable overlay component that reintroduces the moving light beams while respecting motion preferences
- integrate the overlay and supporting Tailwind animations in both hero usages and log the regression fix

## Testing
- pnpm --filter www run typecheck
- pnpm --filter www run lint *(fails: repository already has pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd09427d08832ab1f3aae95d521974