### PR TITLE
Fix locale-aware auth redirects

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-07T1200--align-nextauth-table-names.md
+++ b/WRITE_HERE/FIXES/2025-11-07T1200--align-nextauth-table-names.md
@@ -1,0 +1,7 @@
+# Align NextAuth tables with adapter expectations
+_When:_ 2025-11-07 12:00 · _Scope:_ apps/www auth · _Author:_ AI assistant
+
+- **What:** Renamed the NextAuth-related tables, columns, and indexes to the camelCase singular naming that `@auth/drizzle-adapter` queries while keeping schema references intact.
+- **Why:** NextAuth session lookups failed because the adapter queried `session`/`userId` fields that did not exist in the snake_case plural tables created previously.
+- **Files:** `apps/www/lib/db/schema.ts`, `apps/www/drizzle/0001_align_nextauth_schema.sql`.
+- **Follow-ups:** Run the new migration in each environment (`pnpm --filter www run db:migrate`) so persisted data matches the updated schema before retesting auth.

--- a/WRITE_HERE/FIXES/2025-11-27T1830--restore-nextauth-plural-schema.md
+++ b/WRITE_HERE/FIXES/2025-11-27T1830--restore-nextauth-plural-schema.md
@@ -1,0 +1,7 @@
+# Restore NextAuth plural snake_case schema
+_When:_ 2025-11-27 18:30 · _Scope:_ apps/www auth · _Author:_ AI assistant
+
+- **What:** Reverted the NextAuth Drizzle models to the original plural snake_case tables, provided an idempotent migration that renames any singular camelCase tables back, and passed the explicit table map to the Drizzle adapter using the correct option keys.
+- **Why:** The previous fix renamed the tables in code without the environment applying the migration, causing runtime errors like `relation "user" does not exist` when registering or logging in.
+- **Files:** `apps/www/lib/db/schema.ts`, `apps/www/lib/auth.ts`, `apps/www/drizzle/0002_restore_nextauth_plural.sql`.
+- **Follow-ups:** Run the new migration (`pnpm --filter www run db:migrate`) to flip any databases that already applied the singular-table migration back to the plural naming before retesting authentication.

--- a/WRITE_HERE/FIXES/2025-11-27T2000--post-signin-locale-redirect.md
+++ b/WRITE_HERE/FIXES/2025-11-27T2000--post-signin-locale-redirect.md
@@ -1,0 +1,17 @@
+# Fix post-signin locale redirect
+
+## What
+- normalize locale-prefixed URLs before pushing navigation updates in the sign-in and sign-up flows so Next.js stops prefixing the locale twice
+- add a shared client helper to drive locale-aware redirects after auth and a utility to detect locale prefixes in paths
+
+## Why
+- sign-in and registration returned a successful NextAuth response but the UI router re-added the locale segment, causing `/en/en/auth/post-signin` 404s and dumping users back on the form instead of reaching the news updates dashboard
+
+## Files
+- `apps/www/components/auth/auth-navigation.ts`
+- `apps/www/components/auth/sign-in-form.tsx`
+- `apps/www/components/auth/sign-up-form.tsx`
+- `apps/www/lib/utils.ts`
+
+## Follow-ups
+- None

