### PR TITLE
docs: clarify auth setup workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,12 @@
-# Example environment variables for the mini chat
+# Example environment variables for the marketing app
+# PostgreSQL connection used by Drizzle + NextAuth sessions
+DATABASE_URL=
+# Secret used to encrypt NextAuth JWT/cookies
+AUTH_SECRET=
+# Google OAuth client used for sign-up/sign-in with Google
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+# Public URL for the marketing app (set to your local dev URL in development)
+NEXTAUTH_URL=http://localhost:3000
+# API key for the on-site TransformAI assistant experience
 TRANSFORMAI_ASSISTANT_KEY=

--- a/WRITE_HERE/UPDATES/2025-11-28T0900--auth-docs-refresh.md
+++ b/WRITE_HERE/UPDATES/2025-11-28T0900--auth-docs-refresh.md
@@ -1,0 +1,5 @@
+# Document auth + database setup
+- **What:** Expanded `.env.example` with guidance for new credentials and updated `apps/www/README.md` with the full PostgreSQL/Drizzle/NextAuth setup steps plus role routing notes for the news updates and staff dashboard.
+- **Why:** Give contributors a single reference for configuring the member-only experience locally, matching the recent auth feature work.
+- **Files:** `.env.example`, `apps/www/README.md`.
+- **Follow-ups:** None.

--- a/apps/www/README.md
+++ b/apps/www/README.md
@@ -1,4 +1,4 @@
-# Unkey Landing Page
+# TransformAI Marketing Site (www)
 
 ## Local Development
 
@@ -12,6 +12,33 @@ or from the www directory:
 ```bash
 pnpm run dev
 ```
+
+## Authentication, database, and migrations
+
+The marketing app now persists member accounts so clients can access the news updates area and staff can reach the internal dashboard.
+
+1. **Provision PostgreSQL.** Create a database (Neon, Supabase, local Docker, etc.) and capture the connection string.
+2. **Set environment variables.** Copy `.env.example` in the repo root to `.env.local` and populate:
+   - `DATABASE_URL` – the connection string created in step 1.
+   - `AUTH_SECRET` – a long random string used by NextAuth.
+   - `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` – OAuth credentials for the Google sign-in option (set the callback URL to `<base-url>/api/auth/callback/google`).
+   - `NEXTAUTH_URL` – the URL the app runs on locally (usually `http://localhost:3000`).
+3. **Install dependencies** if you have not already: `pnpm -w install`.
+4. **Apply the database schema** by running migrations from the repo root:
+
+   ```bash
+   pnpm --filter www run db:migrate
+   ```
+
+   To create new migrations, use `pnpm --filter www run db:generate` and commit the generated files in `apps/www/drizzle/migrations`.
+5. **Start the dev server:** `pnpm --filter www dev`.
+
+### Role-aware sign-up flow
+
+- The global navigation’s “Create Account” button routes visitors to `/[locale]/sign-up` where they can register with Google or email.
+- Visitors who click the small “Staff” button in the upper-left corner of the form and enter the access code `Cake2025` are tagged as `staff`; all other sign-ups default to the `client` role.
+- Successful registration (email or Google) redirects clients to `/[locale]/newsupdates` and staff to `/[locale]/dashboard` after the post-sign-in handoff.
+- The staff dashboard tracks the total number of client and staff accounts in real time using the shared PostgreSQL database.
 
 ## Contact form configuration
 


### PR DESCRIPTION
## Summary
- annotate `.env.example` with explanations for the PostgreSQL, NextAuth, and Google OAuth variables that power the member areas.
- expand `apps/www/README.md` with step-by-step instructions for provisioning Postgres, running Drizzle migrations, and explaining the client vs. staff flows.
- log the documentation refresh in `WRITE_HERE/UPDATES` so contributors can trace the new setup guidance.

## Plan
- review the existing authentication/database implementation to identify the configuration touch points that need documentation.
- update the developer docs and env template to cover database provisioning, migrations, and role-based redirects for the news updates and dashboard.
- record the documentation adjustments in the project updates ledger for future reference.

## Testing
- ❌ `pnpm --filter www run lint` *(fails because of pre-existing lint errors in unrelated components; see chunk b26a7a†L1-L82)*

------
https://chatgpt.com/codex/tasks/task_e_68de23a68104832a9f611d418e35c0ee