### PR TITLE
Balance contact layout and inbox messaging

### DIFF
--- a/WRITE_HERE/UPDATES/2025-09-30T1500--launched-contact-page.md
+++ b/WRITE_HERE/UPDATES/2025-09-30T1500--launched-contact-page.md
@@ -1,0 +1,5 @@
+# Launched dedicated contact page
+- **What:** Added a `/contact` page with a pricing-inspired hero, service highlights, and a premium contact form that routes submissions through Resend to `info@transformai.nl` → `yergushbloetjes@gmail.com`. Wired new navigation/footer links and translations in English and Dutch.
+- **Why:** Give prospects a focused way to reach TransformAI while highlighting the official inbox.
+- **Files:** New contact route, client form, server action, shared constants, navbar/footer updates, translations, README instructions, dependency update.
+- **Follow-ups:** Configure Resend with the provided environment variables and verify the `info@transformai.nl` sender identity.

--- a/WRITE_HERE/UPDATES/2025-11-26T1000--contact-form-balance.md
+++ b/WRITE_HERE/UPDATES/2025-11-26T1000--contact-form-balance.md
@@ -1,0 +1,5 @@
+# Contact form layout balanced
+- **What:** Split the contact page into equal columns and elevated the form header with an inbox callout that points to info@transformai.nl.
+- **Why:** The user wanted "Why leaders reach out" and "Send us a message" to share the layout evenly and to make the destination inbox unmistakable.
+- **Files:** `apps/www/app/[locale]/(site)/contact/page.tsx`, `apps/www/app/[locale]/(site)/contact/components/contact-form.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Capture updated screenshots once the deployment reflects the new form header.

--- a/apps/www/README.md
+++ b/apps/www/README.md
@@ -12,3 +12,16 @@ or from the www directory:
 ```bash
 pnpm run dev
 ```
+
+## Contact form configuration
+
+The `/contact` page forwards submissions through [Resend](https://resend.com/) so incoming messages to `info@transformai.nl` land in `yergushbloetjes@gmail.com`.
+
+1. Add the following variables to `apps/www/.env.local` (or your deployment provider):
+   - `RESEND_API_KEY` – API key with permission to send emails.
+   - `CONTACT_FROM_EMAIL` – optional. Defaults to `TransformAI <info@transformai.nl>`, but set this if you use a different verified sender identity.
+   - `CONTACT_FORWARD_TO` – the inbox that should receive the forwarded messages (e.g. `yergushbloetjes@gmail.com`).
+2. Verify the `transformai.nl` domain and the `info@transformai.nl` sender identity inside Resend so mail is delivered from the official address.
+3. (Recommended) Configure an alias or forwarding rule in your email provider so replying from `info@transformai.nl` stays consistent with what visitors see on the site.
+
+If any of the required variables are missing the form gracefully falls back and asks visitors to email `info@transformai.nl` directly.

--- a/apps/www/app/[locale]/(site)/contact/components/contact-form.tsx
+++ b/apps/www/app/[locale]/(site)/contact/components/contact-form.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useFormState, useFormStatus } from "react-dom";
+import { Loader2, Mail } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Alert, AlertDescription } from "@/components/ui/alert/alert";
+import { cn } from "@/lib/utils";
+
+import {
+  CONTACT_REQUEST_TYPES,
+  type ContactRequestType,
+} from "../constants";
+import { initialState, sendContactMessage } from "../server/send-message";
+import { RequestTypeSelector } from "./request-type-selector";
+
+type FieldName = "name" | "company" | "email";
+
+type FieldConfig = {
+  name: FieldName;
+  type?: string;
+  autoComplete?: string;
+  label: string;
+  placeholder: string;
+  required?: boolean;
+};
+
+const fieldClassName =
+  "w-full rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:border-white/40 transition disabled:cursor-not-allowed disabled:opacity-60";
+
+export function ContactForm() {
+  const t = useTranslations("Contact.Form");
+  const [state, formAction] = useFormState(sendContactMessage, initialState);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [requestType, setRequestType] = useState<ContactRequestType>(
+    CONTACT_REQUEST_TYPES[0].value,
+  );
+
+  useEffect(() => {
+    if (state.status === "success") {
+      formRef.current?.reset();
+      setRequestType(CONTACT_REQUEST_TYPES[0].value);
+    }
+  }, [state]);
+
+  const requestTypeOptions = useMemo(
+    () =>
+      CONTACT_REQUEST_TYPES.map((option) => ({
+        value: option.value,
+        title: t(`requestTypes.${option.translationKey}.title`),
+        description: t(`requestTypes.${option.translationKey}.description`),
+      })),
+    [t],
+  );
+
+  const fields: FieldConfig[] = [
+    {
+      name: "name",
+      label: t("fields.name.label"),
+      placeholder: t("fields.name.placeholder"),
+      autoComplete: "name",
+      required: true,
+    },
+    {
+      name: "company",
+      label: t("fields.company.label"),
+      placeholder: t("fields.company.placeholder"),
+      autoComplete: "organization",
+    },
+    {
+      name: "email",
+      type: "email",
+      label: t("fields.email.label"),
+      placeholder: t("fields.email.placeholder"),
+      autoComplete: "email",
+    },
+  ];
+
+  return (
+    <div className="relative isolate overflow-hidden rounded-[32px] border border-white/15 bg-white/[0.04] p-6 sm:p-8 shadow-[0_28px_120px_rgba(15,23,42,0.45)]">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -top-1/3 left-1/2 h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.35),_rgba(59,130,246,0))] blur-3xl"
+      />
+      <form ref={formRef} action={formAction} className="relative z-10 space-y-6">
+        <div className="space-y-4">
+          <span className="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/[0.06] px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white/70">
+            {t("badge")}
+          </span>
+          <div className="space-y-2">
+            <h3 className="text-2xl font-semibold text-white sm:text-3xl">{t("title")}</h3>
+            <p className="text-sm text-white/70 sm:text-base">{t("subtitle")}</p>
+          </div>
+          <div className="flex items-start gap-3 rounded-2xl border border-white/20 bg-white/[0.06] px-4 py-3 text-left shadow-[0_18px_80px_rgba(15,23,42,0.35)]">
+            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white">
+              <Mail className="h-5 w-5" aria-hidden />
+            </span>
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">
+                {t("channel.label")}
+              </p>
+              <p className="text-sm text-white/80">
+                {t("channel.caption", { email: "info@transformai.nl" })}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {state.status === "success" && state.message ? (
+          <Alert variant="success" className="border-none">
+            <AlertDescription variant="success">
+              <div>
+                <p className="text-sm font-semibold text-white">{t("feedback.successTitle")}</p>
+                <p className="mt-1 text-sm text-white/70">{state.message}</p>
+              </div>
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {state.status === "error" && state.message ? (
+          <Alert variant="error" className="border-none">
+            <AlertDescription variant="error">
+              <div>
+                <p className="text-sm font-semibold text-white">{t("feedback.errorTitle")}</p>
+                <p className="mt-1 text-sm text-white/70">{state.message}</p>
+              </div>
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        <RequestTypeSelector
+          label={t("requestType.label")}
+          helperText={t("requestType.helper")}
+          options={requestTypeOptions}
+          selected={requestType}
+          onSelect={setRequestType}
+          error={state.fieldErrors?.requestType}
+        />
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          {fields.map(({ name, label, placeholder, type = "text", autoComplete, required }) => (
+            <div key={name} className="space-y-2">
+              <label className="text-xs font-medium uppercase tracking-[0.2em] text-white/60" htmlFor={name}>
+                {label}
+                {required ? <span className="ml-1 text-white/40">*</span> : null}
+              </label>
+              <input
+                id={name}
+                name={name}
+                type={type}
+                autoComplete={autoComplete}
+                placeholder={placeholder}
+                className={cn(fieldClassName, state.fieldErrors?.[name] && "border-rose-400/70 text-white")}
+                aria-invalid={state.fieldErrors?.[name] ? "true" : undefined}
+                aria-describedby={state.fieldErrors?.[name] ? `${name}-error` : undefined}
+                required={required}
+              />
+              {state.fieldErrors?.[name] ? (
+                <p id={`${name}-error`} className="text-xs font-medium text-rose-300">
+                  {state.fieldErrors[name]}
+                </p>
+              ) : null}
+            </div>
+          ))}
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-xs font-medium uppercase tracking-[0.2em] text-white/60" htmlFor="description">
+            {t("fields.description.label")}
+            <span className="ml-1 text-white/40">*</span>
+          </label>
+          <textarea
+            id="description"
+            name="description"
+            placeholder={t("fields.description.placeholder")}
+            rows={6}
+            className={cn(
+              fieldClassName,
+              "min-h-[160px] resize-y",
+              state.fieldErrors?.description && "border-rose-400/70 text-white",
+            )}
+            aria-invalid={state.fieldErrors?.description ? "true" : undefined}
+            aria-describedby={state.fieldErrors?.description ? "description-error" : undefined}
+            required
+          />
+          {state.fieldErrors?.description ? (
+            <p id="description-error" className="text-xs font-medium text-rose-300">
+              {state.fieldErrors.description}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="pt-2">
+          <SubmitButton label={t("submit.label")} pendingLabel={t("submit.pending")} />
+        </div>
+        <p className="text-xs leading-5 text-white/40">
+          {t("footnote", { email: "info@transformai.nl" })}
+        </p>
+      </form>
+    </div>
+  );
+}
+
+function SubmitButton({ label, pendingLabel }: { label: string; pendingLabel: string }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      className="relative flex w-full items-center justify-center gap-2 overflow-hidden rounded-2xl border border-white/20 bg-gradient-to-r from-white via-white to-white/80 px-5 py-3 text-sm font-semibold text-black shadow-[0_16px_48px_rgba(59,130,246,0.3)] transition hover:from-white hover:via-white hover:to-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 disabled:cursor-not-allowed disabled:opacity-70"
+      disabled={pending}
+    >
+      <span>{pending ? pendingLabel : label}</span>
+      {pending ? <Loader2 className="h-4 w-4 animate-spin text-black/70" aria-hidden /> : null}
+    </button>
+  );
+}

--- a/apps/www/app/[locale]/(site)/contact/components/request-type-selector.tsx
+++ b/apps/www/app/[locale]/(site)/contact/components/request-type-selector.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useFormStatus } from "react-dom";
+
+import type { ContactRequestType } from "../constants";
+
+type RequestTypeOption = {
+  value: ContactRequestType;
+  title: string;
+  description: string;
+};
+
+type RequestTypeSelectorProps = {
+  label: string;
+  helperText?: string;
+  options: RequestTypeOption[];
+  selected: ContactRequestType;
+  onSelect: (value: ContactRequestType) => void;
+  error?: string;
+};
+
+export function RequestTypeSelector({
+  label,
+  helperText,
+  options,
+  selected,
+  onSelect,
+  error,
+}: RequestTypeSelectorProps) {
+  const { pending } = useFormStatus();
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <span className="text-sm font-medium tracking-wide text-white/90">{label}</span>
+        {helperText ? (
+          <span className="text-xs text-white/50 sm:text-right">{helperText}</span>
+        ) : null}
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {options.map((option) => {
+          const isActive = option.value === selected;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => onSelect(option.value)}
+              disabled={pending}
+              className={cn(
+                "group relative overflow-hidden rounded-2xl border px-4 py-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40",
+                isActive
+                  ? "border-white/60 bg-white/[0.12] shadow-[0_18px_60px_rgba(59,130,246,0.25)]"
+                  : "border-white/10 bg-white/[0.04] hover:border-white/30 hover:bg-white/[0.08]",
+                pending && "cursor-not-allowed opacity-70",
+              )}
+            >
+              <div
+                aria-hidden
+                className={cn(
+                  "pointer-events-none absolute inset-0 opacity-0 transition group-hover:opacity-100",
+                  isActive && "opacity-100",
+                  "bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.28),_rgba(59,130,246,0))]",
+                )}
+              />
+              <div className="relative z-10 space-y-1">
+                <p className="text-sm font-semibold text-white/90">{option.title}</p>
+                <p className="text-xs leading-5 text-white/60">{option.description}</p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+      {error ? <p className="text-xs font-medium text-rose-300">{error}</p> : null}
+      <input type="hidden" name="requestType" value={selected} />
+    </div>
+  );
+}

--- a/apps/www/app/[locale]/(site)/contact/constants.ts
+++ b/apps/www/app/[locale]/(site)/contact/constants.ts
@@ -1,0 +1,24 @@
+export const CONTACT_REQUEST_TYPES = [
+  {
+    value: "strategy",
+    translationKey: "strategy",
+    emailLabel: "AI strategy sprint",
+  },
+  {
+    value: "automation",
+    translationKey: "automation",
+    emailLabel: "Automation & efficiency audit",
+  },
+  {
+    value: "integration",
+    translationKey: "integration",
+    emailLabel: "Custom AI integration",
+  },
+  {
+    value: "training",
+    translationKey: "training",
+    emailLabel: "Executive enablement & training",
+  },
+] as const;
+
+export type ContactRequestType = (typeof CONTACT_REQUEST_TYPES)[number]["value"];

--- a/apps/www/app/[locale]/(site)/contact/page.tsx
+++ b/apps/www/app/[locale]/(site)/contact/page.tsx
@@ -1,0 +1,128 @@
+import { Handshake, ShieldCheck, Sparkles } from "lucide-react";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+
+import { Container } from "@/components/container";
+import { SectionTitle } from "@/components/section";
+import { FadeIn, FadeInStagger } from "@/components/fade-in";
+import { isLocale } from "@/i18n/routing";
+
+import { ContactForm } from "./components/contact-form";
+
+export const metadata = {
+  title: "Contact | TransformAI",
+  description: "Partner with TransformAI to shape your AI strategy, automation, and enablement initiatives.",
+  openGraph: {
+    title: "Contact TransformAI",
+    description: "Share your AI ambition and we'll craft a tailored plan within two business days.",
+    url: "https://transformai.nl/contact",
+    siteName: "TransformAI",
+    images: [
+      {
+        url: "https://transformai.nl/images/landing/og.png",
+        width: 1200,
+        height: 675,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Contact TransformAI",
+    description: "Tell us about your AI goals and we'll respond with a tailored action plan.",
+  },
+  icons: {
+    shortcut: "/images/logos/transformai/logosvg.svg",
+  },
+};
+
+type PageProps = {
+  params: {
+    locale: string;
+  };
+};
+
+const highlightItems = [
+  { key: "strategy", icon: Sparkles },
+  { key: "coCreation", icon: Handshake },
+  { key: "governance", icon: ShieldCheck },
+] as const;
+
+export default async function ContactPage({ params }: PageProps) {
+  const { locale } = params;
+
+  if (!isLocale(locale)) {
+    notFound();
+  }
+
+  const t = await getTranslations({ locale, namespace: "Contact" });
+
+  return (
+    <div className="relative isolate pb-24 pt-28">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[620px] bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.28),_transparent_65%)] blur-3xl"
+      />
+      <Container className="relative">
+        <FadeIn>
+          <div className="relative isolate overflow-hidden rounded-[40px] border border-white/10 bg-white/[0.03] px-6 py-16 text-center shadow-[0_32px_140px_rgba(15,23,42,0.6)] sm:px-12">
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0 -z-10"
+            >
+              <div className="absolute left-1/2 top-0 h-[520px] w-[520px] -translate-x-1/2 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.35),_rgba(59,130,246,0))]" />
+              <div className="absolute inset-x-12 bottom-[-180px] h-[360px] bg-[conic-gradient(from_110deg_at_50%_50%,_rgba(255,255,255,0.24),_rgba(59,130,246,0),_transparent)] blur-3xl" />
+            </div>
+
+            <span className="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/[0.06] px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white/70">
+              {t("Hero.eyebrow")}
+            </span>
+            <h1 className="mt-6 text-balance text-4xl font-semibold leading-tight text-transparent sm:text-5xl sm:leading-tight bg-gradient-to-b from-white via-white to-white/60 bg-clip-text">
+              {t("Hero.title")}
+            </h1>
+            <p className="mx-auto mt-4 max-w-2xl text-balance text-base text-white/70 sm:text-lg">
+              {t("Hero.body")}
+            </p>
+            <p className="mx-auto mt-6 max-w-lg text-sm font-medium text-white/60">
+              {t("Hero.emailNotice")}
+            </p>
+          </div>
+        </FadeIn>
+      </Container>
+
+      <Container className="relative mt-16">
+        <div className="grid gap-12 lg:grid-cols-2 lg:items-start xl:gap-16">
+          <FadeInStagger faster className="space-y-10 lg:max-w-xl">
+            <FadeIn>
+              <SectionTitle
+                align="left"
+                label={t("Highlights.label")}
+                title={t("Highlights.title")}
+                text={t("Highlights.description")}
+              />
+            </FadeIn>
+            <FadeIn as="ul" className="space-y-6">
+              {highlightItems.map(({ key, icon: Icon }) => (
+                <li key={key} className="group flex items-start gap-4 rounded-3xl border border-white/5 bg-white/[0.03] p-5 transition hover:border-white/20 hover:bg-white/[0.06]">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white/10 text-white shadow-[0_12px_30px_rgba(59,130,246,0.2)]">
+                    <Icon className="h-5 w-5" aria-hidden />
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold text-white">
+                      {t(`Highlights.items.${key}.title`)}
+                    </p>
+                    <p className="text-sm text-white/70">
+                      {t(`Highlights.items.${key}.description`)}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </FadeIn>
+          </FadeInStagger>
+          <FadeIn className="lg:translate-y-0">
+            <ContactForm />
+          </FadeIn>
+        </div>
+      </Container>
+    </div>
+  );
+}

--- a/apps/www/app/[locale]/(site)/contact/server/send-message.ts
+++ b/apps/www/app/[locale]/(site)/contact/server/send-message.ts
@@ -1,0 +1,169 @@
+"use server";
+
+import { Resend } from "resend";
+import { z } from "zod";
+
+import {
+  CONTACT_REQUEST_TYPES,
+  type ContactRequestType,
+} from "../constants";
+
+const REQUEST_TYPE_VALUES = CONTACT_REQUEST_TYPES.map((option) => option.value) as [
+  ContactRequestType,
+  ...ContactRequestType[],
+];
+
+const contactSchema = z.object({
+  name: z
+    .string({ required_error: "Name is required" })
+    .trim()
+    .min(2, { message: "Name must be at least 2 characters" })
+    .max(120, { message: "Name must be under 120 characters" }),
+  company: z
+    .string()
+    .trim()
+    .max(120, { message: "Company name must be under 120 characters" })
+    .optional(),
+  email: z
+    .string()
+    .trim()
+    .email({ message: "Email must be valid" })
+    .optional(),
+  requestType: z.enum(REQUEST_TYPE_VALUES, {
+    errorMap: () => ({ message: "Select a request type" }),
+  }),
+  description: z
+    .string({ required_error: "Tell us a little about the request" })
+    .trim()
+    .min(20, { message: "Description must be at least 20 characters" })
+    .max(2000, { message: "Description must be under 2000 characters" }),
+});
+
+export type ContactFormState = {
+  status: "idle" | "success" | "error";
+  message?: string;
+  fieldErrors?: Partial<Record<keyof z.infer<typeof contactSchema>, string>>;
+};
+
+export const initialState: ContactFormState = {
+  status: "idle",
+};
+
+export async function sendContactMessage(
+  _prevState: ContactFormState,
+  formData: FormData,
+): Promise<ContactFormState> {
+  const rawName = formData.get("name");
+  const rawCompany = formData.get("company");
+  const rawEmail = formData.get("email");
+  const rawRequestType = formData.get("requestType");
+  const rawDescription = formData.get("description");
+
+  const parsed = contactSchema.safeParse({
+    name: typeof rawName === "string" ? rawName : "",
+    company:
+      typeof rawCompany === "string" && rawCompany.trim().length > 0
+        ? rawCompany
+        : undefined,
+    email:
+      typeof rawEmail === "string" && rawEmail.trim().length > 0
+        ? rawEmail
+        : undefined,
+    requestType:
+      typeof rawRequestType === "string"
+        ? (rawRequestType as ContactRequestType)
+        : undefined,
+    description: typeof rawDescription === "string" ? rawDescription : "",
+  });
+
+  if (!parsed.success) {
+    const fieldErrors: Record<string, string> = {};
+    for (const issue of parsed.error.issues) {
+      const field = issue.path[0];
+      if (typeof field === "string" && !fieldErrors[field]) {
+        fieldErrors[field] = issue.message;
+      }
+    }
+
+    return {
+      status: "error",
+      fieldErrors,
+      message: "Please review the highlighted fields and try again.",
+    } satisfies ContactFormState;
+  }
+
+  const data = parsed.data;
+  const resendApiKey = process.env.RESEND_API_KEY;
+  const fromEmail = process.env.CONTACT_FROM_EMAIL ?? "TransformAI <info@transformai.nl>";
+  const forwardTo = process.env.CONTACT_FORWARD_TO;
+
+  if (!resendApiKey || !forwardTo) {
+    console.error(
+      "Contact form submission failed: Missing RESEND_API_KEY or CONTACT_FORWARD_TO.",
+    );
+    return {
+      status: "error",
+      message:
+        "We couldn't send your message right now. Please email info@transformai.nl while we look into this.",
+    } satisfies ContactFormState;
+  }
+
+  const resend = new Resend(resendApiKey);
+  const requestTypeMeta = CONTACT_REQUEST_TYPES.find(
+    (option) => option.value === data.requestType,
+  );
+
+  const requestLabel = requestTypeMeta?.emailLabel ?? data.requestType;
+
+const emailBody = [
+    `Name: ${data.name}`,
+    data.company ? `Company: ${data.company}` : null,
+    `Request type: ${requestLabel}`,
+    data.email ? `Contact email: ${data.email}` : "Contact email: not provided",
+    "",
+    "Request description:",
+    data.description,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  try {
+    await resend.emails.send({
+      from: fromEmail,
+      to: forwardTo,
+      subject: `New TransformAI contact request – ${requestLabel}`,
+      text: emailBody,
+      html: emailBody
+        .split("\n")
+        .map(
+          (line) =>
+            `<p style="margin:0 0 12px;font-size:14px;line-height:20px;">${escapeHtml(
+              line,
+            )}</p>`,
+        )
+        .join(""),
+      reply_to: data.email ?? undefined,
+      headers: {
+        "X-TransformAI-Request-Type": data.requestType,
+      },
+    });
+  } catch (error) {
+    console.error("Contact form submission failed while sending email:", error);
+    return {
+      status: "error",
+      message:
+        "Something went wrong while sending your message. Please try again or email info@transformai.nl directly.",
+    } satisfies ContactFormState;
+  }
+
+  return {
+    status: "success",
+    message: "Thank you for reaching out. We'll follow up from info@transformai.nl soon.",
+  } satisfies ContactFormState;
+}
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");

--- a/apps/www/components/footer/footer.tsx
+++ b/apps/www/components/footer/footer.tsx
@@ -17,6 +17,7 @@ const navigation = [
       { titleKey: "links.about", href: "/about" },
       { titleKey: "links.roadmap", href: "/roadmap" },
       { titleKey: "links.careers", href: "/careers" },
+      { titleKey: "links.contact", href: "/contact" },
       {
         titleKey: "links.sourceCode",
         href: "https://go.unkey.com/github",

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -147,6 +147,13 @@ function MobileLinks({ className }: { className?: string }) {
               <li>
                 <MobileNavLink
                   onClick={() => setIsOpen(false)}
+                  href="/contact"
+                  label={t("links.contact")}
+                />
+              </li>
+              <li>
+                <MobileNavLink
+                  onClick={() => setIsOpen(false)}
                   href="/changelog"
                   label={t("links.changelog")}
                 />
@@ -218,6 +225,9 @@ function DesktopLinks({ className }: { className: string }) {
       </li>
       <li>
         <DesktopNavLink href="/pricing" label={t("links.pricing")} />
+      </li>
+      <li>
+        <DesktopNavLink href="/contact" label={t("links.contact")} />
       </li>
       <li>
         <DesktopNavLink href="/changelog" label={t("links.changelog")} />

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -24,10 +24,96 @@
       "about": "About",
       "blog": "Blog",
       "pricing": "Pricing",
+      "contact": "Contact",
       "changelog": "Changelog",
       "templates": "Templates",
       "docs": "Docs",
       "discord": "Discord"
+    }
+  },
+  "Contact": {
+    "Hero": {
+      "eyebrow": "Let’s talk",
+      "title": "Contact TransformAI",
+      "body": "Share your challenge and we’ll respond with a tailored AI roadmap within two business days.",
+      "emailNotice": "Prefer email? Reach out at info@transformai.nl — this is our only official inbox."
+    },
+    "Highlights": {
+      "label": "Why leaders reach out",
+      "title": "From first idea to scaled automation",
+      "description": "We partner with Dutch leadership teams to translate AI ambition into measurable results.",
+      "items": {
+        "strategy": {
+          "title": "Strategic direction in weeks",
+          "description": "Run an AI strategy sprint that lands clear priorities, KPIs, and a board-ready plan."
+        },
+        "coCreation": {
+          "title": "Co-create with your operators",
+          "description": "Embed our specialists alongside your teams to map automations and redesign workflows."
+        },
+        "governance": {
+          "title": "Governance without slowing down",
+          "description": "Implement responsible guardrails, data policies, and change management that teams adopt."
+        }
+      }
+    },
+    "Form": {
+      "badge": "Direct line",
+      "title": "Send us a message",
+      "subtitle": "Tell us what you need and we’ll reply within one business day.",
+      "channel": {
+        "label": "Official inbox",
+        "caption": "Every submission is delivered straight to {email} so our leadership team can respond quickly."
+      },
+      "requestType": {
+        "label": "Request type",
+        "helper": "Choose the option that best matches your focus."
+      },
+      "requestTypes": {
+        "strategy": {
+          "title": "AI strategy sprint",
+          "description": "Align leadership around outcomes, KPIs, and the first 90-day roadmap."
+        },
+        "automation": {
+          "title": "Automation opportunity audit",
+          "description": "Spot high-impact automations across teams and model the efficiency gains."
+        },
+        "integration": {
+          "title": "Custom AI integration",
+          "description": "Design bespoke copilots, agents, or data products that plug into your stack."
+        },
+        "training": {
+          "title": "Executive enablement & training",
+          "description": "Upskill leaders and teams so AI adoption sticks across the organisation."
+        }
+      },
+      "fields": {
+        "name": {
+          "label": "Full name",
+          "placeholder": "Your name"
+        },
+        "company": {
+          "label": "Company (optional)",
+          "placeholder": "Company or team name"
+        },
+        "email": {
+          "label": "Contact email (optional)",
+          "placeholder": "you@company.com"
+        },
+        "description": {
+          "label": "Describe your request",
+          "placeholder": "Share context, goals, timelines, or anything else that helps us prepare."
+        }
+      },
+      "submit": {
+        "label": "Send message",
+        "pending": "Sending…"
+      },
+      "feedback": {
+        "successTitle": "Message sent",
+        "errorTitle": "We couldn’t send your message"
+      },
+      "footnote": "We’ll only use the details you share to respond from {email}."
     }
   },
   "Pricing": {
@@ -753,6 +839,7 @@
       "about": "About",
       "roadmap": "Roadmap",
       "careers": "Careers",
+      "contact": "Contact",
       "sourceCode": "Source Code",
       "status": "Status Page",
       "blog": "Blog",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -24,10 +24,96 @@
       "about": "Over ons",
       "blog": "Blog",
       "pricing": "Prijzen",
+      "contact": "Contact",
       "changelog": "Wijzigingen",
       "templates": "Templates",
       "docs": "Documentatie",
       "discord": "Discord"
+    }
+  },
+  "Contact": {
+    "Hero": {
+      "eyebrow": "Laten we praten",
+      "title": "Neem contact op met TransformAI",
+      "body": "Deel je uitdaging en wij leveren binnen twee werkdagen een op maat gemaakt AI-plan.",
+      "emailNotice": "Liever mailen? Gebruik info@transformai.nl — dit is ons enige officiële adres."
+    },
+    "Highlights": {
+      "label": "Waarom leiders ons benaderen",
+      "title": "Van eerste idee naar schaalbare automatisering",
+      "description": "We begeleiden Nederlandse organisaties om AI-ambities om te zetten in meetbare resultaten.",
+      "items": {
+        "strategy": {
+          "title": "Strategische richting in weken",
+          "description": "Doorloop een AI-strategiesprint met duidelijke prioriteiten, KPI's en een board-ready plan."
+        },
+        "coCreation": {
+          "title": "Samen met jouw teams bouwen",
+          "description": "Werk schouder aan schouder met onze specialisten om automatiseringen te ontdekken en processen te herontwerpen."
+        },
+        "governance": {
+          "title": "Governance zonder vertraging",
+          "description": "Introduceer verantwoorde kaders, databeleid en change management dat teams echt adopteren."
+        }
+      }
+    },
+    "Form": {
+      "badge": "Directe lijn",
+      "title": "Stuur ons een bericht",
+      "subtitle": "Laat weten wat je nodig hebt en we reageren binnen één werkdag.",
+      "channel": {
+        "label": "Officiële inbox",
+        "caption": "Elke inzending gaat rechtstreeks naar {email} zodat ons leadershipteam snel kan reageren."
+      },
+      "requestType": {
+        "label": "Soort aanvraag",
+        "helper": "Kies de optie die het beste bij je vraag past."
+      },
+      "requestTypes": {
+        "strategy": {
+          "title": "AI-strategiesprint",
+          "description": "Breng leiders op één lijn over resultaten, KPI's en de eerste 90-dagen-roadmap."
+        },
+        "automation": {
+          "title": "Automatiseringsscan",
+          "description": "Ontdek automatiseringskansen in teams en kwantificeer de efficiëntiewinst."
+        },
+        "integration": {
+          "title": "Maatwerk AI-integratie",
+          "description": "Ontwerp copilots, agents of dataproducten die aansluiten op jullie stack."
+        },
+        "training": {
+          "title": "Executive enablement & training",
+          "description": "Maak leiders en teams vaardig zodat AI-adoptie organisatiebreed blijft plakken."
+        }
+      },
+      "fields": {
+        "name": {
+          "label": "Volledige naam",
+          "placeholder": "Je naam"
+        },
+        "company": {
+          "label": "Bedrijf (optioneel)",
+          "placeholder": "Bedrijfs- of teamnaam"
+        },
+        "email": {
+          "label": "Contact e-mail (optioneel)",
+          "placeholder": "jij@bedrijf.nl"
+        },
+        "description": {
+          "label": "Beschrijf je aanvraag",
+          "placeholder": "Deel context, doelen, planning of andere details die ons helpen voorbereiden."
+        }
+      },
+      "submit": {
+        "label": "Bericht versturen",
+        "pending": "Versturen…"
+      },
+      "feedback": {
+        "successTitle": "Bericht verzonden",
+        "errorTitle": "Bericht kon niet worden verzonden"
+      },
+      "footnote": "We gebruiken je gegevens alleen om te reageren via {email}."
     }
   },
   "Pricing": {
@@ -710,6 +796,7 @@
       "about": "Over ons",
       "roadmap": "Roadmap",
       "careers": "Carrières",
+      "contact": "Contact",
       "sourceCode": "Broncode",
       "status": "Statuspagina",
       "blog": "Blog",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -55,6 +55,7 @@
     "react-hook-form": "^7.51.3",
     "react-markdown": "^8.0.7",
     "react-syntax-highlighter": "^15.5.0",
+    "resend": "^3.2.0",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^3.0.1",
     "rss": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,9 @@ importers:
       remark-gfm:
         specifier: ^3.0.1
         version: 3.0.1
+      resend:
+        specifier: ^3.2.0
+        version: 3.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rss:
         specifier: ^1.2.2
         version: 1.2.2
@@ -1945,6 +1948,9 @@ packages:
   '@octokit/types@14.0.0':
     resolution: {integrity: sha512-VVmZP0lEhbo2O1pdq63gZFiGCKkm8PPp8AUOijlwPO6hojEVjspA0MWKP7E4hbvGxzFKNqKr6p0IYtOH/Wf/zA==}
 
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+
   '@opentelemetry/api-logs@0.51.1':
     resolution: {integrity: sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==}
     engines: {node: '>=14'}
@@ -2883,6 +2889,13 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-email/render@0.0.16':
+    resolution: {integrity: sha512-wDaMy27xAq1cJHtSFptp0DTKPuV2GYhloqia95ub/DH9Dea1aWYsbdM918MOc/b/HvVS3w1z8DWzfAk13bGStQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.2.0
+      react-dom: ^18.2.0
+
   '@reduxjs/toolkit@2.8.2':
     resolution: {integrity: sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==}
     peerDependencies:
@@ -2962,6 +2975,9 @@ packages:
 
   '@schummar/icu-type-parser@1.21.5':
     resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
   '@shikijs/core@1.29.2':
     resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
@@ -3608,6 +3624,10 @@ packages:
   '@zxing/text-encoding@0.9.0':
     resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
 
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -3941,6 +3961,10 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -3964,6 +3988,9 @@ packages:
 
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -4278,6 +4305,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
@@ -4343,8 +4374,21 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   dompurify@3.2.5:
     resolution: {integrity: sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dotenv-cli@8.0.0:
     resolution: {integrity: sha512-aLqYbK7xKOiTMIRf1lDPbI+Y+Ip/wo5k3eyp6ePysVaSqbyxjyK3dK35BTxG+rmd7djf5q2UPs4noPNH+cj0Qw==}
@@ -4555,6 +4599,11 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  editorconfig@1.0.4:
+    resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   electron-to-chromium@1.5.136:
     resolution: {integrity: sha512-kL4+wUTD7RSA5FHx5YwWtjDnEEkIIikFgWHR4P6fqjw1PPLlqYkxeOb++wAauAssat0YClCy8Y3C5SxgSkjibQ==}
@@ -4867,6 +4916,9 @@ packages:
 
   fast-content-type-parse@2.0.1:
     resolution: {integrity: sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==}
+
+  fast-deep-equal@2.0.1:
+    resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -5240,8 +5292,15 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html-to-text@9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
@@ -5290,6 +5349,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   inline-style-parser@0.1.1:
     resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
@@ -5519,6 +5581,15 @@ packages:
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
+  js-beautify@1.15.4:
+    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -5607,6 +5678,9 @@ packages:
 
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
+  leac@0.6.0:
+    resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -6125,6 +6199,10 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@9.0.1:
+    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -6334,6 +6412,11 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -6475,6 +6558,9 @@ packages:
   parse5@7.2.1:
     resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
 
+  parseley@0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
+
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
@@ -6506,6 +6592,9 @@ packages:
 
   pdfast@0.2.0:
     resolution: {integrity: sha512-cq6TTu6qKSFUHwEahi68k/kqN2mfepjkGrG9Un70cgdRRKLKY6Rf8P8uvP2NvZktaQZNF3YE7agEkLj0vGK9bA==}
+
+  peberminta@0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
   periscopic@3.1.0:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
@@ -6644,6 +6733,9 @@ packages:
   property-information@7.0.0:
     resolution: {integrity: sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==}
 
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
   protobufjs@7.4.0:
     resolution: {integrity: sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==}
     engines: {node: '>=12.0.0'}
@@ -6716,6 +6808,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-promise-suspense@0.3.4:
+    resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
 
   react-redux@9.2.0:
     resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
@@ -6899,6 +6994,10 @@ packages:
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
+  resend@3.5.0:
+    resolution: {integrity: sha512-bKu4LhXSecP6krvhfDzyDESApYdNfjirD5kykkT1xO0Cj9TKSiGh5Void4pGTs3Am+inSnp4dg0B5XzdwHBJOQ==}
+    engines: {node: '>=18'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -6986,6 +7085,9 @@ packages:
 
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
+  selderee@0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -9457,6 +9559,8 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 25.0.0
 
+  '@one-ini/wasm@0.1.1': {}
+
   '@opentelemetry/api-logs@0.51.1':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -10737,6 +10841,14 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-email/render@0.0.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      html-to-text: 9.0.5
+      js-beautify: 1.15.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-promise-suspense: 0.3.4
+
   '@reduxjs/toolkit@2.8.2(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
     dependencies:
       '@standard-schema/spec': 1.0.0
@@ -10823,6 +10935,11 @@ snapshots:
   '@rushstack/eslint-patch@1.12.0': {}
 
   '@schummar/icu-type-parser@1.21.5': {}
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
 
   '@shikijs/core@1.29.2':
     dependencies:
@@ -11560,6 +11677,8 @@ snapshots:
   '@zxing/text-encoding@0.9.0':
     optional: true
 
+  abbrev@2.0.0: {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -11968,6 +12087,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@10.0.1: {}
+
   commander@4.1.1: {}
 
   commander@7.2.0: {}
@@ -11981,6 +12102,11 @@ snapshots:
   confbox@0.1.8: {}
 
   confbox@0.2.2: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
 
   cookie-signature@1.2.2: {}
 
@@ -12295,6 +12421,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge@4.3.1: {}
+
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
@@ -12347,9 +12475,27 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
   dompurify@3.2.5:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dotenv-cli@8.0.0:
     dependencies:
@@ -12400,6 +12546,13 @@ snapshots:
   duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
+
+  editorconfig@1.0.4:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.1
+      semver: 7.7.2
 
   electron-to-chromium@1.5.136: {}
 
@@ -12967,6 +13120,8 @@ snapshots:
 
   fast-content-type-parse@2.0.1: {}
 
+  fast-deep-equal@2.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -13458,7 +13613,22 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html-to-text@9.0.5:
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
+
   html-void-elements@3.0.0: {}
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
 
   human-signals@5.0.0: {}
 
@@ -13505,6 +13675,8 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   inline-style-parser@0.1.1: {}
 
@@ -13726,6 +13898,16 @@ snapshots:
 
   jose@5.10.0: {}
 
+  js-beautify@1.15.4:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.4
+      glob: 10.4.5
+      js-cookie: 3.0.5
+      nopt: 7.2.1
+
+  js-cookie@3.0.5: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
@@ -13803,6 +13985,8 @@ snapshots:
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
+
+  leac@0.6.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -14859,6 +15043,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@9.0.1:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
@@ -15064,6 +15252,10 @@ snapshots:
 
   node-releases@2.0.19: {}
 
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
+
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
@@ -15218,6 +15410,11 @@ snapshots:
     dependencies:
       entities: 4.5.0
 
+  parseley@0.12.1:
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+
   path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
@@ -15238,6 +15435,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pdfast@0.2.0: {}
+
+  peberminta@0.9.0: {}
 
   periscopic@3.1.0:
     dependencies:
@@ -15367,6 +15566,8 @@ snapshots:
 
   property-information@7.0.0: {}
 
+  proto-list@1.2.4: {}
+
   protobufjs@7.4.0:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -15467,6 +15668,10 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  react-promise-suspense@0.3.4:
+    dependencies:
+      fast-deep-equal: 2.0.1
 
   react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1):
     dependencies:
@@ -15797,6 +16002,13 @@ snapshots:
 
   reselect@5.1.1: {}
 
+  resend@3.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@react-email/render': 0.0.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -15902,6 +16114,10 @@ snapshots:
       kind-of: 6.0.3
 
   secure-json-parse@2.7.0: {}
+
+  selderee@0.11.0:
+    dependencies:
+      parseley: 0.12.1
 
   semver@6.3.1: {}
 


### PR DESCRIPTION
## Summary
- balance the contact highlights and form into equal-width columns so the hero copy and form share the page evenly
- elevate the contact form header with a direct-line badge and inbox callout so it’s obvious that submissions go to info@transformai.nl
- localize the new copy in EN/NL and log the layout refinement for project history

## Testing
- `pnpm --filter www run typecheck` *(fails: repository still missing next-intl/resend typings)*
- `pnpm --filter www run lint` *(fails: repository still missing next-intl dependency for next config)*

## Plan
- Align highlights and form into balanced columns on the contact page
- Emphasize the contact form entry point with clearer inbox messaging
- Refresh translations and documentation to cover the new copy


------
https://chatgpt.com/codex/tasks/task_e_68dd40d03908832abc9838dd6fd10641