### PR TITLE
Fix auth redirect locale handling and add members account cards

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-28T1030--auth-post-signin-navigation-continue.md
+++ b/WRITE_HERE/FIXES/2025-11-28T1030--auth-post-signin-navigation-continue.md
@@ -1,0 +1,5 @@
+# Fix post-sign-in redirect locale duplication and add account chooser
+- **What:** Ensured auth flows route through the locale-aware post-sign-in page without duplicating the locale segment, added cookie-backed account history tracking, and surfaced "continue as" cards in the members menu.
+- **Why:** Signing up pushed visitors to `/en/en/auth/post-signin`, yielding a blank screen, and returning members lacked a quick way to jump back into their active accounts from the navigation.
+- **Files:** `apps/www/app/[locale]/(site)/auth/post-signin/*`, `apps/www/components/auth/sign-in-form.tsx`, `apps/www/components/auth/sign-up-form.tsx`, `apps/www/components/navbar/navigation.tsx`, `apps/www/hooks/use-account-history.ts`, `apps/www/lib/account-history.ts`, `apps/www/messages/{en,nl}.json`.
+- **Follow-ups:** Consider clearing the signup intent cookie once consumed and explore persisting account avatars to enhance the chooser.

--- a/apps/www/app/[locale]/(site)/auth/post-signin/page.tsx
+++ b/apps/www/app/[locale]/(site)/auth/post-signin/page.tsx
@@ -2,9 +2,12 @@ import { eq } from "drizzle-orm";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { RedirectGate } from "./redirect-gate";
+
 import { getAuthSession } from "@/lib/auth";
 import { db } from "@/lib/db/client";
 import { users } from "@/lib/db/schema";
