### PR TITLE
Fix NextAuth session query by renaming schema tables

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-07T1200--align-nextauth-table-names.md
+++ b/WRITE_HERE/FIXES/2025-11-07T1200--align-nextauth-table-names.md
@@ -1,0 +1,7 @@
+# Align NextAuth tables with adapter expectations
+_When:_ 2025-11-07 12:00 · _Scope:_ apps/www auth · _Author:_ AI assistant
+
+- **What:** Renamed the NextAuth-related tables, columns, and indexes to the camelCase singular naming that `@auth/drizzle-adapter` queries while keeping schema references intact.
+- **Why:** NextAuth session lookups failed because the adapter queried `session`/`userId` fields that did not exist in the snake_case plural tables created previously.
+- **Files:** `apps/www/lib/db/schema.ts`, `apps/www/drizzle/0001_align_nextauth_schema.sql`.
+- **Follow-ups:** Run the new migration in each environment (`pnpm --filter www run db:migrate`) so persisted data matches the updated schema before retesting auth.

--- a/apps/www/drizzle/0001_align_nextauth_schema.sql
+++ b/apps/www/drizzle/0001_align_nextauth_schema.sql
@@ -1,0 +1,24 @@
+-- Align NextAuth tables with @auth/drizzle-adapter defaults
+ALTER TABLE IF EXISTS "users" RENAME TO "user";
+ALTER TABLE IF EXISTS "accounts" RENAME TO "account";
+ALTER TABLE IF EXISTS "sessions" RENAME TO "session";
+ALTER TABLE IF EXISTS "verification_tokens" RENAME TO "verificationToken";
+
+ALTER TABLE IF EXISTS "user" RENAME COLUMN "email_verified" TO "emailVerified";
+ALTER TABLE IF EXISTS "user" RENAME COLUMN "password_hash" TO "passwordHash";
+ALTER TABLE IF EXISTS "user" RENAME COLUMN "created_at" TO "createdAt";
+ALTER TABLE IF EXISTS "user" RENAME COLUMN "updated_at" TO "updatedAt";
+
+ALTER TABLE IF EXISTS "account" RENAME COLUMN "user_id" TO "userId";
+ALTER TABLE IF EXISTS "account" RENAME COLUMN "provider_account_id" TO "providerAccountId";
+
+ALTER TABLE IF EXISTS "session" RENAME COLUMN "session_token" TO "sessionToken";
+ALTER TABLE IF EXISTS "session" RENAME COLUMN "user_id" TO "userId";
+
+ALTER INDEX IF EXISTS "users_email_unique" RENAME TO "user_email_unique";
+ALTER INDEX IF EXISTS "users_role_idx" RENAME TO "user_role_idx";
+ALTER INDEX IF EXISTS "accounts_user_id_idx" RENAME TO "account_userId_idx";
+ALTER INDEX IF EXISTS "sessions_user_id_idx" RENAME TO "session_userId_idx";
+
+ALTER TABLE IF EXISTS "account" RENAME CONSTRAINT "accounts_user_id_users_id_fk" TO "account_userId_user_id_fk";
+ALTER TABLE IF EXISTS "session" RENAME CONSTRAINT "sessions_user_id_users_id_fk" TO "session_userId_user_id_fk";

--- a/apps/www/lib/db/schema.ts
+++ b/apps/www/lib/db/schema.ts
@@ -14,35 +14,35 @@ import type { AdapterAccount } from "next-auth/adapters";
 export const userRoleEnum = pgEnum("user_role", ["client", "staff"]);
 
 export const users = pgTable(
-  "users",
+  "user",
   {
     id: text("id")
       .primaryKey()
       .$defaultFn(() => crypto.randomUUID()),
     name: text("name"),
     email: text("email").notNull(),
-    emailVerified: timestamp("email_verified", { mode: "date" }),
+    emailVerified: timestamp("emailVerified", { mode: "date" }),
     image: text("image"),
     role: userRoleEnum("role").notNull().default("client"),
-    passwordHash: text("password_hash"),
-    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
-    updatedAt: timestamp("updated_at", { mode: "date" }).notNull().defaultNow(),
+    passwordHash: text("passwordHash"),
+    createdAt: timestamp("createdAt", { mode: "date" }).notNull().defaultNow(),
+    updatedAt: timestamp("updatedAt", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => ({
-    emailIdx: uniqueIndex("users_email_unique").on(table.email),
-    roleIdx: index("users_role_idx").on(table.role),
+    emailIdx: uniqueIndex("user_email_unique").on(table.email),
+    roleIdx: index("user_role_idx").on(table.role),
   }),
 );
 
 export const accounts = pgTable(
-  "accounts",
+  "account",
   {
-    userId: text("user_id")
+    userId: text("userId")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
     type: text("type").$type<AdapterAccount["type"]>().notNull(),
     provider: text("provider").notNull(),
-    providerAccountId: text("provider_account_id").notNull(),
+    providerAccountId: text("providerAccountId").notNull(),
     refresh_token: text("refresh_token"),
     access_token: text("access_token"),
     expires_at: integer("expires_at"),
@@ -55,26 +55,26 @@ export const accounts = pgTable(
   },
   (table) => ({
     compoundPk: primaryKey({ columns: [table.provider, table.providerAccountId] }),
-    userIdx: index("accounts_user_id_idx").on(table.userId),
+    userIdx: index("account_userId_idx").on(table.userId),
   }),
 );
 
 export const sessions = pgTable(
-  "sessions",
+  "session",
   {
-    sessionToken: text("session_token").primaryKey(),
-    userId: text("user_id")
+    sessionToken: text("sessionToken").primaryKey(),
+    userId: text("userId")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
     expires: timestamp("expires", { mode: "date" }).notNull(),
   },
   (table) => ({
-    userIdx: index("sessions_user_id_idx").on(table.userId),
+    userIdx: index("session_userId_idx").on(table.userId),
   }),
 );
 
 export const verificationTokens = pgTable(
-  "verification_tokens",
+  "verificationToken",
   {
     identifier: text("identifier").notNull(),
     token: text("token").notNull(),


### PR DESCRIPTION
## Summary
- rename the NextAuth drizzle tables and key columns to the camelCase singular names expected by `@auth/drizzle-adapter`
- add a follow-up migration that renames the existing tables, indexes, and foreign keys without dropping user data
- document the fix in WRITE_HERE so deploys know to run the migration before retesting auth

## Plan
- verify the adapter error stems from table and column naming mismatches
- align the schema definitions with the adapter defaults and provide a migration for existing databases
- validate the change set and capture deployment notes in WRITE_HERE

## Testing
- `pnpm --filter www run typecheck` *(fails: missing many upstream type packages in the workspace install)*

------
https://chatgpt.com/codex/tasks/task_e_68de34445374832ab2f369ac9e47d0f2