### PR TITLE
Shrink navigation logo after scrolling

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-27T1530--navigation-logo-scroll-shrink.md
+++ b/WRITE_HERE/FIXES/2025-11-27T1530--navigation-logo-scroll-shrink.md
@@ -1,0 +1,5 @@
+# Navigation logo scales down on scroll
+- **What:** Animated the header logo to shrink quickly while scrolling and hold a compact size that stays slightly larger than the navigation text and buttons.
+- **Why:** The user wanted the brand mark to feel prominent on page load but reduce its footprint once the visitor scrolls so the header consumes less vertical attention.
+- **Files:** `apps/www/components/navbar/navigation.tsx`.
+- **Follow-ups:** Monitor for additional feedback on scroll thresholds or responsive behavior across devices.

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -62,7 +62,7 @@ export function Navigation() {
       <div className="container flex items-center justify-between">
         <div className="flex items-center justify-between w-full sm:w-auto sm:gap-12 lg:gap-20">
           <Link href="/" aria-label={t("ariaHome")} className="block shrink-0">
-            <Logo />
+            <Logo shrinkProgress={Math.min(scrollPercent * 2.6, 1)} />
           </Link>
           <MobileLinks className="lg:hidden" />
           <DesktopLinks className="hidden lg:flex" />
@@ -224,16 +224,32 @@ function DesktopLinks({ className }: { className: string }) {
   );
 }
 
-function Logo({ className }: { className?: string }) {
+function Logo({
+  className,
+  shrinkProgress = 0,
+}: {
+  className?: string;
+  shrinkProgress?: number;
+}) {
+  const clampedProgress = Math.min(Math.max(shrinkProgress, 0), 1);
+  const scale = 1 - clampedProgress * 0.24;
+
   return (
-    <TransformAILogo
-      variant="transparent"
-      className={cn(
-        "h-auto w-[128px] sm:w-[164px] md:w-[188px] lg:w-[204px] shrink-0",
-        className,
-      )}
-      priority
-      sizes="(max-width: 640px) 164px, (max-width: 1024px) 188px, 204px"
-    />
+    <motion.div
+      animate={{ scale }}
+      transition={{ duration: 0.2, ease: "easeOut" }}
+      style={{ transformOrigin: "left center" }}
+      className="shrink-0"
+    >
+      <TransformAILogo
+        variant="transparent"
+        className={cn(
+          "h-auto w-[128px] sm:w-[164px] md:w-[188px] lg:w-[204px] shrink-0",
+          className,
+        )}
+        priority
+        sizes="(max-width: 640px) 164px, (max-width: 1024px) 188px, 204px"
+      />
+    </motion.div>
   );
 }


### PR DESCRIPTION
## Plan
- Review the navigation header to understand how the logo is currently sized and animated.
- Add scroll-driven scaling so the logo quickly reduces to the desired compact size after the user begins scrolling.
- Confirm no regressions in the navigation layout and capture the change in the FIXES log.

## Summary
- Added a scroll-progress prop to the navigation logo and animate its scale so it shrinks rapidly and then holds a compact size after scrolling.
- Documented the adjustment in the FIXES changelog for future reference.

## Testing
- pnpm --filter www run lint *(fails: missing `next-intl` dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de1c744324832ab42cb4fada3b2a82