### PR TITLE
Fix navigation logo shrink in Dutch locale

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-26T1730--navigation-logo-dutch-sizing.md
+++ b/WRITE_HERE/FIXES/2025-11-26T1730--navigation-logo-dutch-sizing.md
@@ -1,0 +1,5 @@
+# Fix Dutch navigation logo shrinkage
+- **What:** Prevented the header logo from shrinking in flex layouts by adding a `shrink-0` utility to the shared navigation logo wrapper.
+- **Why:** The longer Dutch CTA labels squeezed the flex row, causing the TransformAI logo to shrink dramatically in the top navigation bar.
+- **Files:** `apps/www/components/navbar/navigation.tsx`.
+- **Follow-ups:** Capture updated header screenshots once the environment supports running the Next.js app locally.

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -240,7 +240,7 @@ function Logo({ className }: { className?: string }) {
     <TransformAILogo
       variant="transparent"
       className={cn(
-        "h-auto w-[152px] sm:w-[184px] md:w-[212px] lg:w-[232px]",
+        "h-auto w-[152px] sm:w-[184px] md:w-[212px] lg:w-[232px] shrink-0",
         className,
       )}
       priority


### PR DESCRIPTION
## Summary
- add a flex `shrink-0` guard to the navigation logo so it keeps its intended width on every locale
- record the bug fix in the project FIXES log for traceability

## Plan
- Inspect the shared navigation logo wrapper in `navigation.tsx`
- Apply a non-shrinking width utility that still respects responsive sizing
- Update the FIXES changelog to document the regression and resolution
- Run linting to verify the change (expecting the known next-intl dependency issue)

## Testing
- `pnpm --filter www run lint` *(fails: missing next-intl dependency in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68dd411084d8832a86682b1aa1ffd6f5