### PR TITLE
style: rebalance analytics request form layout

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-26T1400--analytics-request-form.md
+++ b/WRITE_HERE/FIXES/2025-11-26T1400--analytics-request-form.md
@@ -1,0 +1,5 @@
+# Replace analytics code preview with access request form
+- **What:** Swapped the beta request button's code preview for a dedicated form with request-type choices, localized copy, and mail delivery via Resend.
+- **Why:** The homepage button should let users request platform access instead of showing API code samples.
+- **Files:** `apps/www/components/analytics/analytics-bento.tsx`, `apps/www/components/analytics/request-form.tsx`, `apps/www/components/analytics/request-types.ts`, `apps/www/components/analytics/server/send-request.ts`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-27T1300--analytics-request-form-horizontal-balance.md
+++ b/WRITE_HERE/FIXES/2025-11-27T1300--analytics-request-form-horizontal-balance.md
@@ -1,0 +1,6 @@
+# Analytics request form horizontal balance
+
+- **What**: Reflowed the analytics request form into a wider two-column grid, keeping the header and request type controls on the left while grouping inputs on the right, tightened spacing, and widened the card to match the previous code preview footprint.
+- **Why**: The initial vertical stack made the revealed form much taller than the original code block, causing crowding with the surrounding section copy.
+- **Files**: `apps/www/components/analytics/request-form.tsx`
+- **Follow-ups**: Consider adding responsive previews once the dev server runs again to validate the layout in-browser.

--- a/WRITE_HERE/FIXES/2025-11-27T1530--analytics-request-form-button-polish.md
+++ b/WRITE_HERE/FIXES/2025-11-27T1530--analytics-request-form-button-polish.md
@@ -1,0 +1,5 @@
+# Analytics request form button polish
+- **What:** Gave the submit control a pill silhouette, gradient glow, and balanced padding so it reads as a primary action inside the analytics request module.
+- **Why:** The user noted the previous "Send request" CTA looked like plain text rather than a clickable control.
+- **Files:** `apps/www/components/analytics/request-form.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-27T1700--analytics-request-form-whitespace-trim.md
+++ b/WRITE_HERE/FIXES/2025-11-27T1700--analytics-request-form-whitespace-trim.md
@@ -1,0 +1,5 @@
+# Analytics request form whitespace trim
+- **What:** Tightened the analytics request module by reducing the panel padding, gaps, and supporting card spacing so the reveal sits closer to the original code embed footprint.
+- **Why:** The user noted the form felt too spacious with excess white padding compared to the previous layout.
+- **Files:** `apps/www/components/analytics/request-form.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/components/analytics/analytics-bento.tsx
+++ b/apps/www/components/analytics/analytics-bento.tsx
@@ -1,65 +1,18 @@
 "use client";
-import type { LangIconProps } from "@/components/svg/lang-icons";
-import { CurlIcon, GoIcon, PythonIcon, RustIcon, TSIcon } from "@/components/svg/lang-icons";
-import { CopyCodeSnippetButton } from "@/components/ui/copy-code-button";
+
 import { cn } from "@/lib/utils";
 import { motion } from "framer-motion";
 import { Wand2 } from "lucide-react";
-import type { PrismTheme } from "prism-react-renderer";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
+
 import { PrimaryButton } from "../button";
 import { AnalyticsStars } from "../svg/analytics-stars";
 import { WebAppLight } from "../svg/web-app-light";
