### PR TITLE
Adjust navigation logo scale across locales

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-26T1730--navigation-logo-dutch-sizing.md
+++ b/WRITE_HERE/FIXES/2025-11-26T1730--navigation-logo-dutch-sizing.md
@@ -1,0 +1,5 @@
+# Fix Dutch navigation logo shrinkage
+- **What:** Prevented the header logo from shrinking in flex layouts by adding a `shrink-0` utility to the shared navigation logo wrapper.
+- **Why:** The longer Dutch CTA labels squeezed the flex row, causing the TransformAI logo to shrink dramatically in the top navigation bar.
+- **Files:** `apps/www/components/navbar/navigation.tsx`.
+- **Follow-ups:** Capture updated header screenshots once the environment supports running the Next.js app locally.

--- a/WRITE_HERE/FIXES/2025-11-26T2000--navigation-logo-anchor-shrink-guard.md
+++ b/WRITE_HERE/FIXES/2025-11-26T2000--navigation-logo-anchor-shrink-guard.md
@@ -1,0 +1,5 @@
+# Navigation logo anchor shrink guard
+- **What:** Prevented the navigation logo link from shrinking within the flex header so the wordmark keeps the same size across locales.
+- **Why:** The Dutch navigation labels pushed the flex row tight and the anchor was still allowed to shrink, crushing the logo despite the image wrapper using `shrink-0`.
+- **Files:** `apps/www/components/navbar/navigation.tsx`.
+- **Follow-ups:** Capture updated navigation screenshots once the site can run locally without missing dependencies.

--- a/WRITE_HERE/FIXES/2025-11-27T0900--navigation-logo-right-sized.md
+++ b/WRITE_HERE/FIXES/2025-11-27T0900--navigation-logo-right-sized.md
@@ -1,0 +1,5 @@
+# Navigation logo right-sized across locales
+- **What:** Reduced the responsive width presets on the header logo so the TransformAI wordmark renders at a balanced scale in both English and Dutch navigation layouts.
+- **Why:** After preventing flex shrink, the wider locale labels left the logo visually oversized; dialing the widths back keeps the mark prominent without overpowering the menu.
+- **Files:** `apps/www/components/navbar/navigation.tsx`.
+- **Follow-ups:** Capture updated header screenshots once the Next.js workspace runs with the missing `next-intl` dependency.

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -61,7 +61,7 @@ export function Navigation() {
     >
       <div className="container flex items-center justify-between">
         <div className="flex items-center justify-between w-full sm:w-auto sm:gap-12 lg:gap-20">
-          <Link href="/" aria-label={t("ariaHome")}>
+          <Link href="/" aria-label={t("ariaHome")} className="block shrink-0">
             <Logo />
           </Link>
           <MobileLinks className="lg:hidden" />
@@ -240,11 +240,11 @@ function Logo({ className }: { className?: string }) {
     <TransformAILogo
       variant="transparent"
       className={cn(
-        "h-auto w-[152px] sm:w-[184px] md:w-[212px] lg:w-[232px]",
+        "h-auto w-[128px] sm:w-[164px] md:w-[188px] lg:w-[204px] shrink-0",
         className,
       )}
       priority
-      sizes="(max-width: 640px) 184px, (max-width: 1024px) 212px, 232px"
+      sizes="(max-width: 640px) 164px, (max-width: 1024px) 188px, 204px"
     />
   );
 }


### PR DESCRIPTION
## Summary
- reduce the responsive width presets on the header logo so it matches English sizing expectations across locales
- document the regression fix in the FIXES ledger for traceability

## Plan
- review the navigation logo component to identify the sizing utilities controlling rendered width
- adjust the Tailwind width utilities and sizes attribute to dial the wordmark back to a balanced scale
- log the change in WRITE_HERE/FIXES for future reference

## Testing
- not run (workspace missing the required `next-intl` dependency)


------
https://chatgpt.com/codex/tasks/task_e_68dd411084d8832a86682b1aa1ffd6f5