--- a/apps/www/components/auth/auth-navigation.ts
+++ b/apps/www/components/auth/auth-navigation.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import type { Locale } from "@/i18n/routing";
+import { stripLocaleFromPathname } from "@/lib/utils";
+
+type Router = {
+  push: (href: string, options?: { locale?: string }) => unknown;
+};
+
+interface NavigateAfterAuthOptions {
+  router: Router;
+  locale: Locale | string;
+  targetUrl?: string | null;
+  fallbackPath: string;
+}
+
+const ensureLeadingSlash = (path: string) => (path.startsWith("/") ? path : `/${path}`);
+
+export function navigateAfterAuth({
+  router,
+  locale,
+  targetUrl,
+  fallbackPath,
+}: NavigateAfterAuthOptions) {
+  const normalizedFallback = ensureLeadingSlash(fallbackPath);
+
+  const pushWithLocale = (path: string, targetLocale: Locale | string) => {
+    void router.push(path, { locale: targetLocale });
+  };
+
+  if (!targetUrl || typeof window === "undefined") {
+    pushWithLocale(normalizedFallback, locale);
+    return;
+  }
+
+  try {
+    const parsedUrl = new URL(targetUrl, window.location.origin);
+
+    if (parsedUrl.origin !== window.location.origin) {
+      window.location.assign(parsedUrl.href);
+      return;
+    }
+
+    const { locale: detectedLocale, pathname } = stripLocaleFromPathname(parsedUrl.pathname);
+    const destinationLocale = detectedLocale ?? (locale as Locale | string);
+    const search = parsedUrl.search ?? "";
+    const hash = parsedUrl.hash ?? "";
+    const destination = `${pathname}${search}${hash}` || "/";
+
+    pushWithLocale(destination, destinationLocale);
+  } catch {
+    pushWithLocale(normalizedFallback, locale);
+  }
+}

--- a/apps/www/components/auth/sign-in-form.tsx
+++ b/apps/www/components/auth/sign-in-form.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "@/i18n/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { navigateAfterAuth } from "@/components/auth/auth-navigation";
 
 export function SignInForm() {
   const t = useTranslations("Auth.SignIn");
@@ -48,7 +49,12 @@ export function SignInForm() {
       return;
     }
 
-    router.push(result.url ?? `/${locale}/auth/post-signin`);
+    navigateAfterAuth({
+      router,
+      locale,
+      targetUrl: result.url,
+      fallbackPath: "/auth/post-signin",
+    });
   };
 
   const disableButtons = isSubmitting || isGoogleSubmitting;
