### PR TITLE
Tune navigation logo scaling per page

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-27T1500--navigation-logo-scroll-shrink.md
+++ b/WRITE_HERE/FIXES/2025-11-27T1500--navigation-logo-scroll-shrink.md
@@ -1,0 +1,5 @@
+# Navigation logo shrinks on scroll
+- **What:** Scaled the header logo and padding down rapidly on scroll so it settles slightly larger than the nav text while keeping the dark glass treatment intact.
+- **Why:** The user wanted the navigation bar to feel less dominant after leaving the top of the page by shrinking the logo quickly to a comfortable size.
+- **Files:** `apps/www/components/navbar/navigation.tsx`.
+- **Follow-ups:** Capture updated navigation screenshots once the dev environment runs again.

--- a/WRITE_HERE/FIXES/2025-11-27T1700--navigation-logo-resize-tune.md
+++ b/WRITE_HERE/FIXES/2025-11-27T1700--navigation-logo-resize-tune.md
@@ -1,0 +1,5 @@
+# Navigation logo scale tuned per page
+- **What:** Detected the home route to keep the hero-sized logo on load, started other pages with the compact logo, and reduced the settled scale so the mark shrinks faster to a slightly smaller final size.
+- **Why:** The user asked for the scrolled logo to end up a bit smaller overall and to have subpages start at the compact size instead of the hero-scale treatment reserved for the homepage.
+- **Files:** `apps/www/components/navbar/navigation.tsx`.
+- **Follow-ups:** Capture updated navigation screenshots after the environment can run with `next-intl` installed.

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -8,21 +8,23 @@ import {
   DrawerHeader,
   DrawerTrigger,
 } from "@/components/ui/drawer";
-import { Link } from "@/i18n/navigation";
+import { Link, usePathname } from "@/i18n/navigation";
 import { cn } from "@/lib/utils";
 import { useConsentManager } from "@c15t/nextjs";
 import { track } from "@vercel/analytics";
 import { motion } from "framer-motion";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { PrimaryButton, SecondaryButton } from "../button";
 import { DesktopNavLink, MobileNavLink } from "./link";
 
 export function Navigation() {
-  const [scrollPercent, setScrollPercent] = useState(0);
+  const [scrollY, setScrollY] = useState(0);
   const { hasConsentFor } = useConsentManager();
   const t = useTranslations("Navigation");
+  const pathname = usePathname();
+  const locale = useLocale();
   const containerVariants = {
     hidden: {
       opacity: 0,
@@ -37,24 +39,38 @@ export function Navigation() {
 
   useEffect(() => {
     const handleScroll = () => {
-      const scrollThreshold = 100;
-      const scrollPercent = Math.min(window.scrollY / 2 / scrollThreshold, 1);
-      setScrollPercent(scrollPercent);
+      setScrollY(window.scrollY);
     };
 
     handleScroll();
 
-    window.addEventListener("scroll", handleScroll);
+    window.addEventListener("scroll", handleScroll, { passive: true });
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
+
+  const backgroundOpacity = Math.min(scrollY / 200, 1);
+  const borderOpacity = Math.min(backgroundOpacity / 5, 0.15);
+  const shrinkProgress = Math.min(scrollY / 60, 1);
+  const normalizedHomePath = `/${locale}`;
+  const isHome =
+    pathname === normalizedHomePath || pathname === `${normalizedHomePath}/` || pathname === "/";
+  const settledLogoScale = 0.68;
+  const initialLogoScale = isHome ? 1 : 0.74;
+  const logoScale =
+    initialLogoScale - (initialLogoScale - settledLogoScale) * shrinkProgress;
+  const basePadding = 12;
+  const compactPadding = 8;
+  const padding = basePadding - (basePadding - compactPadding) * shrinkProgress;
 
   return (
     <motion.nav
       style={{
-        backgroundColor: `rgba(0, 0, 0, ${scrollPercent})`,
-        borderColor: `rgba(255, 255, 255, ${Math.min(scrollPercent / 5, 0.15)})`,
+        backgroundColor: `rgba(0, 0, 0, ${backgroundOpacity})`,
+        borderColor: `rgba(255, 255, 255, ${borderOpacity})`,
+        paddingTop: `${padding}px`,
+        paddingBottom: `${padding}px`,
       }}
-      className="fixed z-[100] top-0 border-b-[.75px] border-white/10 w-full py-3"
+      className="fixed z-[100] top-0 border-b-[.75px] border-white/10 w-full py-3 transition-all duration-200 ease-out"
       variants={containerVariants}
       initial="hidden"
       animate="visible"
@@ -62,7 +78,7 @@ export function Navigation() {
       <div className="container flex items-center justify-between">
         <div className="flex items-center justify-between w-full sm:w-auto sm:gap-12 lg:gap-20">
           <Link href="/" aria-label={t("ariaHome")} className="block shrink-0">
-            <Logo />
+            <Logo scale={logoScale} />
           </Link>
           <MobileLinks className="lg:hidden" />
           <DesktopLinks className="hidden lg:flex" />
@@ -224,16 +240,21 @@ function DesktopLinks({ className }: { className: string }) {
   );
 }
 
-function Logo({ className }: { className?: string }) {
+function Logo({ className, scale = 1 }: { className?: string; scale?: number }) {
   return (
-    <TransformAILogo
-      variant="transparent"
-      className={cn(
-        "h-auto w-[128px] sm:w-[164px] md:w-[188px] lg:w-[204px] shrink-0",
-        className,
-      )}
-      priority
-      sizes="(max-width: 640px) 164px, (max-width: 1024px) 188px, 204px"
-    />
+    <div
+      className="inline-flex origin-left transition-transform duration-200 ease-out"
+      style={{ transform: `scale(${scale})` }}
+    >
+      <TransformAILogo
+        variant="transparent"
+        className={cn(
+          "h-auto w-[128px] sm:w-[164px] md:w-[188px] lg:w-[204px] shrink-0",
+          className,
+        )}
+        priority
+        sizes="(max-width: 640px) 164px, (max-width: 1024px) 188px, 204px"
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- detect the current locale path to keep the hero-scale logo only on the homepage
- shrink the navigation logo faster to a slightly smaller final size while keeping subpages compact on load
- record the navigation adjustment in the fixes log for traceability

## Plan
- determine how to detect locale-prefixed home routes within the navigation component
- adjust the scroll-driven logo scaling math to support distinct starting and settled sizes
- document the change under WRITE_HERE/FIXES for future reference

## Testing
- `pnpm --filter www run lint` *(fails: missing repo dependency `next-intl` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de1c744324832ab42cb4fada3b2a82