### PR TITLE
Fix Dutch navigation logo shrinking

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-26T1800--navigation-logo-locale-home-link.md
+++ b/WRITE_HERE/FIXES/2025-11-26T1800--navigation-logo-locale-home-link.md
@@ -1,0 +1,5 @@
+# Restored locale-aware navigation logo
+- **What:** Pointed the header logo and mobile home entry to the active locale's root route so the TransformAI mark behaves as a working home icon in Dutch.
+- **Why:** The Dutch locale still routed the logo tap to the default path, leaving users stuck outside their language.
+- **Files:** `apps/www/components/navbar/navigation.tsx`, `apps/www/components/navbar/link.tsx`.
+- **Follow-ups:** Audit other manual "/" links if new locales are introduced.

--- a/WRITE_HERE/FIXES/2025-11-26T1930--navigation-logo-dutch-home-prefix.md
+++ b/WRITE_HERE/FIXES/2025-11-26T1930--navigation-logo-dutch-home-prefix.md
@@ -1,0 +1,5 @@
+# Dutch navigation logo visible again
+- **What:** Reverted the header logo and mobile home links to use the locale-aware navigation helpers with root (`"/"`) paths so next-intl prefixes them correctly instead of doubling the locale segment.
+- **Why:** The prior fix hard-coded `/${locale}` which `next-intl` prefixed again, breaking the Dutch home link and leaving the logo image unloaded on the resulting 404 route.
+- **Files:** `apps/www/components/navbar/navigation.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-26T2100--navigation-logo-dutch-flex.md
+++ b/WRITE_HERE/FIXES/2025-11-26T2100--navigation-logo-dutch-flex.md
@@ -1,0 +1,5 @@
+# Restore Dutch navigation logo scale
+- **What:** Prevented the header logo from shrinking inside the Dutch navigation layout by making the wordmark a non-flexible item.
+- **Why:** Longer Dutch navigation labels squeezed the flex container and collapsed the logo width, leaving it far smaller than on the English locale.
+- **Files:** `apps/www/components/navbar/navigation.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/components/navbar/link.tsx
+++ b/apps/www/components/navbar/link.tsx
@@ -33,13 +33,20 @@ export function MobileNavLink({
   label,
   external,
   onClick,
-}: { href: string; label: string; external?: boolean; onClick: () => void }) {
+  isHome = false,
+}: {
+  href: string;
+  label: string;
+  external?: boolean;
+  onClick: () => void;
+  isHome?: boolean;
+}) {
   const segment = useSelectedLayoutSegment();
   const router = useRouter();
 
   const isActive = segment
     ? href.startsWith(`/${segment}`)
-    : href === "/";
+    : isHome;
 
   return (
     <button

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -121,7 +121,12 @@ function MobileLinks({ className }: { className?: string }) {
           <div className="relative w-full mx-auto antialiased z-[110]">
             <ul className="flex flex-col px-8 divide-y divide-white/25">
               <li>
-                <MobileNavLink onClick={() => setIsOpen(false)} href="/" label={t("links.home")} />
+                <MobileNavLink
+                  onClick={() => setIsOpen(false)}
+                  href="/"
+                  label={t("links.home")}
+                  isHome
+                />
               </li>
               <li>
                 <MobileNavLink
@@ -240,7 +245,7 @@ function Logo({ className }: { className?: string }) {
     <TransformAILogo
       variant="transparent"
       className={cn(
-        "h-auto w-[152px] sm:w-[184px] md:w-[212px] lg:w-[232px]",
+        "h-auto w-[152px] sm:w-[184px] md:w-[212px] lg:w-[232px] flex-shrink-0",
         className,
       )}
       priority


### PR DESCRIPTION
## Plan
- inspect the Dutch header layout to identify why the wordmark collapses
- prevent the logo from shrinking inside the navigation flex row so it matches the English locale
- log the regression fix in WRITE_HERE/FIXES and verify visually via the dev server

## Summary
- add a flex guard to the TransformAI wordmark so the Dutch navigation keeps the same logo scale as English
- record the locale-specific navigation logo fix in the project FIXES log for future reference

## Testing
- `pnpm --filter www run lint` *(fails: existing lint violations in untouched files)*
- `pnpm --filter www dev` *(ran for manual verification; exits with a segmentation fault on shutdown)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1ee4cda4832aa2b0be9bc92c8207