### PR TITLE
Ensure navigation logo link resists flex shrinking

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-26T1730--navigation-logo-dutch-sizing.md
+++ b/WRITE_HERE/FIXES/2025-11-26T1730--navigation-logo-dutch-sizing.md
@@ -1,0 +1,5 @@
+# Fix Dutch navigation logo shrinkage
+- **What:** Prevented the header logo from shrinking in flex layouts by adding a `shrink-0` utility to the shared navigation logo wrapper.
+- **Why:** The longer Dutch CTA labels squeezed the flex row, causing the TransformAI logo to shrink dramatically in the top navigation bar.
+- **Files:** `apps/www/components/navbar/navigation.tsx`.
+- **Follow-ups:** Capture updated header screenshots once the environment supports running the Next.js app locally.

--- a/WRITE_HERE/FIXES/2025-11-26T2000--navigation-logo-anchor-shrink-guard.md
+++ b/WRITE_HERE/FIXES/2025-11-26T2000--navigation-logo-anchor-shrink-guard.md
@@ -1,0 +1,5 @@
+# Navigation logo anchor shrink guard
+- **What:** Prevented the navigation logo link from shrinking within the flex header so the wordmark keeps the same size across locales.
+- **Why:** The Dutch navigation labels pushed the flex row tight and the anchor was still allowed to shrink, crushing the logo despite the image wrapper using `shrink-0`.
+- **Files:** `apps/www/components/navbar/navigation.tsx`.
+- **Follow-ups:** Capture updated navigation screenshots once the site can run locally without missing dependencies.

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -61,7 +61,7 @@ export function Navigation() {
     >
       <div className="container flex items-center justify-between">
         <div className="flex items-center justify-between w-full sm:w-auto sm:gap-12 lg:gap-20">
-          <Link href="/" aria-label={t("ariaHome")}>
+          <Link href="/" aria-label={t("ariaHome")} className="block shrink-0">
             <Logo />
           </Link>
           <MobileLinks className="lg:hidden" />
@@ -240,7 +240,7 @@ function Logo({ className }: { className?: string }) {
     <TransformAILogo
       variant="transparent"
       className={cn(
-        "h-auto w-[152px] sm:w-[184px] md:w-[212px] lg:w-[232px]",
+        "h-auto w-[152px] sm:w-[184px] md:w-[212px] lg:w-[232px] shrink-0",
         className,
       )}
       priority


### PR DESCRIPTION
## Summary
- prevent the navigation logo anchor from shrinking so the wordmark keeps its intended width in Dutch
- document the regression and remedy in the FIXES ledger for traceability

## Plan
- inspect the navigation flex structure to identify which element still shrinks under long locale labels
- add the shrink guard utility to the logo link so the entire logo block preserves its width
- capture the bug fix in `WRITE_HERE/FIXES`

## Testing
- `pnpm --filter www run lint` *(fails: missing next-intl dependency in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68dd411084d8832a86682b1aa1ffd6f5