+import type { AccountHistoryInput } from "@/lib/account-history";
 
 interface PageProps {
   params: {
@@ -16,11 +19,17 @@ export default async function PostSignInPage({ params }: PageProps) {
   const session = await getAuthSession();
   const locale = params.locale;
 
-  if (!session?.user?.id) {
+  if (!session?.user?.id || !session.user.email) {
     redirect(`/${locale}/sign-in`);
   }
 
   const intent = cookies().get("transformai_signup_role")?.value;
+  const account: AccountHistoryInput = {
+    id: session.user.id,
+    email: session.user.email,
+    name: session.user.name ?? null,
+    role: session.user.role === "staff" ? "staff" : "client",
+  };
 
   if (intent === "staff") {
     await db
@@ -28,12 +37,10 @@ export default async function PostSignInPage({ params }: PageProps) {
       .set({ role: "staff", updatedAt: new Date() })
       .where(eq(users.id, session.user.id));
 
-    redirect(`/${locale}/dashboard`);
+    account.role = "staff";
   }
 
-  if (session.user.role === "staff") {
-    redirect(`/${locale}/dashboard`);
-  }
+  const targetPath = account.role === "staff" ? `/${locale}/dashboard` : `/${locale}/newsupdates`;
 
-  redirect(`/${locale}/newsupdates`);
+  return <RedirectGate targetPath={targetPath} account={account} />;
 }

--- a/apps/www/app/[locale]/(site)/auth/post-signin/redirect-gate.tsx
+++ b/apps/www/app/[locale]/(site)/auth/post-signin/redirect-gate.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { useRouter } from "@/i18n/navigation";
+import { rememberAccount, type AccountHistoryInput } from "@/lib/account-history";
+
+interface RedirectGateProps {
+  targetPath: string;
+  account: AccountHistoryInput;
+}
+
+export function RedirectGate({ targetPath, account }: RedirectGateProps) {
+  const router = useRouter();
+  const t = useTranslations("Auth.PostSignIn");
+  const hasRedirected = useRef(false);
+
+  useEffect(() => {
+    if (hasRedirected.current) {
+      return;
+    }
+
+    hasRedirected.current = true;
+    rememberAccount(account);
+    router.replace(targetPath);
+  }, [account, router, targetPath]);
+
+  const displayName = account.name?.trim() || account.email;
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-black text-white">
+      <Loader2 className="h-6 w-6 animate-spin text-sky-400" aria-hidden />
+      <p className="text-sm text-white/60">{t("redirecting", { name: displayName })}</p>
+    </div>
+  );
+}

--- a/apps/www/components/auth/sign-in-form.tsx
+++ b/apps/www/components/auth/sign-in-form.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { signIn } from "next-auth/react";
 import { Loader2, LogIn } from "lucide-react";
-import { useLocale, useTranslations } from "next-intl";
+import { useTranslations } from "next-intl";
 
 import { useRouter } from "@/i18n/navigation";
 import { Button } from "@/components/ui/button";
@@ -12,7 +12,6 @@ import { Label } from "@/components/ui/label";
 
 export function SignInForm() {
   const t = useTranslations("Auth.SignIn");
-  const locale = useLocale();
   const router = useRouter();
 
   const [email, setEmail] = useState("");
@@ -26,7 +25,7 @@ export function SignInForm() {
     setIsGoogleSubmitting(true);
 
     await signIn("google", {
-      callbackUrl: `/${locale}/auth/post-signin`,
+      callbackUrl: "/auth/post-signin",
     });
   };
 
@@ -39,7 +38,7 @@ export function SignInForm() {
       email: email.trim(),
       password,
       redirect: false,
-      callbackUrl: `/${locale}/auth/post-signin`,
+      callbackUrl: "/auth/post-signin",
     });
 
     if (!result || result.error) {
@@ -48,7 +47,17 @@ export function SignInForm() {
       return;
     }
 
-    router.push(result.url ?? `/${locale}/auth/post-signin`);
+    let destination = "/auth/post-signin";
+    if (result.url) {
+      try {
+        const parsed = new URL(result.url);
+        destination = parsed.pathname + parsed.search + parsed.hash;
+      } catch {
+        destination = result.url;
+      }
+    }
+
+    router.push(destination);
   };
 
   const disableButtons = isSubmitting || isGoogleSubmitting;
@@ -156,7 +165,7 @@ export function SignInForm() {
         <button
           type="button"
           className="font-semibold text-white transition hover:text-white/80"
-          onClick={() => router.push(`/${locale}/create-account`)}
+          onClick={() => router.push("/create-account")}
           disabled={disableButtons}
         >
           {t("ctaLink")}

--- a/apps/www/components/auth/sign-up-form.tsx
+++ b/apps/www/components/auth/sign-up-form.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { signIn } from "next-auth/react";
 import { Loader2, Lock, Check } from "lucide-react";
-import { useLocale, useTranslations } from "next-intl";
+import { useTranslations } from "next-intl";
 
 import { useRouter } from "@/i18n/navigation";
 import { Button } from "@/components/ui/button";
@@ -24,7 +24,6 @@ const REGISTER_ENDPOINT = "/api/auth/register";
 
 export function SignUpForm() {
   const t = useTranslations("Auth.SignUp");
-  const locale = useLocale();
   const router = useRouter();
 
   const [name, setName] = useState("");
@@ -94,7 +93,7 @@ export function SignUpForm() {
       }
 
       await signIn("google", {
-        callbackUrl: `/${locale}/auth/post-signin`,
+        callbackUrl: "/auth/post-signin",
       });
     } catch (intentError) {
       setError(intentError instanceof Error ? intentError.message : t("errors.intentFailed"));
@@ -166,7 +165,7 @@ export function SignUpForm() {
         return;
       }
 
-      router.push(`/${locale}/auth/post-signin`);
+      router.push("/auth/post-signin");
     } catch (submitError) {
       setError(submitError instanceof Error ? submitError.message : t("errors.generic"));
       setIsSubmitting(false);
@@ -372,7 +371,7 @@ export function SignUpForm() {
         <button
           type="button"
           className="font-semibold text-white transition hover:text-white/80"
-          onClick={() => router.push(`/${locale}/sign-in`)}
+          onClick={() => router.push("/sign-in")}
           disabled={disableSubmit}
         >
           {t("signInLink")}

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -9,6 +9,7 @@ import {
   DrawerTrigger,
 } from "@/components/ui/drawer";
 import { Link, usePathname } from "@/i18n/navigation";
+import { useAccountHistory } from "@/hooks/use-account-history";
 import { cn } from "@/lib/utils";
 import { useConsentManager } from "@c15t/nextjs";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
@@ -103,6 +104,7 @@ function MembersMenu({ className }: { className?: string }) {
   const { hasConsentFor } = useConsentManager();
   const [open, setOpen] = useState(false);
   const contentId = "members-menu";
+  const accounts = useAccountHistory();
 
   return (
     <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
@@ -127,30 +129,59 @@ function MembersMenu({ className }: { className?: string }) {
           "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         )}
       >
-        <nav className="flex flex-col gap-2" aria-label={t("members")}>
-          <MembersMenuLink
-            href="/create-account"
-            label={t("createAccount")}
-            description={t("membersMenu.createAccountDescription")}
-            icon={UserPlus}
-            onClick={() => {
-              setOpen(false);
-              if (hasConsentFor("measurement")) {
-                track("signup", { location: "navigation" });
-              }
-            }}
-          />
-          <MembersMenuLink
-            href="/sign-in"
-            label={t("signIn")}
-            description={t("membersMenu.signInDescription")}
-            icon={LogIn}
-            onClick={() => {
-              setOpen(false);
-              track("signin", { location: "navigation" });
-            }}
-          />
-        </nav>
+        <div className="flex flex-col gap-3">
+          {accounts.length > 0 ? (
+            <div role="group" aria-label={t("membersMenu.continueHeading")} className="flex flex-col gap-2">
+              <p className="px-1 text-[10px] font-semibold uppercase tracking-[0.32em] text-white/50">
+                {t("membersMenu.continueHeading")}
+              </p>
+              <div className="flex flex-col gap-2">
+                {accounts.map((account) => (
+                  <MembersAccountLink
+                    key={account.id}
+                    href={account.role === "staff" ? "/dashboard" : "/newsupdates"}
+                    name={account.name?.trim() || account.email}
+                    subtitle={
+                      account.role === "staff"
+                        ? t("membersMenu.continueRole.staff")
+                        : t("membersMenu.continueRole.client")
+                    }
+                    onClick={() => {
+                      setOpen(false);
+                      if (hasConsentFor("measurement")) {
+                        track("members-continue", { role: account.role, surface: "navigation" });
+                      }
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
+          <nav className="flex flex-col gap-2" aria-label={t("members")}>
+            <MembersMenuLink
+              href="/create-account"
+              label={t("createAccount")}
+              description={t("membersMenu.createAccountDescription")}
+              icon={UserPlus}
+              onClick={() => {
+                setOpen(false);
+                if (hasConsentFor("measurement")) {
+                  track("signup", { location: "navigation" });
+                }
+              }}
+            />
+            <MembersMenuLink
+              href="/sign-in"
+              label={t("signIn")}
+              description={t("membersMenu.signInDescription")}
+              icon={LogIn}
+              onClick={() => {
+                setOpen(false);
+                track("signin", { location: "navigation" });
+              }}
+            />
+          </nav>
+        </div>
       </PopoverPrimitive.Content>
     </PopoverPrimitive.Root>
   );
@@ -165,6 +196,7 @@ const MembersDrawerMenu = ({ onNavigate }: MembersDrawerMenuProps) => {
   const { hasConsentFor } = useConsentManager();
   const [open, setOpen] = useState(false);
   const menuId = "drawer-members-menu";
+  const accounts = useAccountHistory();
 
   return (
     <div className="w-full">
@@ -179,7 +211,36 @@ const MembersDrawerMenu = ({ onNavigate }: MembersDrawerMenuProps) => {
         aria-haspopup="menu"
       />
       {open ? (
-        <div id={menuId} className="mt-3 flex flex-col gap-2" role="menu" aria-label={t("members")}>
+        <div id={menuId} className="mt-3 flex flex-col gap-3" role="menu" aria-label={t("members")}>
+          {accounts.length > 0 ? (
+            <div role="group" aria-label={t("membersMenu.continueHeading")} className="flex flex-col gap-2">
+              <p className="px-1 text-[10px] font-semibold uppercase tracking-[0.32em] text-white/50">
+                {t("membersMenu.continueHeading")}
+              </p>
+              <div className="flex flex-col gap-2">
+                {accounts.map((account) => (
+                  <MembersAccountLink
+                    key={account.id}
+                    href={account.role === "staff" ? "/dashboard" : "/newsupdates"}
+                    name={account.name?.trim() || account.email}
+                    subtitle={
+                      account.role === "staff"
+                        ? t("membersMenu.continueRole.staff")
+                        : t("membersMenu.continueRole.client")
+                    }
+                    className="border-white/10 bg-white/5"
+                    onClick={() => {
+                      setOpen(false);
+                      onNavigate();
+                      if (hasConsentFor("measurement")) {
+                        track("members-continue", { role: account.role, surface: "navigation-mobile" });
+                      }
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
           <MembersMenuLink
             href="/create-account"
             label={t("createAccount")}
@@ -238,6 +299,34 @@ function MembersMenuLink({ href, label, description, icon: Icon, className, onCl
           {label}
         </span>
         <span className="text-xs text-white/60">{description}</span>
+      </span>
+      <ChevronRight className="h-4 w-4 shrink-0 translate-x-0 text-white/50 transition group-hover:translate-x-1 group-hover:text-white/80" />
+    </Link>
+  );
+}
+
+type MembersAccountLinkProps = {
+  href: string;
+  name: string;
+  subtitle: string;
+  className?: string;
+  onClick?: () => void;
+};
+
+function MembersAccountLink({ href, name, subtitle, className, onClick }: MembersAccountLinkProps) {
+  return (
+    <Link
+      href={href}
+      onClick={onClick}
+      role="menuitem"
+      className={cn(
+        "group flex w-full items-center justify-between gap-3 rounded-xl border border-white/15 bg-white/8 px-4 py-3 text-left text-sm text-white transition hover:border-white/25 hover:bg-white/12 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70 focus-visible:ring-offset-2 focus-visible:ring-offset-black",
+        className,
+      )}
+    >
+      <span className="flex flex-col text-left">
+        <span className="font-semibold text-white">{name}</span>
+        <span className="text-xs text-white/60">{subtitle}</span>
       </span>
       <ChevronRight className="h-4 w-4 shrink-0 translate-x-0 text-white/50 transition group-hover:translate-x-1 group-hover:text-white/80" />
     </Link>

--- a/apps/www/hooks/use-account-history.ts
+++ b/apps/www/hooks/use-account-history.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  ACCOUNT_HISTORY_EVENT,
+  type AccountHistoryEntry,
+  getAccountHistoryFromDocument,
+} from "@/lib/account-history";
+
+export function useAccountHistory() {
+  const [accounts, setAccounts] = useState<AccountHistoryEntry[]>([]);
+
+  useEffect(() => {
+    const update = () => {
+      setAccounts(getAccountHistoryFromDocument());
+    };
+
+    update();
+    window.addEventListener(ACCOUNT_HISTORY_EVENT, update);
+    return () => {
+      window.removeEventListener(ACCOUNT_HISTORY_EVENT, update);
+    };
+  }, []);
+
+  return accounts;
+}

--- a/apps/www/lib/account-history.ts
+++ b/apps/www/lib/account-history.ts
@@ -1,0 +1,105 @@
+export const ACCOUNT_HISTORY_COOKIE = "transformai_recent_accounts";
+export const ACCOUNT_HISTORY_EVENT = "transformai:account-history-updated";
+export const ACCOUNT_HISTORY_MAX_ENTRIES = 3;
+
+export type AccountHistoryEntry = {
+  id: string;
+  email: string;
+  name?: string | null;
+  role: "client" | "staff";
+  lastActiveAt: string;
+};
+
+export type AccountHistoryInput = Omit<AccountHistoryEntry, "lastActiveAt"> & {
+  lastActiveAt?: string;
+};
+
+function readCookieValue(name: string): string | undefined {
+  if (typeof document === "undefined") {
+    return undefined;
+  }
+
+  const prefix = `${name}=`;
+  const cookies = document.cookie.split("; ");
+  for (const cookie of cookies) {
+    if (cookie.startsWith(prefix)) {
+      return decodeURIComponent(cookie.slice(prefix.length));
+    }
+  }
+  return undefined;
+}
+
+function writeCookieValue(name: string, value: string, maxAgeSeconds: number) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const sameSite = "SameSite=Lax";
+  const path = "path=/";
+  document.cookie = `${name}=${encodeURIComponent(value)}; ${path}; Max-Age=${maxAgeSeconds}; ${sameSite}`;
+}
+
+function sanitizeEntries(entries: AccountHistoryEntry[]): AccountHistoryEntry[] {
+  return entries
+    .filter((entry) => Boolean(entry?.id) && Boolean(entry?.email))
+    .map((entry) => ({
+      ...entry,
+      name: entry.name ?? null,
+      role: entry.role === "staff" ? "staff" : "client",
+      lastActiveAt: entry.lastActiveAt ?? new Date(0).toISOString(),
+    }))
+    .sort((a, b) => new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime())
+    .slice(0, ACCOUNT_HISTORY_MAX_ENTRIES);
+}
+
+export function parseAccountHistory(raw?: string): AccountHistoryEntry[] {
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return sanitizeEntries(parsed as AccountHistoryEntry[]);
+  } catch {
+    return [];
+  }
+}
+
+export function getAccountHistoryFromDocument(): AccountHistoryEntry[] {
+  const raw = readCookieValue(ACCOUNT_HISTORY_COOKIE);
+  return parseAccountHistory(raw);
+}
+
+export function rememberAccount(entry: AccountHistoryInput) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const existing = getAccountHistoryFromDocument();
+  const now = entry.lastActiveAt ?? new Date().toISOString();
+  const normalizedId = entry.id || entry.email.toLowerCase();
+
+  const filtered = existing.filter((account) => {
+    const accountId = account.id || account.email.toLowerCase();
+    return accountId !== normalizedId;
+  });
+
+  const nextEntries: AccountHistoryEntry[] = sanitizeEntries([
+    { ...entry, lastActiveAt: now },
+    ...filtered,
+  ]);
+
+  writeCookieValue(
+    ACCOUNT_HISTORY_COOKIE,
+    JSON.stringify(nextEntries),
+    60 * 60 * 24 * 30,
+  );
+
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(ACCOUNT_HISTORY_EVENT));
+  }
+}

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -22,7 +22,12 @@
     "language": "Language",
     "membersMenu": {
       "createAccountDescription": "Join TransformAI to unlock member resources.",
-      "signInDescription": "Access your dashboard and ongoing projects."
+      "signInDescription": "Access your dashboard and ongoing projects.",
+      "continueHeading": "Continue where you left off",
+      "continueRole": {
+        "client": "Members hub",
+        "staff": "Staff workspace"
+      }
     },
     "links": {
       "home": "Home",
@@ -1014,6 +1019,9 @@
       "errors": {
         "invalid": "We couldn’t match those credentials. Try again."
       }
+    },
+    "PostSignIn": {
+      "redirecting": "Redirecting you, {name}…"
     }
   },
   "NewsUpdates": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -22,7 +22,12 @@
     "language": "Taal",
     "membersMenu": {
       "createAccountDescription": "Meld je aan om toegang te krijgen tot onze ledenomgeving.",
-      "signInDescription": "Log in voor je dashboard en lopende trajecten."
+      "signInDescription": "Log in voor je dashboard en lopende trajecten.",
+      "continueHeading": "Ga verder waar je gebleven was",
+      "continueRole": {
+        "client": "Ledenomgeving",
+        "staff": "Teamdashboard"
+      }
     },
     "links": {
       "home": "Home",
@@ -971,6 +976,9 @@
       "errors": {
         "invalid": "We konden deze inloggegevens niet vinden. Probeer het opnieuw."
       }
+    },
+    "PostSignIn": {
+      "redirecting": "Bezig met doorsturen, {name}…"
     }
   },
   "NewsUpdates": {


### PR DESCRIPTION
## Summary
- route every sign-up and sign-in flow through a client redirect gate so locale-prefixed paths no longer duplicate and sign-ins reach the right destination
- remember recently active accounts in a cookie and render “continue as” cards inside the members menu on desktop and mobile navigation
- add shared account-history utilities, translations, and a fix log entry documenting the auth/navigation updates

## Plan
- refactor the post-sign-in step so we can run client logic before redirecting and adjust auth forms to use locale-aware paths
- persist lightweight account metadata in a cookie after login and expose it via a reusable hook
- surface the stored accounts inside the members menu with translated labels for client and staff destinations, covering desktop and mobile layouts

## Testing
- `pnpm --filter www run lint` *(fails: next lint cannot resolve the next-intl package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de60c2ae6c832aa16865297382d5d5