### PR TITLE
Shrink navigation logo on scroll

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-27T1500--navigation-logo-scroll-shrink.md
+++ b/WRITE_HERE/FIXES/2025-11-27T1500--navigation-logo-scroll-shrink.md
@@ -1,0 +1,5 @@
+# Navigation logo shrinks on scroll
+- **What:** Scaled the header logo and padding down rapidly on scroll so it settles slightly larger than the nav text while keeping the dark glass treatment intact.
+- **Why:** The user wanted the navigation bar to feel less dominant after leaving the top of the page by shrinking the logo quickly to a comfortable size.
+- **Files:** `apps/www/components/navbar/navigation.tsx`.
+- **Follow-ups:** Capture updated navigation screenshots once the dev environment runs again.

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -20,7 +20,7 @@ import { PrimaryButton, SecondaryButton } from "../button";
 import { DesktopNavLink, MobileNavLink } from "./link";
 
 export function Navigation() {
-  const [scrollPercent, setScrollPercent] = useState(0);
+  const [scrollY, setScrollY] = useState(0);
   const { hasConsentFor } = useConsentManager();
   const t = useTranslations("Navigation");
   const containerVariants = {
@@ -37,24 +37,33 @@ export function Navigation() {
 
   useEffect(() => {
     const handleScroll = () => {
-      const scrollThreshold = 100;
-      const scrollPercent = Math.min(window.scrollY / 2 / scrollThreshold, 1);
-      setScrollPercent(scrollPercent);
+      setScrollY(window.scrollY);
     };
 
     handleScroll();
 
-    window.addEventListener("scroll", handleScroll);
+    window.addEventListener("scroll", handleScroll, { passive: true });
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
+
+  const backgroundOpacity = Math.min(scrollY / 200, 1);
+  const borderOpacity = Math.min(backgroundOpacity / 5, 0.15);
+  const shrinkProgress = Math.min(scrollY / 80, 1);
+  const minLogoScale = 0.74;
+  const logoScale = 1 - (1 - minLogoScale) * shrinkProgress;
+  const basePadding = 12;
+  const compactPadding = 8;
+  const padding = basePadding - (basePadding - compactPadding) * shrinkProgress;
 
   return (
     <motion.nav
       style={{
-        backgroundColor: `rgba(0, 0, 0, ${scrollPercent})`,
-        borderColor: `rgba(255, 255, 255, ${Math.min(scrollPercent / 5, 0.15)})`,
+        backgroundColor: `rgba(0, 0, 0, ${backgroundOpacity})`,
+        borderColor: `rgba(255, 255, 255, ${borderOpacity})`,
+        paddingTop: `${padding}px`,
+        paddingBottom: `${padding}px`,
       }}
-      className="fixed z-[100] top-0 border-b-[.75px] border-white/10 w-full py-3"
+      className="fixed z-[100] top-0 border-b-[.75px] border-white/10 w-full py-3 transition-all duration-200 ease-out"
       variants={containerVariants}
       initial="hidden"
       animate="visible"
@@ -62,7 +71,7 @@ export function Navigation() {
       <div className="container flex items-center justify-between">
         <div className="flex items-center justify-between w-full sm:w-auto sm:gap-12 lg:gap-20">
           <Link href="/" aria-label={t("ariaHome")} className="block shrink-0">
-            <Logo />
+            <Logo scale={logoScale} />
           </Link>
           <MobileLinks className="lg:hidden" />
           <DesktopLinks className="hidden lg:flex" />
@@ -224,16 +233,21 @@ function DesktopLinks({ className }: { className: string }) {
   );
 }
 
-function Logo({ className }: { className?: string }) {
+function Logo({ className, scale = 1 }: { className?: string; scale?: number }) {
   return (
-    <TransformAILogo
-      variant="transparent"
-      className={cn(
-        "h-auto w-[128px] sm:w-[164px] md:w-[188px] lg:w-[204px] shrink-0",
-        className,
-      )}
-      priority
-      sizes="(max-width: 640px) 164px, (max-width: 1024px) 188px, 204px"
-    />
+    <div
+      className="inline-flex origin-left transition-transform duration-200 ease-out"
+      style={{ transform: `scale(${scale})` }}
+    >
+      <TransformAILogo
+        variant="transparent"
+        className={cn(
+          "h-auto w-[128px] sm:w-[164px] md:w-[188px] lg:w-[204px] shrink-0",
+          className,
+        )}
+        priority
+        sizes="(max-width: 640px) 164px, (max-width: 1024px) 188px, 204px"
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- derive scroll position metrics to drive header background, border, padding, and logo scaling
- shrink the navigation logo quickly after the top of the page while keeping it slightly larger than the surrounding controls
- log the user-requested navigation adjustment in WRITE_HERE/FIXES

## Plan
- review recent navigation updates and existing scroll-driven styling
- compute dedicated scroll progress values for opacity, padding, and logo scale
- wrap the logo in a scalable container and document the change in the fixes log

## Testing
- `pnpm --filter www run lint` *(fails: missing repo dependency `next-intl` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de1c744324832ab42cb4fada3b2a82