### PR TITLE
Fix Dutch navigation logo home link

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-26T1800--navigation-logo-locale-home-link.md
+++ b/WRITE_HERE/FIXES/2025-11-26T1800--navigation-logo-locale-home-link.md
@@ -1,0 +1,5 @@
+# Restored locale-aware navigation logo
+- **What:** Pointed the header logo and mobile home entry to the active locale's root route so the TransformAI mark behaves as a working home icon in Dutch.
+- **Why:** The Dutch locale still routed the logo tap to the default path, leaving users stuck outside their language.
+- **Files:** `apps/www/components/navbar/navigation.tsx`, `apps/www/components/navbar/link.tsx`.
+- **Follow-ups:** Audit other manual "/" links if new locales are introduced.

--- a/apps/www/components/navbar/link.tsx
+++ b/apps/www/components/navbar/link.tsx
@@ -33,13 +33,20 @@ export function MobileNavLink({
   label,
   external,
   onClick,
-}: { href: string; label: string; external?: boolean; onClick: () => void }) {
+  isHome = false,
+}: {
+  href: string;
+  label: string;
+  external?: boolean;
+  onClick: () => void;
+  isHome?: boolean;
+}) {
   const segment = useSelectedLayoutSegment();
   const router = useRouter();
 
   const isActive = segment
     ? href.startsWith(`/${segment}`)
-    : href === "/";
+    : isHome;
 
   return (
     <button

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -14,7 +14,7 @@ import { useConsentManager } from "@c15t/nextjs";
 import { track } from "@vercel/analytics";
 import { motion } from "framer-motion";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { PrimaryButton, SecondaryButton } from "../button";
 import { DesktopNavLink, MobileNavLink } from "./link";
@@ -23,6 +23,8 @@ export function Navigation() {
   const [scrollPercent, setScrollPercent] = useState(0);
   const { hasConsentFor } = useConsentManager();
   const t = useTranslations("Navigation");
+  const locale = useLocale();
+  const homeHref = `/${locale}`;
   const containerVariants = {
     hidden: {
       opacity: 0,
@@ -61,7 +63,7 @@ export function Navigation() {
     >
       <div className="container flex items-center justify-between">
         <div className="flex items-center justify-between w-full sm:w-auto sm:gap-12 lg:gap-20">
-          <Link href="/" aria-label={t("ariaHome")}>
+          <Link href={homeHref} aria-label={t("ariaHome")}>
             <Logo />
           </Link>
           <MobileLinks className="lg:hidden" />
@@ -101,6 +103,8 @@ export function Navigation() {
 function MobileLinks({ className }: { className?: string }) {
   const [isOpen, setIsOpen] = useState(false);
   const t = useTranslations("Navigation");
+  const locale = useLocale();
+  const homeHref = `/${locale}`;
   return (
     <div className={className}>
       <Drawer open={isOpen} onOpenChange={setIsOpen}>
@@ -121,7 +125,12 @@ function MobileLinks({ className }: { className?: string }) {
           <div className="relative w-full mx-auto antialiased z-[110]">
             <ul className="flex flex-col px-8 divide-y divide-white/25">
               <li>
-                <MobileNavLink onClick={() => setIsOpen(false)} href="/" label={t("links.home")} />
+                <MobileNavLink
+                  onClick={() => setIsOpen(false)}
+                  href={homeHref}
+                  label={t("links.home")}
+                  isHome
+                />
               </li>
               <li>
                 <MobileNavLink


### PR DESCRIPTION
## Plan
- inspect the header navigation implementation for locale-specific routing gaps
- update the logo/home interactions to resolve locale mismatches
- verify mobile navigation state handling and document the fix
- run repository lint checks to confirm the change

## Summary
- route the navigation logo and mobile home entry through the active locale so the Dutch header icon links correctly
- adjust mobile navigation active state handling for the localized home link
- log the bug fix in WRITE_HERE/FIXES for project history

## Testing
- `pnpm --filter www run lint` *(fails: missing dependency next-intl in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1ee4cda4832aa2b0be9bc92c8207