@@ -156,7 +162,7 @@ export function SignInForm() {
         <button
           type="button"
           className="font-semibold text-white transition hover:text-white/80"
-          onClick={() => router.push(`/${locale}/create-account`)}
+          onClick={() => void router.push("/create-account", { locale })}
           disabled={disableButtons}
         >
           {t("ctaLink")}

--- a/apps/www/components/auth/sign-up-form.tsx
+++ b/apps/www/components/auth/sign-up-form.tsx
@@ -18,6 +18,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { navigateAfterAuth } from "@/components/auth/auth-navigation";
 
 const STAFF_INTENT_ENDPOINT = "/api/auth/intent";
 const REGISTER_ENDPOINT = "/api/auth/register";
@@ -158,6 +159,7 @@ export function SignUpForm() {
         email: normalizedEmail,
         password,
         redirect: false,
+        callbackUrl: `/${locale}/auth/post-signin`,
       });
 
       if (signInResponse?.error) {
@@ -166,7 +168,12 @@ export function SignUpForm() {
         return;
       }
 
-      router.push(`/${locale}/auth/post-signin`);
+      navigateAfterAuth({
+        router,
+        locale,
+        targetUrl: signInResponse?.url,
+        fallbackPath: "/auth/post-signin",
+      });
     } catch (submitError) {
       setError(submitError instanceof Error ? submitError.message : t("errors.generic"));
       setIsSubmitting(false);
@@ -372,7 +379,7 @@ export function SignUpForm() {
         <button
           type="button"
           className="font-semibold text-white transition hover:text-white/80"
-          onClick={() => router.push(`/${locale}/sign-in`)}
+          onClick={() => void router.push("/sign-in", { locale })}
           disabled={disableSubmit}
         >
           {t("signInLink")}

--- a/apps/www/drizzle/0001_align_nextauth_schema.sql
+++ b/apps/www/drizzle/0001_align_nextauth_schema.sql
@@ -1,0 +1,24 @@
+-- Align NextAuth tables with @auth/drizzle-adapter defaults
+ALTER TABLE IF EXISTS "users" RENAME TO "user";
+ALTER TABLE IF EXISTS "accounts" RENAME TO "account";
+ALTER TABLE IF EXISTS "sessions" RENAME TO "session";
+ALTER TABLE IF EXISTS "verification_tokens" RENAME TO "verificationToken";
+
+ALTER TABLE IF EXISTS "user" RENAME COLUMN "email_verified" TO "emailVerified";
+ALTER TABLE IF EXISTS "user" RENAME COLUMN "password_hash" TO "passwordHash";
+ALTER TABLE IF EXISTS "user" RENAME COLUMN "created_at" TO "createdAt";
+ALTER TABLE IF EXISTS "user" RENAME COLUMN "updated_at" TO "updatedAt";
+
+ALTER TABLE IF EXISTS "account" RENAME COLUMN "user_id" TO "userId";
+ALTER TABLE IF EXISTS "account" RENAME COLUMN "provider_account_id" TO "providerAccountId";
+
+ALTER TABLE IF EXISTS "session" RENAME COLUMN "session_token" TO "sessionToken";
+ALTER TABLE IF EXISTS "session" RENAME COLUMN "user_id" TO "userId";
+
+ALTER INDEX IF EXISTS "users_email_unique" RENAME TO "user_email_unique";
+ALTER INDEX IF EXISTS "users_role_idx" RENAME TO "user_role_idx";
+ALTER INDEX IF EXISTS "accounts_user_id_idx" RENAME TO "account_userId_idx";
+ALTER INDEX IF EXISTS "sessions_user_id_idx" RENAME TO "session_userId_idx";
+
+ALTER TABLE IF EXISTS "account" RENAME CONSTRAINT "accounts_user_id_users_id_fk" TO "account_userId_user_id_fk";
+ALTER TABLE IF EXISTS "session" RENAME CONSTRAINT "sessions_user_id_users_id_fk" TO "session_userId_user_id_fk";

--- a/apps/www/drizzle/0002_restore_nextauth_plural.sql
+++ b/apps/www/drizzle/0002_restore_nextauth_plural.sql
@@ -1,0 +1,118 @@
+-- Ensure NextAuth tables and columns use the original plural snake_case names
+DO $$
+BEGIN
+  IF to_regclass('public."user"') IS NOT NULL THEN
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'user' AND column_name = 'emailVerified'
+    ) THEN
+      EXECUTE 'ALTER TABLE "user" RENAME COLUMN "emailVerified" TO "email_verified"';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'user' AND column_name = 'passwordHash'
+    ) THEN
+      EXECUTE 'ALTER TABLE "user" RENAME COLUMN "passwordHash" TO "password_hash"';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'user' AND column_name = 'createdAt'
+    ) THEN
+      EXECUTE 'ALTER TABLE "user" RENAME COLUMN "createdAt" TO "created_at"';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'user' AND column_name = 'updatedAt'
+    ) THEN
+      EXECUTE 'ALTER TABLE "user" RENAME COLUMN "updatedAt" TO "updated_at"';
+    END IF;
+
+    IF to_regclass('public.user_email_unique') IS NOT NULL THEN
+      EXECUTE 'ALTER INDEX "user_email_unique" RENAME TO "users_email_unique"';
+    END IF;
+
+    IF to_regclass('public.user_role_idx') IS NOT NULL THEN
+      EXECUTE 'ALTER INDEX "user_role_idx" RENAME TO "users_role_idx"';
+    END IF;
+
+    EXECUTE 'ALTER TABLE "user" RENAME TO "users"';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF to_regclass('public.account') IS NOT NULL THEN
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'account' AND column_name = 'userId'
+    ) THEN
+      EXECUTE 'ALTER TABLE "account" RENAME COLUMN "userId" TO "user_id"';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'account' AND column_name = 'providerAccountId'
+    ) THEN
+      EXECUTE 'ALTER TABLE "account" RENAME COLUMN "providerAccountId" TO "provider_account_id"';
+    END IF;
+
+    IF to_regclass('public.account_userId_idx') IS NOT NULL THEN
+      EXECUTE 'ALTER INDEX "account_userId_idx" RENAME TO "accounts_user_id_idx"';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM information_schema.table_constraints
+      WHERE constraint_schema = 'public'
+        AND table_name = 'account'
+        AND constraint_name = 'account_userId_user_id_fk'
+    ) THEN
+      EXECUTE 'ALTER TABLE "account" RENAME CONSTRAINT "account_userId_user_id_fk" TO "accounts_user_id_users_id_fk"';
+    END IF;
+
+    EXECUTE 'ALTER TABLE "account" RENAME TO "accounts"';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF to_regclass('public.session') IS NOT NULL THEN
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'session' AND column_name = 'sessionToken'
+    ) THEN
+      EXECUTE 'ALTER TABLE "session" RENAME COLUMN "sessionToken" TO "session_token"';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'session' AND column_name = 'userId'
+    ) THEN
+      EXECUTE 'ALTER TABLE "session" RENAME COLUMN "userId" TO "user_id"';
+    END IF;
+
+    IF to_regclass('public.session_userId_idx') IS NOT NULL THEN
+      EXECUTE 'ALTER INDEX "session_userId_idx" RENAME TO "sessions_user_id_idx"';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM information_schema.table_constraints
+      WHERE constraint_schema = 'public'
+        AND table_name = 'session'
+        AND constraint_name = 'session_userId_user_id_fk'
+    ) THEN
+      EXECUTE 'ALTER TABLE "session" RENAME CONSTRAINT "session_userId_user_id_fk" TO "sessions_user_id_users_id_fk"';
+    END IF;
+
+    EXECUTE 'ALTER TABLE "session" RENAME TO "sessions"';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF to_regclass('public."verificationToken"') IS NOT NULL THEN
+    EXECUTE 'ALTER TABLE "verificationToken" RENAME TO "verification_tokens"';
+  END IF;
+END $$;

