### PR TITLE
Gradient-tint hero mainboard light sweeps

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-26T0900--restored-mainboard-light-trails.md
+++ b/WRITE_HERE/FIXES/2025-11-26T0900--restored-mainboard-light-trails.md
@@ -1,0 +1,5 @@
+# Restored hero mainboard light trails
+- **What:** Reintroduced layered light sweep animations over the hero mainboard artwork using Tailwind-friendly utility classes and new global keyframes.
+- **Why:** The background mainboard previously had animated light passes that were lost during the artwork swap, and the user requested the motion back for visual energy.
+- **Files:** `apps/www/components/hero/hero.tsx`, `apps/www/app/globals.css`.
+- **Follow-ups:** Monitor animation performance once deployed; expand the effect to additional hero assets if creative direction calls for it.

--- a/WRITE_HERE/FIXES/2025-11-26T1030--tuned-mainboard-light-palette.md
+++ b/WRITE_HERE/FIXES/2025-11-26T1030--tuned-mainboard-light-palette.md
@@ -1,0 +1,5 @@
+# Tuned hero mainboard light palette
+- **What:** Rebalanced the hero mainboard light trails with a teal-to-magenta gradient map and sculpted background glows to mirror the provided reference artwork.
+- **Why:** The user asked for the revived light passes to lean cyan on the left and intensify toward a purple-pink tone near the upper-left, matching their gradient inspiration.
+- **Files:** `apps/www/app/globals.css`.
+- **Follow-ups:** Review in-browser once `next-intl` is available to confirm blend modes remain performant across devices.

--- a/apps/www/app/globals.css
+++ b/apps/www/app/globals.css
@@ -268,6 +268,91 @@ li > p {
   animation: slideGradient 1.5s linear forwards;
 }
 
