### PR TITLE
Fix NextAuth session table and post-signin redirect

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-28T1200--fix-session-table-and-post-signin-redirect.md
+++ b/WRITE_HERE/FIXES/2025-11-28T1200--fix-session-table-and-post-signin-redirect.md
@@ -1,0 +1,5 @@
+# Fix session table mapping and post-signin redirect
+- **What:** Renamed the NextAuth session table to the singular `session` in schema/migrations with a guard migration, and switched sign-in/up forms to use Next.js routing so the callback URL no longer duplicates the locale prefix.
+- **Why:** NextAuth threw `relation "session" does not exist` because it queried a singular table while Drizzle created `sessions`. The sign-in flow also redirected to `/en/en/auth/post-signin`, causing a 404 after authentication.
+- **Files:** `apps/www/lib/db/schema.ts`, `apps/www/drizzle/0000_initial.sql`, `apps/www/drizzle/0001_fix_session_table.sql`, `apps/www/components/auth/sign-in-form.tsx`, `apps/www/components/auth/sign-up-form.tsx`.
+- **Follow-ups:** Ensure the new migration runs on the deployed database and verify Google OAuth once production credentials are configured.

--- a/apps/www/components/auth/sign-in-form.tsx
+++ b/apps/www/components/auth/sign-in-form.tsx
@@ -5,7 +5,7 @@ import { signIn } from "next-auth/react";
 import { Loader2, LogIn } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 
-import { useRouter } from "@/i18n/navigation";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/apps/www/components/auth/sign-up-form.tsx
+++ b/apps/www/components/auth/sign-up-form.tsx
@@ -5,7 +5,7 @@ import { signIn } from "next-auth/react";
 import { Loader2, Lock, Check } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 
-import { useRouter } from "@/i18n/navigation";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/apps/www/drizzle/0000_initial.sql
+++ b/apps/www/drizzle/0000_initial.sql
@@ -37,16 +37,16 @@ CREATE INDEX IF NOT EXISTS "accounts_user_id_idx" ON "accounts" ("user_id");
 ALTER TABLE "accounts"
   ADD CONSTRAINT "accounts_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE cascade ON UPDATE no action;
 
-CREATE TABLE IF NOT EXISTS "sessions" (
+CREATE TABLE IF NOT EXISTS "session" (
   "session_token" text PRIMARY KEY NOT NULL,
   "user_id" text NOT NULL,
   "expires" timestamp NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS "sessions_user_id_idx" ON "sessions" ("user_id");
+CREATE INDEX IF NOT EXISTS "session_user_id_idx" ON "session" ("user_id");
 
-ALTER TABLE "sessions"
-  ADD CONSTRAINT "sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "session"
+  ADD CONSTRAINT "session_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE cascade ON UPDATE no action;
 
 CREATE TABLE IF NOT EXISTS "verification_tokens" (
   "identifier" text NOT NULL,

--- a/apps/www/drizzle/0001_fix_session_table.sql
+++ b/apps/www/drizzle/0001_fix_session_table.sql
@@ -1,0 +1,20 @@
+DO $$
+BEGIN
+  ALTER TABLE "sessions" RENAME TO "session";
+EXCEPTION
+  WHEN undefined_table THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER INDEX "sessions_user_id_idx" RENAME TO "session_user_id_idx";
+EXCEPTION
+  WHEN undefined_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TABLE "session" RENAME CONSTRAINT "sessions_user_id_users_id_fk" TO "session_user_id_users_id_fk";
+EXCEPTION
+  WHEN undefined_object THEN NULL;
+END $$;

--- a/apps/www/lib/db/schema.ts
+++ b/apps/www/lib/db/schema.ts
@@ -60,7 +60,7 @@ export const accounts = pgTable(
 );
 
 export const sessions = pgTable(
-  "sessions",
+  "session",
   {
     sessionToken: text("session_token").primaryKey(),
     userId: text("user_id")
@@ -69,7 +69,7 @@ export const sessions = pgTable(
     expires: timestamp("expires", { mode: "date" }).notNull(),
   },
   (table) => ({
-    userIdx: index("sessions_user_id_idx").on(table.userId),
+    userIdx: index("session_user_id_idx").on(table.userId),
   }),
 );
 


### PR DESCRIPTION
## Plan
- Align the Drizzle schema and migrations with the table names NextAuth expects for persisted sessions.
- Provide a migration that safely renames the existing `sessions` table in deployed environments.
- Adjust the client-side sign-in/up flows so locale-prefixed redirects do not duplicate the locale segment.
- Document the bug fix in WRITE_HERE/FIXES for project history.

## Summary
- Point the Drizzle session table definition to the singular `session` table and update the seed migration plus a guard migration to rename existing tables and indexes.
- Switch the sign-in and sign-up forms to use Next.js routing utilities so callback URLs remain correctly prefixed without duplicating the locale.
- Logged the resolved issue in WRITE_HERE/FIXES with context and follow-up notes.

## Testing
- `pnpm --filter www run typecheck` *(fails: missing workspace type dependencies such as next-intl, drizzle-orm, next-auth, etc. in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de34445374832ab2f369ac9e47d0f2