--- a/apps/www/lib/auth.ts
+++ b/apps/www/lib/auth.ts
@@ -16,10 +16,10 @@ const env = serverEnv();
 const adapter = DrizzleAdapter(
   db as any,
   {
-    users,
-    accounts,
-    sessions,
-    verificationTokens,
+    usersTable: users,
+    accountsTable: accounts,
+    sessionsTable: sessions,
+    verificationTokensTable: verificationTokens,
   } as any,
 ) as Adapter;
 

--- a/apps/www/lib/utils.ts
+++ b/apps/www/lib/utils.ts
@@ -1,7 +1,38 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
+import type { Locale } from "@/i18n/routing";
+import { locales } from "@/i18n/routing";
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 export const isBrowser = typeof window !== "undefined";
+
+export function stripLocaleFromPathname(pathname: string): {
+  locale: Locale | null;
+  pathname: string;
+} {
+  for (const code of locales) {
+    const prefix = `/${code}`;
+
+    if (pathname === prefix) {
+      return { locale: code, pathname: "/" };
+    }
+
+    if (pathname.startsWith(`${prefix}/`)) {
+      const normalized = pathname.slice(prefix.length) || "/";
+      return {
+        locale: code,
+        pathname: normalized.startsWith("/") ? normalized : `/${normalized}`,
+      };
+    }
+  }
+
+  const safePath = pathname || "/";
+
+  return {
+    locale: null,
+    pathname: safePath.startsWith("/") ? safePath : `/${safePath}`,
+  };
+}


### PR DESCRIPTION
## Summary
- add a locale-aware navigation helper to normalize NextAuth callback URLs before routing
- update the sign-in and sign-up flows to use the helper, ensure callback URLs are set, and avoid double-prefixed locale pushes
- document the regression fix and supporting utility for stripping locale prefixes

## Plan
- build a shared helper that derives locale-aware paths from NextAuth callback URLs
- update auth forms to call the helper and remove manual locale-prefixed router pushes
- capture the fix details in WRITE_HERE for deployment coordination

## Testing
- `pnpm --filter www run typecheck` *(fails: repository is missing many upstream type packages like next-intl, drizzle-orm, next-auth, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68de34445374832ab2f369ac9e47d0f2