-import { CodeEditor } from "../ui/code-editor";
-
-const theme = {
-  plain: {
-    color: "#F8F8F2",
-    backgroundColor: "#282A36",
-  },
-  styles: [
-    {
-      types: ["keyword"],
-      style: {
-        color: "#9D72FF",
-      },
-    },
-    {
-      types: ["function"],
-      style: {
-        color: "#FB3186",
-      },
-    },
-    {
-      types: ["string"],
-      style: {
-        color: "#3CEEAE",
-      },
-    },
-    {
-      types: ["string-property"],
-      style: {
-        color: "#9D72FF",
-      },
-    },
-    {
-      types: ["number"],
-      style: {
-        color: "#FB3186",
-      },
-    },
-    {
-      types: ["comment"],
-      style: {
-        color: "#4D4D4D",
-      },
-    },
-  ],
-} satisfies PrismTheme;
+import { AnalyticsRequestForm } from "./request-form";
 
 export function AnalyticsBento() {
-  const [showApi, toggleShowApi] = useState(false);
+  const [showRequestForm, setShowRequestForm] = useState(false);
   const t = useTranslations("Analytics");
 
   return (
@@ -68,7 +21,8 @@ export function AnalyticsBento() {
         <button
           type="button"
           aria-label={t("requestAccess")}
-          onClick={() => toggleShowApi(!showApi)}
+          aria-pressed={showRequestForm}
+          onClick={() => setShowRequestForm((prev) => !prev)}
         >
           <PrimaryButton shiny label={t("requestAccess")} IconLeft={Wand2} />
         </button>
@@ -82,212 +36,19 @@ export function AnalyticsBento() {
         {/* TODO: horizontal scroll */}
         <LightSvg className="absolute hidden md:flex top-[-180px] left-0 lg:left-[300px] z-50 pointer-events-none" />
         <AnalyticsStars className="w-[90px] shrink-0 hidden md:flex" />
-        {showApi ? <AnalyticsApiView /> : <AnalyticsWebAppView />}
+        {showRequestForm ? (
+          <AnalyticsRequestForm onDismiss={() => setShowRequestForm(false)} />
+        ) : (
+          <AnalyticsWebAppView />
+        )}
         <div className="absolute inset-0 w-full h-full duration-500 pointer-events-none bg-gradient-to-t from-black from-10% via-black/50 to-transparent group-hover:opacity-0 group-hover:backdrop-blur-0" />
         <BentoText
           className={
-            showApi ? "group-hover:opacity-0 group-hover:pointer-events-none duration-500" : ""
+            showRequestForm
+              ? "group-hover:opacity-0 group-hover:pointer-events-none duration-500"
+              : ""
           }
         />
-      </div>
-    </div>
-  );
-}
-
-type Language = {
-  name: string;
-  Icon: React.FC<LangIconProps>;
-  codeBlock: string;
-};
-
-type LanguageName = "TypeScript" | "Python" | "Rust" | "Go" | "cURL";
-
-const curlCodeBlock = `curl --request GET \\
-    --url https://api.unkey.dev/v1/keys.getKey?keyId=key_123 \\
-    --header 'Authorization: Bearer <UNKEY_ROOT_KEY>'
-`;
-
-const tsCodeBlock = `import { Unkey } from "@unkey/api";
-
-const unkey = new Unkey({ rootKey: "<UNKEY_ROOT_KEY>" });
-
-const { result, error } = await unkey.keys.get({ keyId: "key_123" });
-
-if ( error ) {
-  // handle network error
-}
-
-// handle request
-`;
-
-const pythonCodeBlock = `import asyncio
-import os
-import unkey
-
-async def main() -> None:
-    client = unkey.Client("<UNKEY_ROOT_KEY>")
-    await client.start()
-
-    result = await client.keys.get_key("key_123")
-
-    if result.is_ok:
-        data = result.unwrap()
-        print(data.id)
-    else:
-        print(result.unwrap_err())
-
-    await client.close()
-`;
-
-const goCodeBlock = `package main
-
-import (
-	"context"
-	"log"
-
-	unkeygo "github.com/unkeyed/unkey-go"
-	"github.com/unkeyed/unkey-go/models/operations"
-)
-
-func main() {
-	s := unkeygo.New(
-		unkeygo.WithSecurity("<UNKEY_ROOT_KEY>"),
-	)
-
-	ctx := context.Background()
-	res, err := s.Keys.GetKey(ctx, operations.GetKeyRequest{
-		KeyID: "key_123",
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	if res.Key != nil {
-		// handle response
-	}
-}
-`;
-
-const rustCodeBlock = `use unkey::models::GetKeyRequest;
-use unkey::Client;
-
-async fn get_key() {
-    let c = Client::new("<UNKEY_ROOT_KEY>");
-    let req = GetKeyRequest::new("key_123");
-
-    match c.get_key(req).await {
-        Ok(res) => println!("{res:?}"),
-        Err(err) => eprintln!("{err:?}"),
-    }
-}
-`;
-
-const languagesList = {
-  cURL: {
-    Icon: CurlIcon,
-    name: "cURL",
-    codeBlock: curlCodeBlock,
-    editorLanguage: "tsx",
-  },
-  TypeScript: {
-    Icon: TSIcon,
-    name: "TypeScript",
-    codeBlock: tsCodeBlock,
-    editorLanguage: "tsx",
-  },
-  Python: {
-    Icon: PythonIcon,
-    name: "Python",
-    codeBlock: pythonCodeBlock,
-    editorLanguage: "python",
-  },
-  Go: {
-    Icon: GoIcon,
-    name: "Go",
-    codeBlock: goCodeBlock,
-    editorLanguage: "go",
-  },
-  Rust: {
-    Icon: RustIcon,
-    name: "Rust",
-    codeBlock: rustCodeBlock,
-    editorLanguage: "rust",
-  },
-};
-
-function AnalyticsApiView() {
-  const [language, setLanguage] = useState<LanguageName>("cURL");
-
-  return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
-      transition={{ duration: 0.2, ease: "easeInOut" }}
-      whileInView="visible"
-      className="w-full overflow-x-hidden relative"
-    >
-      <CopyCodeSnippetButton
-        textToCopy={languagesList[language].codeBlock}
-        className="sticky right-12 top-16 float-right hidden cursor-pointer lg:flex"
-      />
-      <div
-        className={cn(
-          "w-full bg-black bg-opacity-02 lg:rounded-3xl xxl:mr-10",
-          "border-white/10 border border-b-0 border-l-0 border-r-0",
-          "flex flex-col md:flex-row rounded-tl-3xl h-[600px] xl:h-[576px]",
-        )}
-      >
-        <LanguageSwitcher
-          languages={Object.values(languagesList)}
-          currentLanguage={language}
-          setLanguage={setLanguage}
-        />
-        <div className="flex pt-4 pb-8 pl-8 overflow-x-hidden scrollbar-hidden font-mono text-xs text-white sm:text-sm">
-          <CodeEditor
-            theme={theme}
-            codeBlock={languagesList[language].codeBlock}
-            language={languagesList[language].editorLanguage}
-          />
-        </div>
-      </div>
-    </motion.div>
-  );
-}
-
-function LanguageSwitcher({
-  languages,
-  currentLanguage,
-  setLanguage,
-}: {
-  languages: Language[];
-  currentLanguage: LanguageName;
-  setLanguage: React.Dispatch<React.SetStateAction<LanguageName>>;
-}) {
-  return (
-    <div
-      className={cn(
-        "flex flex-col w-[216px] text-white text-sm pt-6 px-4 font-mon",
-        "md:border-r md:border-white/5 overflow-x-hidden scrollbar-hidden",
-      )}
-    >
-      <div className="flex items-center space-x-2 sm:flex-col sm:space-x-0 sm:space-y-2">
-        {languages.map(({ Icon, name }) => (
-          <button
-            key={name}
-            type="button"
-            onClick={() => setLanguage(name as LanguageName)}
-            className={cn(
-              "flex items-center cursor-pointer bg-white/5 py-1 px-2 rounded-lg w-[184px]",
-              {
-                "bg-white/10 text-white": currentLanguage === name,
-                "text-white/40": currentLanguage !== name,
-              },
-            )}
-          >
-            <Icon active={currentLanguage === name} />
-            <div className="ml-3">{name}</div>
-          </button>
-        ))}
       </div>
     </div>
   );

--- a/apps/www/components/analytics/request-form.tsx
+++ b/apps/www/components/analytics/request-form.tsx
@@ -82,7 +82,7 @@ export function AnalyticsRequestForm({ onDismiss }: AnalyticsRequestFormProps) {
   ];
 
   return (
-    <div className="relative isolate flex w-full max-w-4xl flex-col overflow-hidden rounded-[32px] border border-white/12 bg-white/[0.04] p-6 shadow-[0_28px_120px_rgba(15,23,42,0.45)] sm:p-8">
+    <div className="relative isolate flex w-full max-w-[880px] flex-col overflow-hidden rounded-[32px] border border-white/12 bg-white/[0.04] p-5 shadow-[0_28px_120px_rgba(15,23,42,0.45)] sm:p-6">
       <div
         aria-hidden
         className="pointer-events-none absolute -left-24 top-1/2 h-[420px] w-[420px] -translate-y-1/2 rounded-full bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.3),_rgba(59,130,246,0))] blur-3xl"
@@ -90,7 +90,7 @@ export function AnalyticsRequestForm({ onDismiss }: AnalyticsRequestFormProps) {
       <form
         ref={formRef}
         action={formAction}
-        className="relative z-10 grid gap-6 md:grid-cols-[1.05fr_minmax(0,1fr)] md:gap-8"
+        className="relative z-10 grid gap-5 md:grid-cols-[1.05fr_minmax(0,1fr)] md:gap-6"
       >
         {state.status === "success" && state.message ? (
           <Alert variant="success" className="border-none md:col-span-2">
@@ -118,7 +118,7 @@ export function AnalyticsRequestForm({ onDismiss }: AnalyticsRequestFormProps) {
           </Alert>
         ) : null}
 
-        <div className="flex flex-col gap-6 md:pr-6">
+        <div className="flex flex-col gap-5 md:pr-4">
           <div className="flex items-start justify-between gap-4">
             <div className="space-y-3">
               <span className="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/[0.06] px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white/70">
@@ -144,7 +144,7 @@ export function AnalyticsRequestForm({ onDismiss }: AnalyticsRequestFormProps) {
               </button>
             ) : null}
           </div>
-          <div className="flex items-start gap-3 rounded-2xl border border-white/20 bg-white/[0.06] px-4 py-3 text-left shadow-[0_18px_80px_rgba(15,23,42,0.35)]">
+          <div className="flex items-start gap-3 rounded-2xl border border-white/20 bg-white/[0.06] px-3.5 py-2.5 text-left shadow-[0_18px_80px_rgba(15,23,42,0.35)]">
             <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white">
               <Mail className="h-5 w-5" aria-hidden />
             </span>
@@ -167,7 +167,7 @@ export function AnalyticsRequestForm({ onDismiss }: AnalyticsRequestFormProps) {
           />
         </div>
 
-        <div className="space-y-5 md:pl-4">
+        <div className="space-y-4 md:pl-3">
           <div className="grid gap-4 sm:grid-cols-2">
             {fields.map(({ name, label, placeholder, type = "text", autoComplete, required }) => (
               <div key={name} className="space-y-2">
@@ -280,7 +280,7 @@ function RequestTypeSelector({
           <span className="text-xs text-white/50 sm:text-right">{helperText}</span>
         ) : null}
       </div>
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div className="grid gap-2.5 sm:grid-cols-2">
         {options.map((option) => {
           const isActive = option.value === selected;
           return (

--- a/apps/www/components/analytics/request-form.tsx
+++ b/apps/www/components/analytics/request-form.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useFormState, useFormStatus } from "react-dom";
+import { Loader2, Mail, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Alert, AlertDescription } from "@/components/ui/alert/alert";
+import { cn } from "@/lib/utils";
+
+import {
+  ANALYTICS_REQUEST_TYPES,
+  type AnalyticsRequestType,
+} from "./request-types";
+import {
+  initialState,
+  sendAnalyticsRequest,
+} from "./server/send-request";
+
+type AnalyticsRequestFormProps = {
+  onDismiss?: () => void;
+};
+
+const fieldClassName =
+  "w-full rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:border-white/40 transition disabled:cursor-not-allowed disabled:opacity-60";
+
+export function AnalyticsRequestForm({ onDismiss }: AnalyticsRequestFormProps) {
+  const t = useTranslations("Analytics.requestForm");
+  const [state, formAction] = useFormState(sendAnalyticsRequest, initialState);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [requestType, setRequestType] = useState<AnalyticsRequestType>(
+    ANALYTICS_REQUEST_TYPES[0].value,
+  );
+
+  useEffect(() => {
+    if (state.status === "success") {
+      formRef.current?.reset();
+      setRequestType(ANALYTICS_REQUEST_TYPES[0].value);
+    }
+  }, [state]);
+
+  const requestTypeOptions = useMemo(
+    () =>
+      ANALYTICS_REQUEST_TYPES.map((option) => ({
+        value: option.value,
+        title: t(`requestType.options.${option.translationKey}.title`),
+        description: t(
+          `requestType.options.${option.translationKey}.description`,
+        ),
+      })),
+    [t],
+  );
+
+  const fields: {
+    name: "name" | "company" | "email";
+    label: string;
+    placeholder: string;
+    type?: string;
+    autoComplete?: string;
+    required?: boolean;
+  }[] = [
+    {
+      name: "name",
+      label: t("fields.name.label"),
+      placeholder: t("fields.name.placeholder"),
+      autoComplete: "name",
+      required: true,
+    },
+    {
+      name: "company",
+      label: t("fields.company.label"),
+      placeholder: t("fields.company.placeholder"),
+      autoComplete: "organization",
+    },
+    {
+      name: "email",
+      type: "email",
+      label: t("fields.email.label"),
+      placeholder: t("fields.email.placeholder"),
+      autoComplete: "email",
+    },
+  ];
+
+  return (
+    <div className="relative isolate flex w-full max-w-4xl flex-col overflow-hidden rounded-[32px] border border-white/12 bg-white/[0.04] p-6 shadow-[0_28px_120px_rgba(15,23,42,0.45)] sm:p-8">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -left-24 top-1/2 h-[420px] w-[420px] -translate-y-1/2 rounded-full bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.3),_rgba(59,130,246,0))] blur-3xl"
+      />
+      <form
+        ref={formRef}
+        action={formAction}
+        className="relative z-10 grid gap-6 md:grid-cols-[1.05fr_minmax(0,1fr)] md:gap-8"
+      >
+        {state.status === "success" && state.message ? (
+          <Alert variant="success" className="border-none md:col-span-2">
+            <AlertDescription variant="success">
+              <div>
+                <p className="text-sm font-semibold text-white">
+                  {t("feedback.successTitle")}
+                </p>
+                <p className="mt-1 text-sm text-white/70">{state.message}</p>
+              </div>
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {state.status === "error" && state.message ? (
+          <Alert variant="error" className="border-none md:col-span-2">
+            <AlertDescription variant="error">
+              <div>
+                <p className="text-sm font-semibold text-white">
+                  {t("feedback.errorTitle")}
+                </p>
+                <p className="mt-1 text-sm text-white/70">{state.message}</p>
+              </div>
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="flex flex-col gap-6 md:pr-6">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-3">
+              <span className="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/[0.06] px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white/70">
+                {t("badge")}
+              </span>
+              <div className="space-y-2">
+                <h3 className="text-2xl font-semibold text-white sm:text-3xl">
+                  {t("title")}
+                </h3>
+                <p className="text-sm text-white/70 sm:text-base">
+                  {t("subtitle")}
+                </p>
+              </div>
+            </div>
+            {onDismiss ? (
+              <button
+                type="button"
+                onClick={onDismiss}
+                className="group inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] text-white/60 transition hover:border-white/30 hover:text-white"
+                aria-label={t("dismiss")}
+              >
+                <X className="h-4 w-4" aria-hidden />
+              </button>
+            ) : null}
+          </div>
+          <div className="flex items-start gap-3 rounded-2xl border border-white/20 bg-white/[0.06] px-4 py-3 text-left shadow-[0_18px_80px_rgba(15,23,42,0.35)]">
+            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white">
+              <Mail className="h-5 w-5" aria-hidden />
+            </span>
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">
+                {t("channel.label")}
+              </p>
+              <p className="text-sm text-white/80">
+                {t("channel.caption", { email: "info@transformai.nl" })}
+              </p>
+            </div>
+          </div>
+          <RequestTypeSelector
+            label={t("requestType.label")}
+            helperText={t("requestType.helper")}
+            options={requestTypeOptions}
+            selected={requestType}
+            onSelect={setRequestType}
+            error={state.fieldErrors?.requestType}
+          />
+        </div>
+
+        <div className="space-y-5 md:pl-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            {fields.map(({ name, label, placeholder, type = "text", autoComplete, required }) => (
+              <div key={name} className="space-y-2">
+                <label
+                  className="text-xs font-medium uppercase tracking-[0.2em] text-white/60"
+                  htmlFor={name}
+                >
+                  {label}
+                  {required ? <span className="ml-1 text-white/40">*</span> : null}
+                </label>
+                <input
+                  id={name}
+                  name={name}
+                  type={type}
+                  autoComplete={autoComplete}
+                  placeholder={placeholder}
+                  className={cn(
+                    fieldClassName,
+                    state.fieldErrors?.[name] && "border-rose-400/70 text-white",
+                  )}
+                  aria-invalid={state.fieldErrors?.[name] ? "true" : undefined}
+                  aria-describedby={state.fieldErrors?.[name] ? `${name}-error` : undefined}
+                  required={required}
+                />
+                {state.fieldErrors?.[name] ? (
+                  <p id={`${name}-error`} className="text-xs font-medium text-rose-300">
+                    {state.fieldErrors[name]}
+                  </p>
+                ) : null}
+              </div>
+            ))}
+          </div>
+
+          <div className="space-y-2">
+            <label
+              className="text-xs font-medium uppercase tracking-[0.2em] text-white/60"
+              htmlFor="description"
+            >
+              {t("fields.description.label")}
+              <span className="ml-1 text-white/40">*</span>
+            </label>
+            <textarea
+              id="description"
+              name="description"
+              placeholder={t("fields.description.placeholder")}
+              rows={5}
+              className={cn(
+                fieldClassName,
+                "min-h-[140px] resize-y",
+                state.fieldErrors?.description && "border-rose-400/70 text-white",
+              )}
+              aria-invalid={state.fieldErrors?.description ? "true" : undefined}
+              aria-describedby={state.fieldErrors?.description ? "description-error" : undefined}
+              required
+            />
+            {state.fieldErrors?.description ? (
+              <p id="description-error" className="text-xs font-medium text-rose-300">
+                {state.fieldErrors.description}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:items-center sm:justify-between">
+            <SubmitButton
+              label={t("submit.label")}
+              pendingLabel={t("submit.pending")}
+            />
+            <p className="text-xs leading-5 text-white/40 sm:text-right">
+              {t("footnote", { email: "info@transformai.nl" })}
+            </p>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+type RequestTypeOption = {
+  value: AnalyticsRequestType;
+  title: string;
+  description: string;
+};
+
+type RequestTypeSelectorProps = {
+  label: string;
+  helperText?: string;
+  options: RequestTypeOption[];
+  selected: AnalyticsRequestType;
+  onSelect: (value: AnalyticsRequestType) => void;
+  error?: string;
+};
+
+function RequestTypeSelector({
+  label,
+  helperText,
+  options,
+  selected,
+  onSelect,
+  error,
+}: RequestTypeSelectorProps) {
+  const { pending } = useFormStatus();
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <span className="text-sm font-medium tracking-wide text-white/90">
+          {label}
+        </span>
+        {helperText ? (
+          <span className="text-xs text-white/50 sm:text-right">{helperText}</span>
+        ) : null}
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {options.map((option) => {
+          const isActive = option.value === selected;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => onSelect(option.value)}
+              disabled={pending}
+              className={cn(
+                "group relative overflow-hidden rounded-2xl border px-4 py-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40",
+                isActive
+                  ? "border-white/60 bg-white/[0.12] shadow-[0_18px_60px_rgba(59,130,246,0.25)]"
+                  : "border-white/10 bg-white/[0.04] hover:border-white/30 hover:bg-white/[0.08]",
+                pending && "cursor-not-allowed opacity-70",
+              )}
+            >
+              <div
+                aria-hidden
+                className={cn(
+                  "pointer-events-none absolute inset-0 opacity-0 transition group-hover:opacity-100",
+                  isActive && "opacity-100",
+                  "bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.28),_rgba(59,130,246,0))]",
+                )}
+              />
+              <div className="relative z-10 space-y-1">
+                <p className="text-sm font-semibold text-white/90">
+                  {option.title}
+                </p>
+                <p className="text-xs leading-5 text-white/60">
+                  {option.description}
+                </p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+      {error ? <p className="text-xs font-medium text-rose-300">{error}</p> : null}
+      <input type="hidden" name="requestType" value={selected} />
+    </div>
+  );
+}
+
+type SubmitButtonProps = {
+  label: string;
+  pendingLabel: string;
+};
+
+function SubmitButton({ label, pendingLabel }: SubmitButtonProps) {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      className="inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white text-sm font-semibold text-black transition hover:border-white/40 hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 disabled:cursor-not-allowed disabled:opacity-70"
+      disabled={pending}
+    >
+      {pending ? (
+        <>
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          {pendingLabel}
+        </>
+      ) : (
+        label
+      )}
+    </button>
+  );
+}

--- a/apps/www/components/analytics/request-form.tsx
+++ b/apps/www/components/analytics/request-form.tsx
@@ -335,17 +335,23 @@ function SubmitButton({ label, pendingLabel }: SubmitButtonProps) {
   return (
     <button
       type="submit"
-      className="inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white text-sm font-semibold text-black transition hover:border-white/40 hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 disabled:cursor-not-allowed disabled:opacity-70"
+      className="group relative inline-flex items-center justify-center overflow-hidden rounded-full border border-white/20 bg-gradient-to-r from-white/95 via-white to-white/90 px-6 py-3 text-sm font-semibold text-slate-950 shadow-[0_22px_80px_rgba(15,23,42,0.45)] transition hover:border-white/40 hover:shadow-[0_26px_100px_rgba(15,23,42,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900/60 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/70 disabled:text-slate-800 disabled:shadow-none"
       disabled={pending}
     >
-      {pending ? (
-        <>
-          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-          {pendingLabel}
-        </>
-      ) : (
-        label
-      )}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-[linear-gradient(110deg,_rgba(255,255,255,0.4),_rgba(255,255,255,0.7)_40%,_rgba(255,255,255,0.4))] opacity-0 transition duration-300 group-hover:opacity-100"
+      />
+      <span className="relative z-10 inline-flex items-center gap-2">
+        {pending ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            {pendingLabel}
+          </>
+        ) : (
+          label
+        )}
+      </span>
     </button>
   );
 }

--- a/apps/www/components/analytics/request-types.ts
+++ b/apps/www/components/analytics/request-types.ts
@@ -1,0 +1,15 @@
+export const ANALYTICS_REQUEST_TYPES = [
+  {
+    value: "platform-access",
+    translationKey: "platformAccess",
+    emailLabel: "Platform access request",
+  },
+  {
+    value: "other",
+    translationKey: "other",
+    emailLabel: "Other request",
+  },
+] as const;
+
+export type AnalyticsRequestType =
+  (typeof ANALYTICS_REQUEST_TYPES)[number]["value"];

--- a/apps/www/components/analytics/server/send-request.ts
+++ b/apps/www/components/analytics/server/send-request.ts
@@ -1,0 +1,174 @@
+"use server";
+
+import { Resend } from "resend";
+import { z } from "zod";
+
+import {
+  ANALYTICS_REQUEST_TYPES,
+  type AnalyticsRequestType,
+} from "../request-types";
+
+const REQUEST_TYPE_VALUES = ANALYTICS_REQUEST_TYPES.map(
+  (option) => option.value,
+) as [AnalyticsRequestType, ...AnalyticsRequestType[]];
+
+const requestSchema = z.object({
+  name: z
+    .string({ required_error: "Name is required" })
+    .trim()
+    .min(2, { message: "Name must be at least 2 characters" })
+    .max(120, { message: "Name must be under 120 characters" }),
+  company: z
+    .string()
+    .trim()
+    .max(120, { message: "Company name must be under 120 characters" })
+    .optional(),
+  email: z
+    .string()
+    .trim()
+    .email({ message: "Email must be valid" })
+    .optional(),
+  requestType: z.enum(REQUEST_TYPE_VALUES, {
+    errorMap: () => ({ message: "Select a request type" }),
+  }),
+  description: z
+    .string({ required_error: "Tell us a little about the request" })
+    .trim()
+    .min(20, { message: "Description must be at least 20 characters" })
+    .max(2000, { message: "Description must be under 2000 characters" }),
+});
+
+export type AnalyticsRequestFormState = {
+  status: "idle" | "success" | "error";
+  message?: string;
+  fieldErrors?: Partial<Record<keyof z.infer<typeof requestSchema>, string>>;
+};
+
+export const initialState: AnalyticsRequestFormState = {
+  status: "idle",
+};
+
+export async function sendAnalyticsRequest(
+  _prevState: AnalyticsRequestFormState,
+  formData: FormData,
+): Promise<AnalyticsRequestFormState> {
+  const rawName = formData.get("name");
+  const rawCompany = formData.get("company");
+  const rawEmail = formData.get("email");
+  const rawRequestType = formData.get("requestType");
+  const rawDescription = formData.get("description");
+
+  const parsed = requestSchema.safeParse({
+    name: typeof rawName === "string" ? rawName : "",
+    company:
+      typeof rawCompany === "string" && rawCompany.trim().length > 0
+        ? rawCompany
+        : undefined,
+    email:
+      typeof rawEmail === "string" && rawEmail.trim().length > 0
+        ? rawEmail
+        : undefined,
+    requestType:
+      typeof rawRequestType === "string"
+        ? (rawRequestType as AnalyticsRequestType)
+        : undefined,
+    description: typeof rawDescription === "string" ? rawDescription : "",
+  });
+
+  if (!parsed.success) {
+    const fieldErrors: Record<string, string> = {};
+    for (const issue of parsed.error.issues) {
+      const field = issue.path[0];
+      if (typeof field === "string" && !fieldErrors[field]) {
+        fieldErrors[field] = issue.message;
+      }
+    }
+
+    return {
+      status: "error",
+      fieldErrors,
+      message: "Please review the highlighted fields and try again.",
+    } satisfies AnalyticsRequestFormState;
+  }
+
+  const data = parsed.data;
+
+  const resendApiKey = process.env.RESEND_API_KEY;
+  const fromEmail =
+    process.env.CONTACT_FROM_EMAIL ?? "TransformAI <info@transformai.nl>";
+  const forwardTo = process.env.CONTACT_FORWARD_TO;
+
+  if (!resendApiKey || !forwardTo) {
+    console.error(
+      "Analytics request submission failed: Missing RESEND_API_KEY or CONTACT_FORWARD_TO.",
+    );
+    return {
+      status: "error",
+      message:
+        "We couldn't send your request right now. Please email info@transformai.nl while we look into this.",
+    } satisfies AnalyticsRequestFormState;
+  }
+
+  const resend = new Resend(resendApiKey);
+  const requestTypeMeta = ANALYTICS_REQUEST_TYPES.find(
+    (option) => option.value === data.requestType,
+  );
+
+  const requestLabel = requestTypeMeta?.emailLabel ?? data.requestType;
+
+  const emailBody = [
+    `Name: ${data.name}`,
+    data.company ? `Company: ${data.company}` : null,
+    `Request type: ${requestLabel}`,
+    data.email ? `Contact email: ${data.email}` : "Contact email: not provided",
+    "",
+    "Request description:",
+    data.description,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  try {
+    await resend.emails.send({
+      from: fromEmail,
+      to: forwardTo,
+      subject: `New TransformAI platform request – ${requestLabel}`,
+      text: emailBody,
+      html: emailBody
+        .split("\n")
+        .map(
+          (line) =>
+            `<p style="margin:0 0 12px;font-size:14px;line-height:20px;">${escapeHtml(
+              line,
+            )}</p>`,
+        )
+        .join(""),
+      reply_to: data.email ?? undefined,
+      headers: {
+        "X-TransformAI-Platform-Request-Type": data.requestType,
+      },
+    });
+  } catch (error) {
+    console.error(
+      "Analytics request submission failed while sending email:",
+      error,
+    );
+    return {
+      status: "error",
+      message:
+        "Something went wrong while sending your request. Please try again or email info@transformai.nl directly.",
+    } satisfies AnalyticsRequestFormState;
+  }
+
+  return {
+    status: "success",
+    message:
+      "Thank you for requesting access. We'll follow up from info@transformai.nl soon.",
+  } satisfies AnalyticsRequestFormState;
+}
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -668,6 +668,57 @@
   },
   "Analytics": {
     "requestAccess": "Request Access",
+    "requestForm": {
+      "badge": "Platform beta",
+      "title": "Request access to the TransformAI platform",
+      "subtitle": "Share a bit about your team and we'll reach out with next steps.",
+      "dismiss": "Close request form",
+      "channel": {
+        "label": "Prefer email?",
+        "caption": "Email {email} and we'll respond within one business day."
+      },
+      "feedback": {
+        "successTitle": "Request received",
+        "errorTitle": "We couldn't send that"
+      },
+      "requestType": {
+        "label": "What brings you here?",
+        "helper": "Pick the option that best describes your request.",
+        "options": {
+          "platformAccess": {
+            "title": "Request access to the platform",
+            "description": "Join the beta and connect your team to TransformAI's workspace."
+          },
+          "other": {
+            "title": "Something else",
+            "description": "Ask a different question about the platform beta."
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "label": "Your name",
+          "placeholder": "Alex Janssen"
+        },
+        "company": {
+          "label": "Company",
+          "placeholder": "Company name"
+        },
+        "email": {
+          "label": "Email",
+          "placeholder": "name@company.com"
+        },
+        "description": {
+          "label": "How can we help?",
+          "placeholder": "Tell us about your team, use case, or anything else we should know."
+        }
+      },
+      "submit": {
+        "label": "Send request",
+        "pending": "Sending..."
+      },
+      "footnote": "Prefer email? Reach us at {email}."
+    },
     "caption": {
       "title": "Realtime Analytics",
       "subtitle": "Live insight into AI usage across your company."

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -625,6 +625,57 @@
   },
   "Analytics": {
     "requestAccess": "Vraag Toegang",
+    "requestForm": {
+      "badge": "Platform bèta",
+      "title": "Toegang aanvragen tot het TransformAI-platform",
+      "subtitle": "Vertel kort waar je naar zoekt en we nemen contact op.",
+      "dismiss": "Aanvraagformulier sluiten",
+      "channel": {
+        "label": "Liever mailen?",
+        "caption": "Mail {email} en we reageren binnen één werkdag."
+      },
+      "feedback": {
+        "successTitle": "Aanvraag ontvangen",
+        "errorTitle": "Verzenden is niet gelukt"
+      },
+      "requestType": {
+        "label": "Waarmee kunnen we helpen?",
+        "helper": "Kies de optie die het beste past.",
+        "options": {
+          "platformAccess": {
+            "title": "Toegang tot het platform",
+            "description": "Doe mee aan de bèta en geef je team toegang tot de TransformAI-omgeving."
+          },
+          "other": {
+            "title": "Iets anders",
+            "description": "Stel een andere vraag over de platform-bèta."
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "label": "Naam",
+          "placeholder": "Alex Janssen"
+        },
+        "company": {
+          "label": "Bedrijf",
+          "placeholder": "Bedrijfsnaam"
+        },
+        "email": {
+          "label": "E-mail",
+          "placeholder": "naam@bedrijf.nl"
+        },
+        "description": {
+          "label": "Hoe kunnen we helpen?",
+          "placeholder": "Vertel over je team, use-case of andere details."
+        }
+      },
+      "submit": {
+        "label": "Aanvraag versturen",
+        "pending": "Versturen..."
+      },
+      "footnote": "Liever mailen? Bereik ons op {email}."
+    },
     "caption": {
       "title": "Realtime-analyse",
       "subtitle": "Direct inzicht in AI-gebruik binnen jouw organisatie."


### PR DESCRIPTION
## Summary
- widen the analytics request panel and swap it to a responsive two-column grid so the revealed form matches the code preview footprint
- keep the hero copy and request-type picker together on the left while grouping the inputs, textarea, and footnote on the right for a shorter stack
- document the layout adjustment in the fixes log for future traceability

## Plan
- adjust the analytics request form container sizing to better mirror the original code card dimensions
- refactor the form markup into a grid that separates narrative content from fields without breaking the existing styling tokens
- ensure success and error alerts, field validation, and submission controls continue to behave correctly after the layout change

## Testing
- `pnpm --filter www run lint` *(fails: missing next-intl dependency in the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68de173473a0832a899b775bb3287e7d