+.hero-mainboard-light {
+  position: absolute;
+  top: var(--hero-mainboard-light-top, 40%);
+  height: var(--hero-mainboard-light-height, 24%);
+  width: 220%;
+  left: -70%;
+  opacity: 0.55;
+  border-radius: 999px;
+  --hero-mainboard-light-cyan-opacity: 0.34;
+  --hero-mainboard-light-violet-opacity: 0.38;
+  --hero-mainboard-light-magenta-opacity: 0.32;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    hsla(var(--hero-mainboard-light-teal), 0.24) 18%,
+    hsla(var(--hero-mainboard-light-cyan), var(--hero-mainboard-light-cyan-opacity)) 32%,
+    hsla(var(--hero-mainboard-light-blue), 0.48) 52%,
+    hsla(var(--hero-mainboard-light-violet), var(--hero-mainboard-light-violet-opacity)) 72%,
+    hsla(var(--hero-mainboard-light-magenta), var(--hero-mainboard-light-magenta-opacity)) 86%,
+    transparent 100%
+  );
+  filter: blur(14px);
+  animation: hero-mainboard-scan var(--hero-mainboard-light-duration, 10s) linear infinite;
+  animation-delay: var(--hero-mainboard-light-delay, 0s);
+}
+
+.hero-mainboard-lights {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  isolation: isolate;
+}
+
+.hero-mainboard-lights::before {
+  content: "";
+  position: absolute;
+  inset: -12%;
+  background: radial-gradient(
+      110% 90% at 8% 8%,
+      hsla(var(--hero-mainboard-light-magenta), 0.45) 0%,
+      hsla(var(--hero-mainboard-light-violet), 0.12) 38%,
+      transparent 68%
+    ),
+    radial-gradient(
+      150% 120% at 0% 60%,
+      hsla(var(--hero-mainboard-light-teal), 0.28) 0%,
+      hsla(var(--hero-mainboard-light-cyan), 0.16) 42%,
+      transparent 70%
+    );
+  filter: blur(40px);
+  opacity: 0.7;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.hero-mainboard-light--one {
+  --hero-mainboard-light-top: 28%;
+  --hero-mainboard-light-height: 22%;
+  --hero-mainboard-light-duration: 9s;
+  --hero-mainboard-light-delay: 0s;
+  --hero-mainboard-light-violet-opacity: 0.46;
+  --hero-mainboard-light-magenta-opacity: 0.44;
+}
+
+.hero-mainboard-light--two {
+  --hero-mainboard-light-top: 46%;
+  --hero-mainboard-light-height: 18%;
+  --hero-mainboard-light-duration: 12s;
+  --hero-mainboard-light-delay: -4s;
+  --hero-mainboard-light-violet-opacity: 0.38;
+  --hero-mainboard-light-magenta-opacity: 0.32;
+}
+
+.hero-mainboard-light--three {
+  --hero-mainboard-light-top: 64%;
+  --hero-mainboard-light-height: 24%;
+  --hero-mainboard-light-duration: 10.5s;
+  --hero-mainboard-light-delay: -7s;
+  --hero-mainboard-light-cyan-opacity: 0.4;
+  --hero-mainboard-light-violet-opacity: 0.32;
+  --hero-mainboard-light-magenta-opacity: 0.26;
+}
+
 @keyframes slideGradient {
   from {
     left: -50%;
@@ -275,6 +360,37 @@ li > p {
 
   to {
     left: 0;
+  }
+}
+
+@keyframes hero-mainboard-scan {
+  0% {
+    transform: translate3d(-45%, 0, 0);
+    opacity: 0;
+  }
+
+  15% {
+    opacity: 0.45;
+  }
+
+  50% {
+    opacity: 0.7;
+  }
+
+  85% {
+    opacity: 0.45;
+  }
+
+  100% {
+    transform: translate3d(45%, 0, 0);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-mainboard-light {
+    animation: none;
+    opacity: 0.3;
   }
 }
 
@@ -731,6 +847,13 @@ https://www.radix-ui.com/colors/docs/palette-composition/scales
     --info-11: 208, 88%, 43%;
     --info-12: 216, 71%, 23%;
 
+    /* Hero mainboard light spectrum */
+    --hero-mainboard-light-teal: 170, 92%, 56%;
+    --hero-mainboard-light-cyan: 189, 95%, 62%;
+    --hero-mainboard-light-blue: 224, 88%, 60%;
+    --hero-mainboard-light-violet: 266, 86%, 66%;
+    --hero-mainboard-light-magenta: 292, 88%, 70%;
+
     /* Slate */
     /* Brand */
     --accent-1: 240, 20%, 99%;
@@ -901,6 +1024,13 @@ https://www.radix-ui.com/colors/docs/palette-composition/scales
     --info-10: 210, 100%, 62%;
     --info-11: 210, 100%, 72%;
     --info-12: 205, 100%, 88%;
+
+    /* Hero mainboard light spectrum */
+    --hero-mainboard-light-teal: 168, 88%, 50%;
+    --hero-mainboard-light-cyan: 189, 92%, 55%;
+    --hero-mainboard-light-blue: 224, 82%, 58%;
+    --hero-mainboard-light-violet: 266, 80%, 62%;
+    --hero-mainboard-light-magenta: 292, 82%, 65%;
 
     /* Slate Dark */
     --accent-1: 240, 6%, 7%;

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -46,14 +46,23 @@ export const Hero: React.FC = () => {
         />
       </motion.div>
 
-      <div>
-        <Image
-          src={mainboard}
-          alt="Animated SVG showing computer circuits lighting up"
-          className="absolute hidden xl:right-32 xl:flex -z-10 xl:-top-56"
-          style={{ transform: "scale(2)" }}
-          priority
-        />
+      <div
+        className="absolute hidden xl:flex -z-10 xl:-top-56 xl:right-32"
+        aria-hidden="true"
+      >
+        <div className="relative" style={{ transform: "scale(2)" }}>
+          <Image
+            src={mainboard}
+            alt="Animated SVG showing computer circuits lighting up"
+            className="pointer-events-none select-none"
+            priority
+          />
+          <div className="hero-mainboard-lights">
+            <span className="hero-mainboard-light hero-mainboard-light--one" />
+            <span className="hero-mainboard-light hero-mainboard-light--two" />
+            <span className="hero-mainboard-light hero-mainboard-light--three" />
+          </div>
+        </div>
       </div>
       <SubHeroMainboard className="absolute hidden md:flex left-1/2 -translate-x-[calc(50%+85px)] -bottom-[224px] -z-10" />
     </motion.div>


### PR DESCRIPTION
## Plan
- Sample a teal-to-magenta palette from the reference artwork and expose it as hero light tokens.
- Regrade each mainboard sweep and add ambient gradients so the animation leans cyan on the left and magenta toward the upper-left.
- Capture the color-tuning request in the FIXES ledger and rerun lint for regressions.

## Summary
- Introduced hero-specific light spectrum variables and reshaped each sweep’s gradient mix to shift from teal to magenta with stronger purple emphasis near the top pass.
- Added a layered glow backdrop behind the mainboard to blend cyan energy at the left edge with a magenta wash in the upper-left corner.
- Logged the palette adjustment in a new FIXES entry for traceability.

## Testing
- `pnpm --filter www run lint` *(fails: missing optional dependency `next-intl` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd09427d08832ab1f3aae95d521974