### PR TITLE
Ensure unavailable meeting blocks stay visible

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-28T1530--staff-planner-syntax-fix.md
+++ b/WRITE_HERE/FIXES/2025-11-28T1530--staff-planner-syntax-fix.md
@@ -1,0 +1,6 @@
+# Restore staff planner JSX closure
+- **What:** Removed an extra JSX closing fragment in the staff planning component that prevented the dashboard planning page fr
+  om compiling.
+- **Why:** The stray `);` + `}` pair introduced a syntax error that crashed the staff planner route when loading in staff mode.
+- **Files:** `apps/www/app/[locale]/(site)/dashboard/planning/components/planner.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-28T1700--meeting-unavailable-visibility.md
+++ b/WRITE_HERE/FIXES/2025-11-28T1700--meeting-unavailable-visibility.md
@@ -1,0 +1,5 @@
+# Ensure unavailable meeting blocks remain visible
+- **What:** Count unavailable but published meeting blocks in the day summaries, surface blocked counts in the staff planner metrics, and extend the legend/translations so staff and visitors can see when time has been intentionally blocked.
+- **Why:** Unavailable slots were omitted from totals, causing public visitors and staff planners to miss those blocked windows even though they should signal limited availability.
+- **Files:** `apps/www/lib/meetings/queries.ts`, `apps/www/app/[locale]/(site)/dashboard/planning/components/planner.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Consider exposing unavailable block counts on the public day cards if users request more explicit labelling.

--- a/WRITE_HERE/TASK_PLANNING/2025-11-28T0000--meeting-scheduler.md
+++ b/WRITE_HERE/TASK_PLANNING/2025-11-28T0000--meeting-scheduler.md
@@ -1,0 +1,55 @@
+# Meeting scheduler feature
+
+## Scope
+- Add public meeting scheduling page at /meeting with 2-week availability view, booking form, and success messaging.
+- Persist meeting slots and bookings in database; ensure booking toggles availability.
+- Enhance staff dashboard overview with upcoming meetings list and build planning tab with editable calendar including slot CRUD.
+- Provide staff interface to adjust slot duration in 15-minute increments, update metadata (description, assigned staff), and delete slots.
+- Keep UI consistent with site design, support EN/NL translations.
+
+## Assumptions
+- Meetings occur in a single timezone (use Europe/Amsterdam display) and durations manageable via 15-minute increments.
+- One booking per slot; slot removal implies availability removal.
+- Staff identified via existing users table; assigned staff optional and displayed by name.
+- Email notifications/actual Zoom links out of scope; success message suffices.
+
+## Risks & Mitigations
+- **Complex drag interactions**: Build custom 15-minute grid with pointer events; provide keyboard-accessible fallback controls.
+- **Concurrency**: Add transactional guard when booking to prevent double booking.
+- **Timezones**: Normalize to UTC in DB, format using locale/timezone on display.
+- **Performance**: Limit queries to 14-day window and use server actions with revalidation.
+
+## Dependencies
+- Drizzle schema update + migration file.
+- New API/server actions for slots and bookings management.
+- Translations in messages/en.json and nl.json.
+
+## TODOs
+- [x] Extend schema with meeting_slots + meeting_bookings tables, add migration.
+- [x] Create shared utilities/types for scheduler.
+- [x] Build public meeting page (server data fetch, client calendar + form, server action for booking).
+- [ ] Update navigation or routes to include meeting page.
+- [x] Enhance staff dashboard overview metrics with meetings list.
+- [x] Implement staff planning route with interactive grid, including polished creation/resizing + mutation handling.
+- [x] Wire translations for new copy (ensure Dutch parity).
+- [x] Document update in WRITE_HERE/UPDATES.
+- [ ] Run lint/typecheck (blocked by legacy violations in careers/startups/auth modules).
+- [ ] Capture screenshot of meeting page.
+
+### Current focus (2025-11-28)
+- Track upstream lint/typecheck failures so we can resolve or document exclusions.
+- QA staff planner interactions across DST boundaries and confirm day-bound limits before launch.
+- Prepare visual assets (screenshots/demo) for meeting scheduler once QA completes.
+
+## Testing Plan
+- pnpm --filter www run lint
+- pnpm --filter www run typecheck
+- Manual verification in dev server (public meeting booking, staff planning edits).
+
+## Considerations
+- **Accessibility**: Ensure focusable controls, announce statuses, color contrast for availability indicators.
+- **Responsiveness**: Calendar adapts to mobile (list view) and desktop (grid).
+- **Internationalization**: Use translation keys; format dates via locale.
+- **SEO**: Provide page metadata; ensure headings semantic.
+- **Analytics**: Optionally track bookings (defer).
+- **Polish**: Use gradient backgrounds consistent with design system.

--- a/WRITE_HERE/UPDATES/2025-11-28T1030--meeting-planner-finalization.md
+++ b/WRITE_HERE/UPDATES/2025-11-28T1030--meeting-planner-finalization.md
@@ -1,0 +1,5 @@
+# Meeting planner timezone and translation polish
+- **What:** Hardened the staff planning grid with timezone-aware dragging/resizing, prevented deletion of booked slots, surfaced actionable error messaging, and filled in Dutch translations for the Planning interface. Also added reusable utilities for meeting day bounds/minute conversions.
+- **Why:** Drag interactions were susceptible to DST offsets and server mutations allowed removing confirmed meetings; Dutch strings were missing for the new planner.
+- **Files:** `apps/www/app/[locale]/(site)/dashboard/planning/components/planner.tsx`, `apps/www/lib/meetings/utils.ts`, `apps/www/lib/meetings/mutations.ts`, `apps/www/app/[locale]/(site)/dashboard/planning/actions.ts`, `apps/www/messages/{en,nl}.json`.
+- **Follow-ups:** Investigate global lint/typecheck failures flagged in existing startup/auth modules; consider adding automated tests around meeting slot CRUD.

--- a/apps/www/app/[locale]/(site)/dashboard/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/page.tsx
@@ -2,6 +2,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getAuthSession } from "@/lib/auth";
 import { db } from "@/lib/db/client";
 import { users } from "@/lib/db/schema";
+import { formatDateWithZone } from "@/lib/date";
+import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
+import { getUpcomingMeetings } from "@/lib/meetings/queries";
 import { cn } from "@/lib/utils";
 import { sql } from "drizzle-orm";
 import { getTranslations } from "next-intl/server";
@@ -35,6 +38,8 @@ export default async function DashboardPage({ params }: PageProps) {
   for (const row of roleCounts) {
     totals[row.role] = Number(row.total);
   }
+
+  const upcomingMeetings = await getUpcomingMeetings(8);
 
   const metrics = [
     {
@@ -99,7 +104,84 @@ export default async function DashboardPage({ params }: PageProps) {
           ))}
         </div>
 
-        <div className="mt-16 rounded-2xl border border-white/10 bg-black/40 p-8 text-sm leading-relaxed text-white/70">
+        <div className="mt-16 space-y-6">
+          <div>
+            <h2 className="text-xl font-semibold text-white">
+              {t("meetings.title")}
+            </h2>
+            {upcomingMeetings.length === 0 ? (
+              <p className="mt-4 rounded-2xl border border-white/10 bg-white/[0.05] p-4 text-sm text-white/70">
+                {t("meetings.empty")}
+              </p>
+            ) : (
+              <div className="mt-4 grid gap-4">
+                {upcomingMeetings.map((meeting) => {
+                  const startLabel = formatDateWithZone(
+                    meeting.startAt,
+                    {
+                      weekday: "short",
+                      day: "numeric",
+                      month: "long",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    },
+                    locale,
+                    MEETING_TIME_ZONE,
+                  );
+                  const endLabel = formatDateWithZone(
+                    meeting.endAt,
+                    { hour: "2-digit", minute: "2-digit" },
+                    locale,
+                    MEETING_TIME_ZONE,
+                  );
+                  const contactLines = [
+                    meeting.personName,
+                    meeting.company,
+                    meeting.email,
+                  ].filter(Boolean);
+
+                  return (
+                    <div
+                      key={meeting.slotId}
+                      className="rounded-2xl border border-white/10 bg-white/[0.04] p-5 text-sm text-white/80"
+                    >
+                      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                        <DashboardMeetingField
+                          label={t("meetings.fields.when")}
+                          value={`${startLabel} – ${endLabel}`}
+                        />
+                        <DashboardMeetingField
+                          label={t("meetings.fields.reason")}
+                          value={meeting.reason}
+                        />
+                        <DashboardMeetingField
+                          label={t("meetings.fields.contact")}
+                          value={contactLines.join(" • ")}
+                        />
+                        <DashboardMeetingField
+                          label={t("meetings.fields.staff")}
+                          value={meeting.assignedStaffName ?? "–"}
+                        />
+                      </div>
+                      {meeting.publicDescription ? (
+                        <div className="mt-4 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 text-xs text-white/70">
+                          <p className="font-semibold uppercase tracking-[0.3em] text-white/50">
+                            {t("meetings.fields.notes")}
+                          </p>
+                          <p className="mt-1 leading-relaxed text-white/70">
+                            {meeting.publicDescription}
+                          </p>
+                        </div>
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-white/10 bg-black/40 p-8 text-sm leading-relaxed text-white/70">
           <h2 className="text-xl font-semibold text-white">{t("nextSteps.title")}</h2>
           <ul className="mt-4 space-y-3 text-sm text-white/70">
             <li>{t("nextSteps.items.audit")}</li>
@@ -108,6 +190,22 @@ export default async function DashboardPage({ params }: PageProps) {
           </ul>
         </div>
       </div>
+    </div>
+  );
+}
+
+type DashboardMeetingFieldProps = {
+  label: string;
+  value: string;
+};
+
+function DashboardMeetingField({ label, value }: DashboardMeetingFieldProps) {
+  return (
+    <div className="space-y-2">
+      <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+        {label}
+      </p>
+      <p className="text-sm text-white/80">{value}</p>
     </div>
   );
 }

--- a/apps/www/app/[locale]/(site)/dashboard/planning/actions.ts
+++ b/apps/www/app/[locale]/(site)/dashboard/planning/actions.ts
@@ -1,0 +1,128 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import type { MeetingSlotStatus } from "@/lib/db/schema";
+import { createMeetingSlot, updateMeetingSlot, deleteMeetingSlot } from "@/lib/meetings/mutations";
+import { getSlotById } from "@/lib/meetings/queries";
+
+export type SerializedMeetingSlot = {
+  id: string;
+  startAt: string;
+  endAt: string;
+  status: MeetingSlotStatus;
+  isPublished: boolean;
+  publicDescription?: string | null;
+  assignedStaffId?: string | null;
+  assignedStaffName?: string | null;
+  hasBooking: boolean;
+  booking?: {
+    personName: string;
+    email: string;
+    company?: string | null;
+    reason: string;
+    description?: string | null;
+  } | null;
+};
+
+function serializeSlot(slot: Awaited<ReturnType<typeof getSlotById>>): SerializedMeetingSlot | null {
+  if (!slot) {
+    return null;
+  }
+
+  return {
+    id: slot.id,
+    startAt: slot.startAt.toISOString(),
+    endAt: slot.endAt.toISOString(),
+    status: slot.status,
+    isPublished: slot.isPublished,
+    publicDescription: slot.publicDescription,
+    assignedStaffId: slot.assignedStaffId ?? null,
+    assignedStaffName: slot.assignedStaffName ?? slot.assignedStaff?.name ?? null,
+    hasBooking: Boolean(slot.booking),
+    booking: slot.booking
+      ? {
+          personName: slot.booking.personName,
+          email: slot.booking.email,
+          company: slot.booking.company,
+          reason: slot.booking.reason,
+          description: slot.booking.description,
+        }
+      : null,
+  };
+}
+
+export async function createSlotAction(
+  locale: string,
+  payload: {
+    startAt: string;
+    endAt: string;
+    status?: MeetingSlotStatus;
+    publicDescription?: string;
+    assignedStaffId?: string;
+    assignedStaffName?: string;
+    isPublished?: boolean;
+  },
+) {
+  const result = await createMeetingSlot(payload);
+
+  if (!result.success) {
+    return {
+      success: false as const,
+      error: result.error ?? "validation",
+      issues: result.issues,
+    };
+  }
+
+  await revalidatePath(`/${locale}/dashboard/planning`);
+
+  return {
+    success: true as const,
+    slot: serializeSlot(result.slot) ?? null,
+  };
+}
+
+export async function updateSlotAction(
+  locale: string,
+  payload: {
+    slotId: string;
+    startAt: string;
+    endAt: string;
+    status?: MeetingSlotStatus;
+    publicDescription?: string;
+    assignedStaffId?: string;
+    assignedStaffName?: string;
+    isPublished?: boolean;
+  },
+) {
+  const result = await updateMeetingSlot(payload);
+
+  if (!result.success) {
+    return {
+      success: false as const,
+      error: result.error ?? "validation",
+      issues: result.issues,
+    };
+  }
+
+  await revalidatePath(`/${locale}/dashboard/planning`);
+
+  return {
+    success: true as const,
+    slot: serializeSlot(result.slot) ?? null,
+  };
+}
+
+export async function deleteSlotAction(locale: string, slotId: string) {
+  const result = await deleteMeetingSlot(slotId);
+
+  if (!result.success) {
+    return {
+      success: false as const,
+      error: result.error ?? "unknown",
+    };
+  }
+
+  await revalidatePath(`/${locale}/dashboard/planning`);
+  return { success: true as const };
+}

--- a/apps/www/app/[locale]/(site)/dashboard/planning/components/planner.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/planning/components/planner.tsx
@@ -1,0 +1,950 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
+import {
+  Building2,
+  CalendarDays,
+  Loader2,
+  Mail,
+  MessageSquare,
+  ShieldAlert,
+  Trash2,
+  Users,
+} from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+
+import type { MeetingSlotStatus } from "@/lib/db/schema";
+import { formatDateWithZone } from "@/lib/date";
+import {
+  MEETING_SLOT_INCREMENT_MINUTES,
+  MEETING_TIME_ZONE,
+} from "@/lib/meetings/constants";
+import {
+  getMeetingDateKey,
+  getMeetingDayLengthMinutes,
+  getMeetingMinutesFromIso,
+  meetingMinutesToIso,
+} from "@/lib/meetings/utils";
+
+import { cn } from "@/lib/utils";
+
+import {
+  createSlotAction,
+  deleteSlotAction,
+  updateSlotAction,
+  type SerializedMeetingSlot,
+} from "../actions";
+
+const PIXELS_PER_MINUTE = 1.2;
+const SNAP_MINUTES = MEETING_SLOT_INCREMENT_MINUTES;
+
+const slotColorMap: Record<MeetingSlotStatus, string> = {
+  available: "bg-emerald-500/20 border-emerald-400/70",
+  booked: "bg-rose-500/25 border-rose-400/70",
+  unavailable: "bg-slate-500/20 border-slate-400/60",
+};
+
+const dayStatusDotMap: Record<PlannerDay["status"], string> = {
+  available: "bg-emerald-400",
+  limited: "bg-amber-400",
+  full: "bg-rose-500",
+};
+
+const dayStatusHighlightMap: Record<PlannerDay["status"], string> = {
+  available: "shadow-[0_14px_48px_rgba(16,185,129,0.25)]",
+  limited: "shadow-[0_14px_48px_rgba(251,191,36,0.25)]",
+  full: "shadow-[0_14px_48px_rgba(244,63,94,0.28)]",
+};
+
+type PlannerSlot = SerializedMeetingSlot & {
+  assignedStaffId?: string | null;
+};
+
+type PlannerDay = {
+  dateKey: string;
+  date: string;
+  availableSlots: number;
+  totalSlots: number;
+  status: "available" | "limited" | "full";
+  slots: PlannerSlot[];
+};
+
+type StaffMember = {
+  id: string;
+  name: string;
+  email: string | null;
+};
+
+type StaffPlannerProps = {
+  days: PlannerDay[];
+  staff: StaffMember[];
+  locale: string;
+};
+
+type DraftRange = {
+  dayKey: string;
+  startMinutes: number;
+  endMinutes: number;
+};
+
+type ResizeDraft = DraftRange & {
+  slotId: string;
+};
+
+type FormState = {
+  assignedStaffId: string;
+  customStaffName: string;
+  publicDescription: string;
+  status: MeetingSlotStatus;
+  isPublished: boolean;
+};
+
+function clampMinutes(value: number, dayLength: number): number {
+  return Math.min(Math.max(value, 0), dayLength);
+}
+
+function snapMinutes(value: number, dayLength: number): number {
+  const snapped = Math.round(value / SNAP_MINUTES) * SNAP_MINUTES;
+  return clampMinutes(snapped, dayLength);
+}
+
+export function StaffPlanner({ days, staff, locale }: StaffPlannerProps) {
+  const t = useTranslations("Planning");
+  const router = useRouter();
+  const [selectedDayKey, setSelectedDayKey] = useState(
+    () => days.find((day) => day.status !== "full")?.dateKey ?? days[0]?.dateKey ?? "",
+  );
+  const [selectedSlotId, setSelectedSlotId] = useState<string | null>(null);
+  const [draft, setDraft] = useState<DraftRange | null>(null);
+  const [resizeDraft, setResizeDraft] = useState<ResizeDraft | null>(null);
+  const [formState, setFormState] = useState<FormState | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selectedDay = useMemo(
+    () => days.find((day) => day.dateKey === selectedDayKey) ?? days[0] ?? null,
+    [days, selectedDayKey],
+  );
+
+  const dayLength = useMemo(
+    () =>
+      selectedDay
+        ? getMeetingDayLengthMinutes(selectedDay.dateKey)
+        : 24 * 60,
+    [selectedDay],
+  );
+
+  const hourLabels = useMemo(() => {
+    const count = Math.floor(dayLength / 60) + 1;
+    return Array.from({ length: count }, (_, index) => index);
+  }, [dayLength]);
+
+  const selectedSlot = useMemo(() => {
+    if (!selectedDay || !selectedSlotId) {
+      return null;
+    }
+    return selectedDay.slots.find((slot) => slot.id === selectedSlotId) ?? null;
+  }, [selectedDay, selectedSlotId]);
+
+  useEffect(() => {
+    if (!selectedDay && days.length > 0) {
+      setSelectedDayKey(days[0].dateKey);
+    }
+  }, [days, selectedDay]);
+
+  useEffect(() => {
+    if (!selectedSlot) {
+      setFormState(null);
+      return;
+    }
+
+    setFormState({
+      assignedStaffId: selectedSlot.assignedStaffId ?? "",
+      customStaffName: selectedSlot.assignedStaffName ?? "",
+      publicDescription: selectedSlot.publicDescription ?? "",
+      status: selectedSlot.status,
+      isPublished: selectedSlot.isPublished,
+    });
+  }, [selectedSlot]);
+
+  const handleBackgroundPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!selectedDay || isPending || event.button !== 0) {
+        return;
+      }
+      if (event.currentTarget !== event.target) {
+        return;
+      }
+      const container = containerRef.current;
+      if (!container) {
+        return;
+      }
+
+      const maxStart = Math.max(0, dayLength - SNAP_MINUTES);
+      const anchorRaw = positionToMinutes(event.clientY, container, dayLength);
+      const anchorSnapped = snapMinutes(anchorRaw, dayLength);
+      const initialStart = Math.min(anchorSnapped, maxStart);
+      const initialEnd = clampMinutes(initialStart + SNAP_MINUTES, dayLength);
+      setDraft({
+        dayKey: selectedDay.dateKey,
+        startMinutes: initialStart,
+        endMinutes: initialEnd,
+      });
+      container.setPointerCapture(event.pointerId);
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        const nextRaw = positionToMinutes(
+          moveEvent.clientY,
+          container,
+          dayLength,
+        );
+        const nextSnapped = snapMinutes(nextRaw, dayLength);
+        const startCandidate = Math.min(initialStart, nextSnapped);
+        const endCandidate = Math.max(initialStart, nextSnapped);
+        const safeStart = Math.min(startCandidate, maxStart);
+        const safeEnd = clampMinutes(
+          Math.max(endCandidate, safeStart + SNAP_MINUTES),
+          dayLength,
+        );
+        setDraft({
+          dayKey: selectedDay.dateKey,
+          startMinutes: safeStart,
+          endMinutes: safeEnd,
+        });
+      };
+
+      const finalize = (finalEvent: PointerEvent) => {
+        container.releasePointerCapture(event.pointerId);
+        container.removeEventListener("pointermove", handleMove);
+        container.removeEventListener("pointerup", finalize);
+        container.removeEventListener("pointercancel", finalize);
+
+        const nextRaw = positionToMinutes(
+          finalEvent.clientY,
+          container,
+          dayLength,
+        );
+        const nextSnapped = snapMinutes(nextRaw, dayLength);
+        const startCandidate = Math.min(initialStart, nextSnapped);
+        const endCandidate = Math.max(initialStart, nextSnapped);
+        const safeStart = Math.min(startCandidate, maxStart);
+        const safeEnd = clampMinutes(
+          Math.max(endCandidate, safeStart + SNAP_MINUTES),
+          dayLength,
+        );
+        setDraft(null);
+
+        startTransition(async () => {
+          setActionError(null);
+          const response = await createSlotAction(locale, {
+            startAt: meetingMinutesToIso(selectedDay.dateKey, safeStart),
+            endAt: meetingMinutesToIso(selectedDay.dateKey, safeEnd),
+            status: "available",
+            isPublished: true,
+          });
+          if (!response.success) {
+            setActionError("form.error");
+          } else {
+            setSelectedSlotId(response.slot?.id ?? null);
+          }
+          router.refresh();
+        });
+      };
+
+      container.addEventListener("pointermove", handleMove);
+      container.addEventListener("pointerup", finalize);
+      container.addEventListener("pointercancel", finalize);
+    },
+    [dayLength, isPending, locale, router, selectedDay],
+  );
+
+  const beginResize = useCallback(
+    (
+      slot: PlannerSlot,
+      handle: "start" | "end",
+      event: React.PointerEvent<HTMLDivElement>,
+    ) => {
+      if (isPending || slot.hasBooking) {
+        return;
+      }
+      event.stopPropagation();
+      const container = containerRef.current;
+      if (!container) {
+        return;
+      }
+
+      const startMinutes = getMeetingMinutesFromIso(slot.startAt);
+      const endMinutes = getMeetingMinutesFromIso(slot.endAt);
+      const draftState: ResizeDraft = {
+        dayKey: getMeetingDateKey(new Date(slot.startAt)),
+        slotId: slot.id,
+        startMinutes,
+        endMinutes,
+      };
+      setResizeDraft(draftState);
+      container.setPointerCapture(event.pointerId);
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        setResizeDraft((current) => {
+          if (!current) {
+            return current;
+          }
+          const dayLimit = getMeetingDayLengthMinutes(current.dayKey);
+          const minutePosition = snapMinutes(
+            positionToMinutes(moveEvent.clientY, container, dayLimit),
+            dayLimit,
+          );
+          if (handle === "start") {
+            const maxStart = Math.max(0, dayLimit - SNAP_MINUTES);
+            const nextStart = Math.min(
+              minutePosition,
+              current.endMinutes - SNAP_MINUTES,
+            );
+            return {
+              ...current,
+              startMinutes: Math.max(0, Math.min(nextStart, maxStart)),
+            };
+          }
+          const nextEnd = Math.max(
+            minutePosition,
+            current.startMinutes + SNAP_MINUTES,
+          );
+          return {
+            ...current,
+            endMinutes: clampMinutes(nextEnd, dayLimit),
+          };
+        });
+      };
+
+      const finalize = () => {
+        container.releasePointerCapture(event.pointerId);
+        container.removeEventListener("pointermove", handleMove);
+        container.removeEventListener("pointerup", finalize);
+        container.removeEventListener("pointercancel", finalize);
+
+        setResizeDraft((current) => {
+          if (!current) {
+            return null;
+          }
+          const dayLimit = getMeetingDayLengthMinutes(current.dayKey);
+          const maxStart = Math.max(0, dayLimit - SNAP_MINUTES);
+          const nextStart = Math.min(
+            current.startMinutes,
+            current.endMinutes - SNAP_MINUTES,
+          );
+          const safeStart = Math.max(0, Math.min(nextStart, maxStart));
+          const nextEnd = Math.max(current.endMinutes, safeStart + SNAP_MINUTES);
+          const safeEnd = clampMinutes(nextEnd, dayLimit);
+          startTransition(async () => {
+            setActionError(null);
+            const response = await updateSlotAction(locale, {
+              slotId: current.slotId,
+              startAt: meetingMinutesToIso(current.dayKey, safeStart),
+              endAt: meetingMinutesToIso(current.dayKey, safeEnd),
+              status: slot.status,
+              publicDescription: slot.publicDescription ?? undefined,
+              assignedStaffId: slot.assignedStaffId ?? undefined,
+              assignedStaffName: slot.assignedStaffName ?? undefined,
+              isPublished: slot.isPublished,
+            });
+            if (!response.success) {
+              setActionError("form.error");
+            }
+            router.refresh();
+          });
+          return null;
+        });
+      };
+
+      container.addEventListener("pointermove", handleMove);
+      container.addEventListener("pointerup", finalize);
+      container.addEventListener("pointercancel", finalize);
+    },
+    [isPending, locale, router],
+  );
+
+  const handleSave = useCallback(() => {
+    if (!selectedSlot || !formState) {
+      return;
+    }
+
+    startTransition(async () => {
+      setActionError(null);
+      const staffMember =
+        formState.assignedStaffId !== ""
+          ? staff.find((member) => member.id === formState.assignedStaffId)
+          : undefined;
+      const assignedName =
+        staffMember?.name?.trim() || formState.customStaffName.trim() || undefined;
+
+      const response = await updateSlotAction(locale, {
+        slotId: selectedSlot.id,
+        startAt: selectedSlot.startAt,
+        endAt: selectedSlot.endAt,
+        status: selectedSlot.hasBooking ? "booked" : formState.status,
+        publicDescription: formState.publicDescription.trim() || undefined,
+        assignedStaffId:
+          formState.assignedStaffId !== "" ? formState.assignedStaffId : undefined,
+        assignedStaffName: assignedName,
+        isPublished: formState.isPublished,
+      });
+
+      if (!response.success) {
+        setActionError("form.error");
+      }
+
+      router.refresh();
+    });
+  }, [formState, locale, router, selectedSlot, staff]);
+
+  const handleDelete = useCallback(() => {
+    if (!selectedSlot || selectedSlot.hasBooking) {
+      return;
+    }
+    startTransition(async () => {
+      setActionError(null);
+      const response = await deleteSlotAction(locale, selectedSlot.id);
+      if (!response.success) {
+        setActionError(
+          response.error === "has_booking"
+            ? "form.errors.deleteBooked"
+            : "form.error",
+        );
+        router.refresh();
+        return;
+      }
+
+      setSelectedSlotId(null);
+      router.refresh();
+    });
+  }, [locale, router, selectedSlot]);
+
+  const renderSlot = useCallback(
+    (slot: PlannerSlot) => {
+      const startMinutes = getMeetingMinutesFromIso(slot.startAt);
+      const endMinutes = getMeetingMinutesFromIso(slot.endAt);
+      const isSelected = slot.id === selectedSlotId;
+
+      const displayStatus: MeetingSlotStatus = slot.hasBooking
+        ? "booked"
+        : slot.isPublished
+          ? slot.status
+          : "unavailable";
+      const colorClass = slotColorMap[displayStatus];
+      const draftForSlot = resizeDraft?.slotId === slot.id ? resizeDraft : null;
+      const top = (draftForSlot?.startMinutes ?? startMinutes) * PIXELS_PER_MINUTE;
+      const height = Math.max(
+        (draftForSlot?.endMinutes ?? endMinutes) * PIXELS_PER_MINUTE - top,
+        SNAP_MINUTES * PIXELS_PER_MINUTE,
+      );
+
+      return (
+        <div
+          key={slot.id}
+          className="absolute left-2 right-2 rounded-2xl border px-4 py-3 text-xs text-white transition"
+          style={{ top, height }}
+          onClick={(event) => {
+            event.stopPropagation();
+            setSelectedSlotId(slot.id);
+          }}
+        >
+          <div
+            className={`${colorClass} absolute inset-0 rounded-2xl border transition ${
+              isSelected ? "ring-2 ring-white/80" : ""
+            } ${slot.isPublished ? "" : "border-dashed"}`}
+          />
+          <div className="relative z-10 flex flex-col gap-2">
+            <div className="flex items-center justify-between gap-2 text-[11px] font-medium text-white">
+              <span>
+                {formatDateWithZone(
+                  slot.startAt,
+                  { hour: "2-digit", minute: "2-digit" },
+                  locale,
+                  MEETING_TIME_ZONE,
+                )}
+                {" – "}
+                {formatDateWithZone(
+                  slot.endAt,
+                  { hour: "2-digit", minute: "2-digit" },
+                  locale,
+                  MEETING_TIME_ZONE,
+                )}
+              </span>
+              {slot.hasBooking ? (
+                <span className="rounded-full bg-rose-500/30 px-2 py-1 text-[10px] uppercase tracking-[0.2em] text-rose-50">
+                  {t("legend.booked")}
+                </span>
+              ) : !slot.isPublished ? (
+                <span className="rounded-full bg-white/10 px-2 py-1 text-[10px] uppercase tracking-[0.2em] text-white/80">
+                  {t("legend.hidden")}
+                </span>
+              ) : null}
+            </div>
+            {slot.hasBooking && slot.booking ? (
+              <div className="space-y-1 text-[11px] text-white/80">
+                <p className="font-semibold">{slot.booking.personName}</p>
+                <p>{slot.booking.reason}</p>
+              </div>
+            ) : slot.publicDescription ? (
+              <p className="text-[11px] text-white/70">{slot.publicDescription}</p>
+            ) : (
+              <p className="text-[11px] text-white/60">{t("timeline.availableLabel")}</p>
+            )}
+          </div>
+          {slot.hasBooking ? null : (
+            <>
+              <div
+                className="absolute left-2 right-2 top-0 h-3 cursor-ns-resize rounded-t-2xl bg-white/10"
+                onPointerDown={(event) => beginResize(slot, "start", event)}
+              />
+              <div
+                className="absolute bottom-0 left-2 right-2 h-3 cursor-ns-resize rounded-b-2xl bg-white/10"
+                onPointerDown={(event) => beginResize(slot, "end", event)}
+              />
+            </>
+          )}
+        </div>
+      );
+    },
+    [beginResize, locale, resizeDraft, selectedSlotId, t],
+  );
+
+  return (
+    <div className="space-y-10">
+      <div className="rounded-3xl border border-white/15 bg-white/[0.04] p-6 shadow-[0_30px_120px_rgba(15,23,42,0.45)]">
+        <div className="flex items-center gap-3 text-white">
+          <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10">
+            <CalendarDays className="h-5 w-5" aria-hidden />
+          </span>
+          <div>
+            <h2 className="text-lg font-semibold text-white">{t("calendar.heading")}</h2>
+            <p className="text-sm text-white/70">{t("calendar.caption")}</p>
+          </div>
+        </div>
+
+        <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-7">
+          {days.map((day) => {
+            const available = day.slots.filter(
+              (slot) => slot.status === "available" && !slot.hasBooking,
+            ).length;
+            const booked = day.slots.filter((slot) => slot.hasBooking).length;
+            const blocked = day.slots.filter(
+              (slot) => slot.status === "unavailable" && slot.isPublished,
+            ).length;
+            const hidden = day.slots.filter((slot) => !slot.isPublished).length;
+            const total = day.totalSlots;
+            const weekday = formatDateWithZone(
+              day.date,
+              { weekday: "short" },
+              locale,
+              MEETING_TIME_ZONE,
+            );
+            const month = formatDateWithZone(
+              day.date,
+              { month: "short" },
+              locale,
+              MEETING_TIME_ZONE,
+            );
+            const dayNumber = formatDateWithZone(
+              day.date,
+              { day: "numeric" },
+              locale,
+              MEETING_TIME_ZONE,
+            );
+
+            const isSelected = day.dateKey === selectedDayKey;
+            const statusLabel = t(`calendar.status.${day.status}` as const);
+
+            return (
+              <button
+                key={day.dateKey}
+                type="button"
+                onClick={() => {
+                  setSelectedDayKey(day.dateKey);
+                  setSelectedSlotId(null);
+                }}
+                className={cn(
+                  "relative flex flex-col gap-2 rounded-2xl border border-white/12 bg-white/[0.04] px-4 py-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60",
+                  isSelected
+                    ? cn("border-white/60 bg-white/12", dayStatusHighlightMap[day.status])
+                    : "hover:border-white/35 hover:bg-white/10",
+                )}
+                aria-pressed={isSelected}
+                aria-label={`${weekday} ${dayNumber} ${month}. ${statusLabel}. ${t("calendar.count.available", { count: available })}, ${t("calendar.count.booked", { count: booked })}, ${t("calendar.count.blocked", { count: blocked })}, ${t("calendar.count.hidden", { count: hidden })}`}
+              >
+                <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.32em] text-white/50">
+                  <span>{weekday}</span>
+                  <span>{month}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-2xl font-semibold text-white">{dayNumber}</span>
+                  <span className="inline-flex items-center gap-2">
+                    <span className={cn("h-2.5 w-2.5 rounded-full", dayStatusDotMap[day.status])} aria-hidden />
+                    <span className="sr-only">{statusLabel}</span>
+                  </span>
+                </div>
+                <div className="grid grid-cols-2 gap-x-2 gap-y-1 text-[11px] leading-snug text-white/65">
+                  <span>{t("calendar.metrics.available", { count: available })}</span>
+                  <span className="text-right">{t("calendar.metrics.booked", { count: booked })}</span>
+                  <span>{t("calendar.metrics.blocked", { count: blocked })}</span>
+                  <span className="text-right text-white/60">
+                    {t("calendar.metrics.hidden", { count: hidden })}
+                  </span>
+                  <span className="col-span-2 text-right text-white/55">
+                    {t("calendar.metrics.total", { count: total })}
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mt-8 space-y-2 text-xs text-white/60">
+          <p className="font-semibold uppercase tracking-[0.3em] text-white/50">
+            {t("legend.title")}
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <LegendBadge color="bg-emerald-500/40" label={t("legend.available")} />
+            <LegendBadge color="bg-rose-500/40" label={t("legend.booked")} />
+            <LegendBadge color="bg-slate-400/35" label={t("legend.blocked")} />
+            <LegendBadge color="bg-white/20" label={t("legend.hidden")} />
+          </div>
+          <p>{t("timeline.createHint")}</p>
+          <p>{t("timeline.updateHint")}</p>
+        </div>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,420px)]">
+        <div className="rounded-3xl border border-white/15 bg-white/[0.04] p-6 shadow-[0_30px_120px_rgba(15,23,42,0.45)]">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">
+                {t("timeline.heading")}
+              </p>
+              {selectedDay ? (
+                <h2 className="mt-2 text-2xl font-semibold text-white">
+                  {formatDateWithZone(
+                    selectedDay.date,
+                    { weekday: "long", month: "long", day: "numeric" },
+                    locale,
+                    MEETING_TIME_ZONE,
+                  )}
+                </h2>
+              ) : null}
+            </div>
+            {isPending ? <Loader2 className="h-5 w-5 animate-spin text-white" /> : null}
+          </div>
+
+          <div className="mt-6 h-[520px] overflow-y-auto rounded-2xl border border-white/10 bg-black/40">
+            <div
+              ref={containerRef}
+              className="relative w-full"
+              style={{ height: dayLength * PIXELS_PER_MINUTE }}
+              onPointerDown={handleBackgroundPointerDown}
+            >
+              {hourLabels.map((hour) => {
+                const top = hour * 60 * PIXELS_PER_MINUTE;
+                const label =
+                  selectedDay
+                    ? formatDateWithZone(
+                        meetingMinutesToIso(
+                          selectedDay.dateKey,
+                          hour * 60,
+                        ),
+                        { hour: "2-digit", minute: "2-digit" },
+                        locale,
+                        MEETING_TIME_ZONE,
+                      )
+                    : `${hour.toString().padStart(2, "0")}:00`;
+                return (
+                  <div
+                    key={hour}
+                    className="absolute left-0 right-0 border-t border-white/[0.06]"
+                    style={{ top }}
+                  >
+                    <span className="absolute left-0 top-0 translate-y-[-50%] px-3 text-[10px] uppercase tracking-[0.2em] text-white/40">
+                      {label}
+                    </span>
+                  </div>
+                );
+              })}
+
+              {selectedDay?.slots.map((slot) => renderSlot(slot))}
+
+              {draft ? (
+                <div
+                  className="absolute left-2 right-2 rounded-2xl border border-dashed border-emerald-300/70 bg-emerald-500/20"
+                  style={{
+                    top: draft.startMinutes * PIXELS_PER_MINUTE,
+                    height: Math.max(
+                      (draft.endMinutes - draft.startMinutes) * PIXELS_PER_MINUTE,
+                      SNAP_MINUTES * PIXELS_PER_MINUTE,
+                    ),
+                  }}
+                />
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-3xl border border-white/15 bg-white/[0.04] p-6 shadow-[0_30px_120px_rgba(15,23,42,0.45)]">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">
+                {t("form.heading")}
+              </p>
+              <h3 className="mt-2 text-xl font-semibold text-white">
+                {selectedSlot
+                  ? formatDateWithZone(
+                      selectedSlot.startAt,
+                      {
+                        weekday: "long",
+                        month: "long",
+                        day: "numeric",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      },
+                      locale,
+                      MEETING_TIME_ZONE,
+                    )
+                  : t("form.empty")}
+              </h3>
+            </div>
+            {isPending ? <Loader2 className="h-5 w-5 animate-spin text-white" /> : null}
+          </div>
+
+          {actionError ? (
+            <div className="mt-4 rounded-2xl border border-rose-400/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+              {t(actionError as any)}
+            </div>
+          ) : null}
+
+          {selectedSlot && formState ? (
+            <div className="mt-6 space-y-5 text-sm text-white/80">
+              {selectedSlot.hasBooking && selectedSlot.booking ? (
+                <div className="space-y-3 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 text-xs text-white/70">
+                  <p className="font-semibold uppercase tracking-[0.25em] text-white/50">
+                    {t("form.booking.heading")}
+                  </p>
+                  <div className="grid gap-2">
+                    <InfoRow
+                      icon={<Users className="h-3.5 w-3.5" aria-hidden />}
+                      label={t("form.booking.person")}
+                      value={selectedSlot.booking.personName}
+                    />
+                    {selectedSlot.booking.company ? (
+                      <InfoRow
+                        icon={<Building2 className="h-3.5 w-3.5" aria-hidden />}
+                        label={t("form.booking.company")}
+                        value={selectedSlot.booking.company}
+                      />
+                    ) : null}
+                    <InfoRow
+                      icon={<MessageSquare className="h-3.5 w-3.5" aria-hidden />}
+                      label={t("form.booking.reason")}
+                      value={selectedSlot.booking.reason}
+                    />
+                    <InfoRow
+                      icon={<Mail className="h-3.5 w-3.5" aria-hidden />}
+                      label={t("form.booking.email")}
+                      value={selectedSlot.booking.email}
+                    />
+                  </div>
+                </div>
+              ) : null}
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="space-y-2">
+                  <span className="text-xs font-semibold uppercase tracking-[0.25em] text-white/60">
+                    {t("form.labels.staff")}
+                  </span>
+                  <select
+                    className="w-full rounded-xl border border-white/15 bg-black/40 px-3 py-2 text-sm text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                    value={formState.assignedStaffId}
+                    onChange={(event) => {
+                      const value = event.target.value;
+                      setFormState((state) =>
+                        state
+                          ? {
+                              ...state,
+                              assignedStaffId: value,
+                              customStaffName:
+                                value === ""
+                                  ? state.customStaffName
+                                  : staff.find((member) => member.id === value)?.name ?? "",
+                            }
+                          : state,
+                      );
+                    }}
+                  >
+                    <option value="">{t("form.staff.unassigned")}</option>
+                    {staff.map((member) => (
+                      <option key={member.id} value={member.id}>
+                        {member.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="space-y-2">
+                  <span className="text-xs font-semibold uppercase tracking-[0.25em] text-white/60">
+                    {t("form.labels.customStaff")}
+                  </span>
+                  <input
+                    className="w-full rounded-xl border border-white/15 bg-black/40 px-3 py-2 text-sm text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                    value={formState.customStaffName}
+                    onChange={(event) =>
+                      setFormState((state) =>
+                        state ? { ...state, customStaffName: event.target.value } : state,
+                      )
+                    }
+                    placeholder={t("form.placeholders.customStaff")}
+                  />
+                </label>
+
+                <label className="space-y-2">
+                  <span className="text-xs font-semibold uppercase tracking-[0.25em] text-white/60">
+                    {t("form.labels.status")}
+                  </span>
+                  <select
+                    className="w-full rounded-xl border border-white/15 bg-black/40 px-3 py-2 text-sm text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:opacity-60"
+                    value={formState.status}
+                    onChange={(event) =>
+                      setFormState((state) =>
+                        state
+                          ? {
+                              ...state,
+                              status: event.target.value as MeetingSlotStatus,
+                            }
+                          : state,
+                      )
+                    }
+                    disabled={selectedSlot.hasBooking}
+                  >
+                    <option value="available">{t("form.status.available")}</option>
+                    <option value="unavailable">{t("form.status.unavailable")}</option>
+                  </select>
+                  {selectedSlot.hasBooking ? (
+                    <p className="text-xs text-white/50">{t("form.alerts.bookedLocked")}</p>
+                  ) : null}
+                </label>
+
+                <label className="flex items-center gap-3 rounded-xl border border-white/15 bg-black/40 px-4 py-3 text-sm text-white/80">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border border-white/20 bg-black/40"
+                    checked={formState.isPublished}
+                    onChange={(event) =>
+                      setFormState((state) =>
+                        state ? { ...state, isPublished: event.target.checked } : state,
+                      )
+                    }
+                  />
+                  <span>{t("form.labels.published")}</span>
+                </label>
+              </div>
+
+              <label className="block space-y-2">
+                <span className="text-xs font-semibold uppercase tracking-[0.25em] text-white/60">
+                  {t("form.labels.description")}
+                </span>
+                <textarea
+                  rows={4}
+                  className="w-full rounded-xl border border-white/15 bg-black/40 px-3 py-3 text-sm text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                  value={formState.publicDescription}
+                  onChange={(event) =>
+                    setFormState((state) =>
+                      state ? { ...state, publicDescription: event.target.value } : state,
+                    )
+                  }
+                  placeholder={t("form.placeholders.description")}
+                />
+              </label>
+
+              <div className="flex flex-wrap items-center gap-3">
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-5 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:opacity-60"
+                  onClick={handleSave}
+                  disabled={isPending}
+                >
+                  {isPending ? t("form.actions.saving") : t("form.actions.save")}
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 bg-transparent px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-white/60 transition hover:border-rose-400/60 hover:text-rose-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/60 disabled:opacity-40"
+                  onClick={handleDelete}
+                  disabled={isPending || selectedSlot.hasBooking}
+                >
+                  <Trash2 className="h-3.5 w-3.5" aria-hidden />
+                  {isPending ? t("form.actions.deleting") : t("form.actions.delete")}
+                </button>
+                {selectedSlot.hasBooking ? (
+                  <div className="flex items-center gap-2 rounded-full bg-white/10 px-3 py-2 text-xs text-white/60">
+                    <ShieldAlert className="h-3.5 w-3.5" aria-hidden />
+                    {t("form.alerts.deleteDisabled")}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          ) : (
+            <p className="mt-6 text-sm text-white/60">{t("form.instructions")}</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type LegendBadgeProps = {
+  color: string;
+  label: string;
+};
+
+function LegendBadge({ color, label }: LegendBadgeProps) {
+  return (
+    <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.06] px-3 py-1 text-[11px] uppercase tracking-[0.2em] text-white/70">
+      <span className={`h-2 w-2 rounded-full ${color}`} aria-hidden />
+      {label}
+    </span>
+  );
+}
+
+type InfoRowProps = {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+};
+
+function InfoRow({ icon, label, value }: InfoRowProps) {
+  return (
+    <div className="flex items-start gap-2">
+      <span className="mt-[2px] text-white/50">{icon}</span>
+      <div className="space-y-1">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.25em] text-white/40">
+          {label}
+        </p>
+        <p className="text-xs text-white/70">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+function positionToMinutes(
+  clientY: number,
+  container: HTMLDivElement,
+  dayLength: number,
+): number {
+  const rect = container.getBoundingClientRect();
+  const offset = clientY - rect.top + container.scrollTop;
+  return clampMinutes(offset / PIXELS_PER_MINUTE, dayLength);
+}

--- a/apps/www/app/[locale]/(site)/dashboard/planning/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/planning/page.tsx
@@ -1,0 +1,85 @@
+import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+
+import { getAuthSession } from "@/lib/auth";
+import { getMeetingCalendar, getStaffMembers } from "@/lib/meetings/queries";
+
+import { StaffPlanner } from "./components/planner";
+
+interface PageProps {
+  params: {
+    locale: string;
+  };
+}
+
+export default async function PlanningPage({ params }: PageProps) {
+  const session = await getAuthSession();
+  const { locale } = params;
+
+  if (session?.user?.role !== "staff") {
+    redirect(`/${locale}/newsupdates`);
+  }
+
+  const t = await getTranslations({ locale, namespace: "Planning" });
+
+  const [calendar, staffMembers] = await Promise.all([
+    getMeetingCalendar({ includeHidden: true }),
+    getStaffMembers(),
+  ]);
+
+  const days = calendar.map((day) => ({
+    dateKey: day.dateKey,
+    date: day.date.toISOString(),
+    availableSlots: day.availableSlots,
+    totalSlots: day.totalSlots,
+    status: day.status,
+    slots: day.slots.map((slot) => ({
+      id: slot.id,
+      startAt: slot.startAt.toISOString(),
+      endAt: slot.endAt.toISOString(),
+      status: slot.status,
+      isPublished: slot.isPublished,
+      publicDescription: slot.publicDescription,
+      assignedStaffId: slot.assignedStaffId ?? null,
+      assignedStaffName: slot.assignedStaffName ?? slot.assignedStaff?.name ?? null,
+      hasBooking: Boolean(slot.booking),
+      booking: slot.booking
+        ? {
+            personName: slot.booking.personName,
+            email: slot.booking.email,
+            company: slot.booking.company,
+            reason: slot.booking.reason,
+            description: slot.booking.description,
+          }
+        : null,
+    })),
+  }));
+
+  const staff = staffMembers.map((member) => ({
+    id: member.id,
+    name: member.name ?? member.email ?? "Unnamed",
+    email: member.email ?? null,
+  }));
+
+  return (
+    <div className="relative isolate overflow-hidden bg-[radial-gradient(circle_at_top,_rgba(168,85,247,0.18),_transparent_55%)] py-32">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-[-320px] h-[600px] bg-gradient-to-b from-purple-500/25 via-transparent to-transparent blur-3xl"
+      />
+      <div className="container relative z-10 max-w-7xl space-y-16">
+        <div className="max-w-3xl space-y-6">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.08] px-5 py-2 text-xs font-semibold uppercase tracking-[0.32em] text-white/70">
+            {t("eyebrow")}
+          </span>
+          <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+            {t("title")}
+          </h1>
+          <p className="text-lg text-white/70 sm:text-xl">{t("subtitle")}</p>
+        </div>
+
+        <StaffPlanner days={days} staff={staff} locale={locale} />
+      </div>
+    </div>
+  );
+}

--- a/apps/www/app/[locale]/(site)/meeting/actions.ts
+++ b/apps/www/app/[locale]/(site)/meeting/actions.ts
@@ -1,0 +1,73 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { bookMeetingSlot } from "@/lib/meetings/mutations";
+import { meetingBookingSchema } from "@/lib/meetings/validation";
+
+import type { ScheduleMeetingState } from "./state";
+
+export async function scheduleMeetingAction(
+  prevState: ScheduleMeetingState,
+  formData: FormData,
+) {
+  const input = {
+    slotId: String(formData.get("slotId") ?? ""),
+    reason: String(formData.get("reason") ?? ""),
+    company: String(formData.get("company") ?? ""),
+    personName: String(formData.get("personName") ?? ""),
+    email: String(formData.get("email") ?? ""),
+    description: String(formData.get("description") ?? ""),
+    locale: String(formData.get("locale") ?? "en"),
+  };
+
+  const parsed = meetingBookingSchema.safeParse(input);
+  if (!parsed.success) {
+    const errors = parsed.error.flatten().fieldErrors;
+    if (!input.slotId) {
+      errors.slotId = errors.slotId ?? ["Slots.selectError"];
+    }
+    return {
+      status: "error" as const,
+      errors,
+    } satisfies ScheduleMeetingState;
+  }
+
+  const result = await bookMeetingSlot(parsed.data);
+
+  if (!result.success) {
+    if (result.error === "validation") {
+      return {
+        status: "error" as const,
+        errors: result.issues,
+      } satisfies ScheduleMeetingState;
+    }
+
+    const errorKey =
+      result.error === "unavailable"
+        ? "Meeting.Form.errors.unavailable"
+        : "Meeting.Form.errors.generic";
+
+    return {
+      status: "error" as const,
+      message: errorKey,
+    } satisfies ScheduleMeetingState;
+  }
+
+  const slot = result.slot;
+  if (slot?.startAt && slot?.endAt) {
+    await revalidatePath(`/${parsed.data.locale}/meeting`);
+    return {
+      status: "success" as const,
+      slot: {
+        startAt: new Date(slot.startAt).toISOString(),
+        endAt: new Date(slot.endAt).toISOString(),
+      },
+    } satisfies ScheduleMeetingState;
+  }
+
+  return {
+    status: "error" as const,
+    message: "Meeting.Form.errors.generic",
+  } satisfies ScheduleMeetingState;
+}

--- a/apps/www/app/[locale]/(site)/meeting/components/scheduler.tsx
+++ b/apps/www/app/[locale]/(site)/meeting/components/scheduler.tsx
@@ -1,0 +1,454 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useFormState, useFormStatus } from "react-dom";
+import { CalendarDays, CheckCircle2, Users } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+
+import { formatDateWithZone } from "@/lib/date";
+import type { MeetingSlotStatus } from "@/lib/db/schema";
+import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
+import { cn } from "@/lib/utils";
+
+import { scheduleMeetingAction } from "../actions";
+import { initialScheduleState, type ScheduleMeetingState } from "../state";
+
+type SchedulerSlot = {
+  id: string;
+  startAt: string;
+  endAt: string;
+  status: MeetingSlotStatus;
+  isPublished: boolean;
+  publicDescription?: string | null;
+  staffName?: string | null;
+  hasBooking: boolean;
+};
+
+type SchedulerDay = {
+  dateKey: string;
+  date: string;
+  availableSlots: number;
+  totalSlots: number;
+  status: "available" | "limited" | "full";
+  slots: SchedulerSlot[];
+};
+
+type SchedulerProps = {
+  days: SchedulerDay[];
+  locale: string;
+};
+
+const statusDotMap: Record<SchedulerDay["status"], string> = {
+  available: "bg-emerald-400",
+  limited: "bg-amber-400",
+  full: "bg-rose-500",
+};
+
+const statusHighlightMap: Record<SchedulerDay["status"], string> = {
+  available: "shadow-[0_14px_48px_rgba(16,185,129,0.25)]",
+  limited: "shadow-[0_14px_48px_rgba(251,191,36,0.25)]",
+  full: "shadow-[0_14px_48px_rgba(244,63,94,0.28)]",
+};
+
+const statusKeyMap: Record<SchedulerDay["status"], string> = {
+  available: "Calendar.status.available",
+  limited: "Calendar.status.limited",
+  full: "Calendar.status.full",
+};
+
+function DayButton({
+  day,
+  locale,
+  selected,
+  onSelect,
+}: {
+  day: SchedulerDay;
+  locale: string;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const t = useTranslations("Meeting");
+  const { weekday, month, dayNumber } = useMemo(() => {
+    const date = new Date(day.date);
+    return {
+      weekday: new Intl.DateTimeFormat(locale, { weekday: "short" }).format(date),
+      month: new Intl.DateTimeFormat(locale, { month: "short" }).format(date),
+      dayNumber: new Intl.DateTimeFormat(locale, { day: "numeric" }).format(date),
+    };
+  }, [day.date, locale]);
+
+  const statusLabel = t(statusKeyMap[day.status] as any);
+  const totalSlots = Math.max(day.totalSlots, day.availableSlots);
+  const slotsLabel =
+    totalSlots > 0
+      ? t("Calendar.slotsCount", {
+          available: day.availableSlots,
+          total: totalSlots,
+        })
+      : t("Calendar.noSlots");
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "relative flex flex-col gap-2 rounded-2xl border border-white/12 bg-white/[0.04] px-4 py-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60",
+        selected
+          ? cn("border-white/60 bg-white/12", statusHighlightMap[day.status])
+          : "hover:border-white/35 hover:bg-white/10",
+      )}
+      aria-pressed={selected}
+      aria-label={`${weekday} ${dayNumber} ${month}. ${statusLabel}. ${slotsLabel}`}
+    >
+      <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.32em] text-white/50">
+        <span>{weekday}</span>
+        <span>{month}</span>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-2xl font-semibold text-white">{dayNumber}</span>
+        <span className="inline-flex items-center gap-2">
+          <span
+            className={cn("h-2.5 w-2.5 rounded-full", statusDotMap[day.status])}
+            aria-hidden
+          />
+          <span className="sr-only">{statusLabel}</span>
+        </span>
+      </div>
+      <div className="text-[11px] leading-snug text-white/65">{slotsLabel}</div>
+    </button>
+  );
+}
+
+function SlotButton({
+  slot,
+  locale,
+  selected,
+  disabled,
+  onSelect,
+}: {
+  slot: SchedulerSlot;
+  locale: string;
+  selected: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+}) {
+  const start = useMemo(() => new Date(slot.startAt), [slot.startAt]);
+  const end = useMemo(() => new Date(slot.endAt), [slot.endAt]);
+  const timeRange = useMemo(
+    () =>
+      `${formatDateWithZone(start, { hour: "2-digit", minute: "2-digit" }, locale, MEETING_TIME_ZONE)} – ${formatDateWithZone(end, { hour: "2-digit", minute: "2-digit" }, locale, MEETING_TIME_ZONE)}`,
+    [end, locale, start],
+  );
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={disabled}
+      className={cn(
+        "w-full rounded-2xl border border-white/15 bg-white/[0.05] p-4 text-left transition hover:border-white/40 hover:bg-white/[0.08] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60",
+        selected && "border-white/70 bg-white/10",
+        disabled && "cursor-not-allowed opacity-50 hover:border-white/15 hover:bg-white/[0.05]",
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-medium text-white">{timeRange}</span>
+        {selected ? (
+          <CheckCircle2 className="h-4 w-4 text-emerald-300" aria-hidden />
+        ) : null}
+      </div>
+      <div className="mt-2 flex flex-col gap-2 text-xs text-white/60">
+        {slot.staffName ? (
+          <span className="inline-flex items-center gap-2">
+            <Users className="h-3.5 w-3.5" aria-hidden />
+            {slot.staffName}
+          </span>
+        ) : null}
+        {slot.publicDescription ? <p>{slot.publicDescription}</p> : null}
+      </div>
+    </button>
+  );
+}
+
+function SubmitButton({ disabled }: { disabled: boolean }) {
+  const { pending } = useFormStatus();
+  const t = useTranslations("Meeting");
+
+  return (
+    <button
+      type="submit"
+      className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-6 py-3 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:cursor-not-allowed disabled:opacity-60"
+      disabled={pending || disabled}
+    >
+      {pending ? t("Form.submitPending") : t("Form.submit")}
+    </button>
+  );
+}
+
+export function MeetingScheduler({ days, locale }: SchedulerProps) {
+  const t = useTranslations("Meeting");
+  const router = useRouter();
+  const [selectedDayKey, setSelectedDayKey] = useState(() => {
+    const firstWithAvailability = days.find((day) => day.availableSlots > 0);
+    return (firstWithAvailability ?? days[0])?.dateKey ?? "";
+  });
+  const [selectedSlotId, setSelectedSlotId] = useState<string | null>(null);
+  const [state, formAction] = useFormState<ScheduleMeetingState, FormData>(
+    scheduleMeetingAction,
+    initialScheduleState,
+  );
+
+  useEffect(() => {
+    if (state.status === "success") {
+      setSelectedSlotId(null);
+      router.refresh();
+    }
+  }, [router, state.status]);
+
+  const selectedDay = useMemo(
+    () => days.find((day) => day.dateKey === selectedDayKey),
+    [days, selectedDayKey],
+  );
+
+  useEffect(() => {
+    if (!selectedDay && days.length > 0) {
+      setSelectedDayKey(days[0]?.dateKey ?? "");
+    }
+  }, [days, selectedDay]);
+
+  const availableSlots = useMemo(() => {
+    if (!selectedDay) {
+      return [];
+    }
+
+    return selectedDay.slots.filter(
+      (slot) => slot.status === "available" && !slot.hasBooking && slot.isPublished,
+    );
+  }, [selectedDay]);
+
+  const successMessage = useMemo(() => {
+    if (state.status !== "success" || !state.slot) {
+      return null;
+    }
+    const start = new Date(state.slot.startAt);
+    return t("Form.success.message", {
+      date: formatDateWithZone(
+        start,
+        {
+          weekday: "long",
+          month: "long",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        },
+        locale,
+        MEETING_TIME_ZONE,
+      ),
+    });
+  }, [locale, state, t]);
+
+  return (
+    <div className="space-y-10">
+      <div className="rounded-3xl border border-white/12 bg-white/[0.04] p-6 shadow-[0_32px_120px_rgba(15,23,42,0.45)]">
+        <div className="flex items-center gap-3 text-white">
+          <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10">
+            <CalendarDays className="h-5 w-5" aria-hidden />
+          </span>
+          <div>
+            <h2 className="text-lg font-semibold text-white">{t("Calendar.heading")}</h2>
+            <p className="text-sm text-white/70">{t("Calendar.caption")}</p>
+          </div>
+        </div>
+        <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-7">
+          {days.map((day) => (
+            <DayButton
+              key={day.dateKey}
+              day={day}
+              locale={locale}
+              selected={day.dateKey === selectedDayKey}
+              onSelect={() => {
+                setSelectedDayKey(day.dateKey);
+                setSelectedSlotId(null);
+              }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,420px)] xl:grid-cols-[minmax(0,1.15fr)_minmax(0,420px)]">
+        <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 shadow-[0_32px_120px_rgba(15,23,42,0.45)]">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">
+                {t("Slots.badge")}
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold text-white">
+                {t("Slots.heading", {
+                  day: selectedDay
+                    ? formatDateWithZone(
+                        new Date(selectedDay.date),
+                        { weekday: "long", month: "long", day: "numeric" },
+                        locale,
+                        MEETING_TIME_ZONE,
+                      )
+                    : "",
+                })}
+              </h2>
+            </div>
+          </div>
+
+          <div className="mt-6 grid gap-3">
+            {availableSlots.length === 0 ? (
+              <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4 text-sm text-white/60">
+                {t("Slots.empty")}
+              </div>
+            ) : (
+              availableSlots.map((slot) => (
+                <SlotButton
+                  key={slot.id}
+                  slot={slot}
+                  locale={locale}
+                  selected={slot.id === selectedSlotId}
+                  disabled={false}
+                  onSelect={() => setSelectedSlotId(slot.id)}
+                />
+              ))
+            )}
+          </div>
+          {state.errors?.slotId ? (
+            <p className="text-xs font-medium text-rose-200">{t("Slots.selectError")}</p>
+          ) : null}
+        </div>
+
+        <form
+          action={formAction}
+          className="rounded-3xl border border-white/15 bg-white/[0.04] p-6 shadow-[0_32px_120px_rgba(15,23,42,0.45)]"
+        >
+          <input type="hidden" name="slotId" value={selectedSlotId ?? ""} />
+          <input type="hidden" name="locale" value={locale} />
+
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-xl font-semibold text-white">{t("Form.heading")}</h3>
+              <p className="mt-1 text-sm text-white/70">{t("Form.caption")}</p>
+            </div>
+
+            {state.status === "success" && successMessage ? (
+              <div className="rounded-2xl border border-emerald-400/40 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+                <p className="font-semibold">{t("Form.success.title")}</p>
+                <p className="mt-1 text-emerald-100/90">{successMessage}</p>
+              </div>
+            ) : null}
+
+            {state.status === "error" && state.message ? (
+              <div className="rounded-2xl border border-rose-400/50 bg-rose-500/10 p-4 text-sm text-rose-100">
+                <p>{t(state.message as any)}</p>
+              </div>
+            ) : null}
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <Field
+                label={t("Form.fields.reason.label")}
+                name="reason"
+                placeholder={t("Form.fields.reason.placeholder")}
+                error={state.errors?.reason?.[0]}
+                required
+              />
+              <Field
+                label={t("Form.fields.company.label")}
+                name="company"
+                placeholder={t("Form.fields.company.placeholder")}
+                error={state.errors?.company?.[0]}
+              />
+              <Field
+                label={t("Form.fields.personName.label")}
+                name="personName"
+                placeholder={t("Form.fields.personName.placeholder")}
+                error={state.errors?.personName?.[0]}
+                required
+              />
+              <Field
+                label={t("Form.fields.email.label")}
+                name="email"
+                type="email"
+                placeholder={t("Form.fields.email.placeholder")}
+                error={state.errors?.email?.[0]}
+                required
+              />
+            </div>
+
+            <Field
+              label={t("Form.fields.description.label")}
+              name="description"
+              as="textarea"
+              placeholder={t("Form.fields.description.placeholder")}
+              error={state.errors?.description?.[0]}
+              required
+              rows={4}
+            />
+
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <SubmitButton disabled={!selectedSlotId} />
+              <p className="text-xs text-white/60">{t("Form.privacy")}</p>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+type FieldProps = {
+  label: string;
+  name: string;
+  placeholder?: string;
+  error?: string;
+  required?: boolean;
+  type?: string;
+  as?: "input" | "textarea";
+  rows?: number;
+};
+
+function Field({
+  label,
+  name,
+  placeholder,
+  error,
+  required,
+  type = "text",
+  as = "input",
+  rows = 3,
+}: FieldProps) {
+  const id = `${name}-field`;
+  const Element = as === "textarea" ? "textarea" : "input";
+  return (
+    <div className="space-y-2">
+      <label
+        htmlFor={id}
+        className="text-xs font-semibold uppercase tracking-[0.25em] text-white/60"
+      >
+        {label}
+        {required ? <span className="ml-1 text-white/40">*</span> : null}
+      </label>
+      <Element
+        id={id}
+        name={name}
+        placeholder={placeholder}
+        required={required}
+        className={cn(
+          "w-full rounded-2xl border border-white/15 bg-white/[0.05] px-4 py-3 text-sm text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50",
+          error && "border-rose-400/60 text-white",
+        )}
+        {...(as === "textarea"
+          ? {
+              rows,
+            }
+          : {
+              type,
+            })}
+      />
+      {error ? <p className="text-xs font-medium text-rose-200">{error}</p> : null}
+    </div>
+  );
+}

--- a/apps/www/app/[locale]/(site)/meeting/page.tsx
+++ b/apps/www/app/[locale]/(site)/meeting/page.tsx
@@ -1,0 +1,70 @@
+import { getTranslations } from "next-intl/server";
+import type { Metadata } from "next";
+
+import { getMeetingCalendar } from "@/lib/meetings/queries";
+
+import { MeetingScheduler } from "./components/scheduler";
+
+interface PageProps {
+  params: {
+    locale: string;
+  };
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const t = await getTranslations({
+    locale: params.locale,
+    namespace: "Meeting",
+  });
+
+  return {
+    title: t("meta.title"),
+    description: t("meta.description"),
+  };
+}
+
+export default async function MeetingPage({ params }: PageProps) {
+  const { locale } = params;
+  const t = await getTranslations({ locale, namespace: "Meeting" });
+  const calendar = await getMeetingCalendar();
+
+  const days = calendar.map((day) => ({
+    dateKey: day.dateKey,
+    date: day.date.toISOString(),
+    availableSlots: day.availableSlots,
+    totalSlots: day.totalSlots,
+    status: day.status,
+    slots: day.slots.map((slot) => ({
+      id: slot.id,
+      startAt: slot.startAt.toISOString(),
+      endAt: slot.endAt.toISOString(),
+      status: slot.status,
+      isPublished: slot.isPublished,
+      publicDescription: slot.publicDescription,
+      staffName: slot.assignedStaffName ?? slot.assignedStaff?.name ?? null,
+      hasBooking: Boolean(slot.booking),
+    })),
+  }));
+
+  return (
+    <div className="relative isolate overflow-hidden bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.12),_transparent_55%)] py-32">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-[-280px] h-[520px] bg-gradient-to-b from-blue-500/30 via-transparent to-transparent blur-3xl"
+      />
+      <div className="container relative z-10 max-w-6xl space-y-16">
+        <div className="max-w-3xl space-y-6">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.08] px-5 py-2 text-xs font-semibold uppercase tracking-[0.32em] text-white/70">
+            {t("Hero.badge")}
+          </span>
+          <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+            {t("Hero.title")}
+          </h1>
+          <p className="text-lg text-white/70 sm:text-xl">{t("Hero.subtitle")}</p>
+        </div>
+
+        <MeetingScheduler days={days} locale={locale} />
+      </div>
+    </div>
+  );
+}

--- a/apps/www/app/[locale]/(site)/meeting/state.ts
+++ b/apps/www/app/[locale]/(site)/meeting/state.ts
@@ -1,0 +1,13 @@
+export type ScheduleMeetingState = {
+  status: "idle" | "success" | "error";
+  message?: string;
+  errors?: Record<string, string[]>;
+  slot?: {
+    startAt: string;
+    endAt: string;
+  };
+};
+
+export const initialScheduleState: ScheduleMeetingState = {
+  status: "idle",
+};

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -79,8 +79,10 @@ export function Navigation() {
   const isHome = normalizedPathname === "/";
   const isClientView =
     normalizedPathname === "/newsupdates" || normalizedPathname.startsWith("/newsupdates/");
+  const isStaffOverviewView = normalizedPathname === "/dashboard";
+  const isStaffPlanningView = normalizedPathname.startsWith("/dashboard/planning");
   const isStaffView =
-    normalizedPathname === "/dashboard" || normalizedPathname.startsWith("/dashboard/");
+    isStaffOverviewView || isStaffPlanningView || normalizedPathname.startsWith("/dashboard/");
   const isLoggedInView = isClientView || isStaffView;
   const settledLogoScale = 0.68;
   const initialLogoScale = isHome ? 1 : 0.74;
@@ -102,12 +104,13 @@ export function Navigation() {
             key: "overview",
             href: "/dashboard",
             label: t("loggedIn.overview"),
-            current: isStaffView,
+            current: isStaffOverviewView,
           },
           {
             key: "planning",
+            href: "/dashboard/planning",
             label: t("loggedIn.planning"),
-            comingSoon: true,
+            current: isStaffPlanningView,
           },
         ] satisfies LoggedInNavItem[])
       : ([

--- a/apps/www/drizzle/0001_meeting_scheduler.sql
+++ b/apps/www/drizzle/0001_meeting_scheduler.sql
@@ -1,0 +1,41 @@
+CREATE TYPE "meeting_slot_status" AS ENUM ('available', 'booked', 'unavailable');
+
+CREATE TABLE IF NOT EXISTS "meeting_slots" (
+  "id" text PRIMARY KEY NOT NULL,
+  "start_at" timestamptz NOT NULL,
+  "end_at" timestamptz NOT NULL,
+  "status" "meeting_slot_status" DEFAULT 'available' NOT NULL,
+  "public_description" text,
+  "assigned_staff_id" text,
+  "assigned_staff_name" text,
+  "is_published" boolean DEFAULT true NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "meeting_slots_start_at_idx" ON "meeting_slots" ("start_at");
+CREATE INDEX IF NOT EXISTS "meeting_slots_status_idx" ON "meeting_slots" ("status");
+
+ALTER TABLE "meeting_slots"
+  ADD CONSTRAINT "meeting_slots_assigned_staff_id_users_id_fk"
+  FOREIGN KEY ("assigned_staff_id") REFERENCES "users"("id") ON DELETE set null ON UPDATE no action;
+
+CREATE TABLE IF NOT EXISTS "meeting_bookings" (
+  "id" text PRIMARY KEY NOT NULL,
+  "slot_id" text NOT NULL,
+  "reason" text NOT NULL,
+  "company" text,
+  "person_name" text NOT NULL,
+  "email" text NOT NULL,
+  "description" text,
+  "locale" text,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "meeting_bookings_slot_unique" ON "meeting_bookings" ("slot_id");
+CREATE INDEX IF NOT EXISTS "meeting_bookings_email_idx" ON "meeting_bookings" ("email");
+
+ALTER TABLE "meeting_bookings"
+  ADD CONSTRAINT "meeting_bookings_slot_id_meeting_slots_id_fk"
+  FOREIGN KEY ("slot_id") REFERENCES "meeting_slots"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/www/lib/date.ts
+++ b/apps/www/lib/date.ts
@@ -35,3 +35,17 @@ export function formatIsoDateUtc(value: DateInput): string {
 
   return date.toISOString().split("T")[0] ?? "";
 }
+
+export function formatDateWithZone(
+  value: DateInput,
+  options: Intl.DateTimeFormatOptions,
+  locale: string,
+  timeZone: string,
+): string {
+  const date = toDate(value);
+  if (!date) {
+    return "";
+  }
+
+  return new Intl.DateTimeFormat(locale, { timeZone, ...options }).format(date);
+}

--- a/apps/www/lib/db/schema.ts
+++ b/apps/www/lib/db/schema.ts
@@ -1,5 +1,6 @@
 import { relations } from "drizzle-orm";
 import {
+  boolean,
   index,
   integer,
   pgEnum,
@@ -12,6 +13,12 @@ import {
 import type { AdapterAccount } from "next-auth/adapters";
 
 export const userRoleEnum = pgEnum("user_role", ["client", "staff"]);
+
+export const meetingSlotStatusEnum = pgEnum("meeting_slot_status", [
+  "available",
+  "booked",
+  "unavailable",
+]);
 
 export const users = pgTable(
   "users",
@@ -85,9 +92,64 @@ export const verificationTokens = pgTable(
   }),
 );
 
+export const meetingSlots = pgTable(
+  "meeting_slots",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    startAt: timestamp("start_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
+    endAt: timestamp("end_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
+    status: meetingSlotStatusEnum("status").notNull().default("available"),
+    publicDescription: text("public_description"),
+    assignedStaffId: text("assigned_staff_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    assignedStaffName: text("assigned_staff_name"),
+    isPublished: boolean("is_published").notNull().default(true),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).notNull().defaultNow(),
+  },
+  (table) => ({
+    startIdx: index("meeting_slots_start_at_idx").on(table.startAt),
+    statusIdx: index("meeting_slots_status_idx").on(table.status),
+  }),
+);
+
+export const meetingBookings = pgTable(
+  "meeting_bookings",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    slotId: text("slot_id")
+      .notNull()
+      .references(() => meetingSlots.id, { onDelete: "cascade" }),
+    reason: text("reason").notNull(),
+    company: text("company"),
+    personName: text("person_name").notNull(),
+    email: text("email").notNull(),
+    description: text("description"),
+    locale: text("locale"),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).notNull().defaultNow(),
+  },
+  (table) => ({
+    slotIdx: uniqueIndex("meeting_bookings_slot_unique").on(table.slotId),
+    emailIdx: index("meeting_bookings_email_idx").on(table.email),
+  }),
+);
+
 export const usersRelations = relations(users, ({ many }) => ({
   accounts: many(accounts),
   sessions: many(sessions),
+  meetingSlots: many(meetingSlots, { relationName: "assignedStaff" }),
 }));
 
 export const accountsRelations = relations(accounts, ({ one }) => ({
@@ -104,4 +166,25 @@ export const sessionsRelations = relations(sessions, ({ one }) => ({
   }),
 }));
 
+export const meetingSlotsRelations = relations(meetingSlots, ({ one }) => ({
+  assignedStaff: one(users, {
+    relationName: "assignedStaff",
+    fields: [meetingSlots.assignedStaffId],
+    references: [users.id],
+  }),
+  booking: one(meetingBookings, {
+    fields: [meetingSlots.id],
+    references: [meetingBookings.slotId],
+  }),
+}));
+
+export const meetingBookingsRelations = relations(meetingBookings, ({ one }) => ({
+  slot: one(meetingSlots, {
+    fields: [meetingBookings.slotId],
+    references: [meetingSlots.id],
+  }),
+}));
+
 export type UserRole = (typeof userRoleEnum.enumValues)[number];
+export type MeetingSlotStatus =
+  (typeof meetingSlotStatusEnum.enumValues)[number];

--- a/apps/www/lib/meetings/constants.ts
+++ b/apps/www/lib/meetings/constants.ts
@@ -1,0 +1,4 @@
+export const MEETING_TIME_ZONE = "Europe/Amsterdam";
+export const MEETING_DAY_RANGE = 14;
+export const MEETING_SLOT_INCREMENT_MINUTES = 15;
+export const MEETING_DEFAULT_DURATION_MINUTES = 45;

--- a/apps/www/lib/meetings/mutations.ts
+++ b/apps/www/lib/meetings/mutations.ts
@@ -1,0 +1,152 @@
+import { eq } from "drizzle-orm";
+
+import { db } from "@/lib/db/client";
+import { meetingBookings, meetingSlots } from "@/lib/db/schema";
+
+import { getSlotById } from "./queries";
+
+import {
+  createSlotSchema,
+  meetingBookingSchema,
+  updateSlotSchema,
+} from "./validation";
+
+export async function bookMeetingSlot(input: unknown) {
+  const parsed = meetingBookingSchema.safeParse(input);
+
+  if (!parsed.success) {
+    return {
+      success: false as const,
+      error: "validation",
+      issues: parsed.error.flatten().fieldErrors,
+    };
+  }
+
+  const data = parsed.data;
+
+  return db.transaction(async (tx) => {
+    const slot = await tx.query.meetingSlots.findFirst({
+      where: (slots, { eq }) => eq(slots.id, data.slotId),
+      with: { booking: true },
+    });
+
+    if (!slot) {
+      return {
+        success: false as const,
+        error: "not_found" as const,
+      };
+    }
+
+    if (slot.status !== "available" || slot.booking) {
+      return {
+        success: false as const,
+        error: "unavailable" as const,
+      };
+    }
+
+    await tx.insert(meetingBookings).values({
+      slotId: data.slotId,
+      reason: data.reason,
+      company: data.company,
+      personName: data.personName,
+      email: data.email,
+      description: data.description,
+      locale: data.locale,
+    });
+
+    await tx
+      .update(meetingSlots)
+      .set({ status: "booked", updatedAt: new Date() })
+      .where(eq(meetingSlots.id, data.slotId));
+
+    const updatedSlot = await tx.query.meetingSlots.findFirst({
+      where: (slots, { eq }) => eq(slots.id, data.slotId),
+      with: { booking: true },
+    });
+
+    return {
+      success: true as const,
+      slot: updatedSlot ?? slot,
+    };
+  });
+}
+
+export async function createMeetingSlot(input: unknown) {
+  const parsed = createSlotSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false as const,
+      error: "validation" as const,
+      issues: parsed.error.flatten().fieldErrors,
+    };
+  }
+
+  const data = parsed.data;
+
+  const [created] = await db
+    .insert(meetingSlots)
+    .values({
+      startAt: data.startAt,
+      endAt: data.endAt,
+      publicDescription: data.publicDescription,
+      assignedStaffId: data.assignedStaffId,
+      assignedStaffName: data.assignedStaffName,
+      status: data.status ?? "available",
+      isPublished: data.isPublished ?? true,
+    })
+    .returning();
+
+  const slot = created ? await getSlotById(created.id) : null;
+
+  return { success: true as const, slot: slot ?? created };
+}
+
+export async function updateMeetingSlot(input: unknown) {
+  const parsed = updateSlotSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false as const,
+      error: "validation" as const,
+      issues: parsed.error.flatten().fieldErrors,
+    };
+  }
+
+  const data = parsed.data;
+  const [updated] = await db
+    .update(meetingSlots)
+    .set({
+      startAt: data.startAt,
+      endAt: data.endAt,
+      publicDescription: data.publicDescription,
+      assignedStaffId: data.assignedStaffId,
+      assignedStaffName: data.assignedStaffName,
+      status: data.status ?? "available",
+      isPublished: data.isPublished ?? true,
+      updatedAt: new Date(),
+    })
+    .where(eq(meetingSlots.id, data.slotId))
+    .returning();
+
+  return {
+    success: true as const,
+    slot: updated ? await getSlotById(updated.id) : updated,
+  };
+}
+
+export async function deleteMeetingSlot(slotId: string) {
+  const slot = await db.query.meetingSlots.findFirst({
+    where: (slots, { eq: eqFn }) => eqFn(slots.id, slotId),
+    with: { booking: true },
+  });
+
+  if (!slot) {
+    return { success: false as const, error: "not_found" as const };
+  }
+
+  if (slot.booking) {
+    return { success: false as const, error: "has_booking" as const };
+  }
+
+  await db.delete(meetingSlots).where(eq(meetingSlots.id, slotId));
+  return { success: true as const };
+}

--- a/apps/www/lib/meetings/queries.ts
+++ b/apps/www/lib/meetings/queries.ts
@@ -1,0 +1,180 @@
+import { addDays } from "date-fns";
+import { and, asc, eq, gte, lt } from "drizzle-orm";
+
+import { db } from "@/lib/db/client";
+import { meetingBookings, meetingSlots, users } from "@/lib/db/schema";
+import { formatIsoDateUtc } from "@/lib/date";
+
+import { MEETING_DAY_RANGE } from "./constants";
+import type { MeetingDaySummary, MeetingSlotWithRelations } from "./types";
+import {
+  createMeetingDayRange,
+  getDateFromMeetingKey,
+  getMeetingDateKey,
+} from "./utils";
+
+function normalizeSlots(
+  slots: MeetingSlotWithRelations[],
+  { includeHidden }: { includeHidden: boolean },
+): MeetingDaySummary[] {
+  const byDay = new Map<string, MeetingDaySummary>();
+
+  for (const slot of slots) {
+    const key = getMeetingDateKey(slot.startAt);
+    if (!byDay.has(key)) {
+      byDay.set(key, {
+        dateKey: key,
+        date: getDateFromMeetingKey(key),
+        availableSlots: 0,
+        totalSlots: 0,
+        status: "full",
+        slots: [],
+      });
+    }
+
+    const summary = byDay.get(key)!;
+    summary.slots.push(slot);
+
+    const slotIsVisible = slot.isPublished || includeHidden;
+    if (slotIsVisible) {
+      summary.totalSlots += 1;
+    }
+
+    const slotIsAvailable =
+      slotIsVisible &&
+      slot.status === "available" &&
+      !slot.booking &&
+      slot.isPublished;
+
+    if (slotIsAvailable) {
+      summary.availableSlots += 1;
+    }
+  }
+
+  for (const summary of byDay.values()) {
+    if (summary.availableSlots === 0) {
+      summary.status = "full";
+    } else if (summary.availableSlots <= 2) {
+      summary.status = "limited";
+    } else {
+      summary.status = "available";
+    }
+
+    summary.slots.sort((a, b) =>
+      a.startAt.getTime() - b.startAt.getTime(),
+    );
+  }
+
+  return Array.from(byDay.values()).sort(
+    (a, b) => a.date.getTime() - b.date.getTime(),
+  );
+}
+
+export async function getMeetingCalendar(
+  options: {
+    start?: Date;
+    end?: Date;
+    includeHidden?: boolean;
+  } = {},
+): Promise<MeetingDaySummary[]> {
+  const now = options.start ?? new Date();
+  const dayRange = createMeetingDayRange(now, MEETING_DAY_RANGE);
+  const lastDay = dayRange.at(-1)?.date ?? now;
+  const rangeEnd = options.end ?? addDays(lastDay, 1);
+  const includeHidden = options.includeHidden ?? false;
+
+  const slots = await db.query.meetingSlots.findMany({
+    where: (slots, { and: andFn, gte: gteFn, lt: ltFn, eq: eqFn }) =>
+      andFn(
+        gteFn(slots.startAt, now),
+        ltFn(slots.startAt, rangeEnd),
+        includeHidden ? undefined : eqFn(slots.isPublished, true),
+      ),
+    with: {
+      booking: true,
+      assignedStaff: {
+        columns: { id: true, name: true, email: true },
+      },
+    },
+    orderBy: (slots, { asc: ascFn }) => ascFn(slots.startAt),
+  });
+
+  const summaries = normalizeSlots(slots, { includeHidden });
+  const summaryByKey = new Map(summaries.map((summary) => [summary.dateKey, summary]));
+
+  return dayRange.map(({ date, dateKey }) => {
+    const match = summaryByKey.get(dateKey);
+    if (match) {
+      return match;
+    }
+
+    return {
+      date,
+      dateKey,
+      availableSlots: 0,
+      totalSlots: 0,
+      status: "full" as const,
+      slots: [],
+    } satisfies MeetingDaySummary;
+  });
+}
+
+export async function getUpcomingMeetings(limit = 8) {
+  const now = new Date();
+
+  const results = await db
+    .select({
+      slotId: meetingSlots.id,
+      startAt: meetingSlots.startAt,
+      endAt: meetingSlots.endAt,
+      assignedStaffName: meetingSlots.assignedStaffName,
+      publicDescription: meetingSlots.publicDescription,
+      personName: meetingBookings.personName,
+      company: meetingBookings.company,
+      email: meetingBookings.email,
+      reason: meetingBookings.reason,
+      bookingCreatedAt: meetingBookings.createdAt,
+    })
+    .from(meetingSlots)
+    .innerJoin(
+      meetingBookings,
+      eq(meetingBookings.slotId, meetingSlots.id),
+    )
+    .where(and(gte(meetingSlots.startAt, now), eq(meetingSlots.status, "booked")))
+    .orderBy(asc(meetingSlots.startAt))
+    .limit(limit);
+
+  return results.map((row) => ({
+    ...row,
+    dayKey: getMeetingDateKey(row.startAt),
+    isoDate: formatIsoDateUtc(row.startAt),
+  }));
+}
+
+export async function getStaffMembers() {
+  const staff = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+    })
+    .from(users)
+    .where(eq(users.role, "staff"))
+    .orderBy(asc(users.name));
+
+  return staff;
+}
+
+export async function getSlotById(id: string): Promise<MeetingSlotWithRelations | null> {
+  const slot = await db.query.meetingSlots.findFirst({
+    where: (slots, { eq }) => eq(slots.id, id),
+    with: {
+      booking: true,
+      assignedStaff: {
+        columns: { id: true, name: true, email: true },
+      },
+    },
+  });
+
+  return slot ?? null;
+}

--- a/apps/www/lib/meetings/types.ts
+++ b/apps/www/lib/meetings/types.ts
@@ -1,0 +1,23 @@
+import type { InferSelectModel } from "drizzle-orm";
+
+import type {
+  meetingBookings,
+  meetingSlots,
+  users,
+} from "@/lib/db/schema";
+
+export type MeetingSlot = InferSelectModel<typeof meetingSlots>;
+export type MeetingBooking = InferSelectModel<typeof meetingBookings>;
+export type MeetingSlotWithRelations = MeetingSlot & {
+  assignedStaff?: Pick<InferSelectModel<typeof users>, "id" | "name" | "email"> | null;
+  booking?: MeetingBooking | null;
+};
+
+export type MeetingDaySummary = {
+  dateKey: string;
+  date: Date;
+  availableSlots: number;
+  totalSlots: number;
+  status: "available" | "limited" | "full";
+  slots: MeetingSlotWithRelations[];
+};

--- a/apps/www/lib/meetings/utils.ts
+++ b/apps/www/lib/meetings/utils.ts
@@ -1,0 +1,130 @@
+import { addDays } from "date-fns";
+
+import { MEETING_DAY_RANGE, MEETING_TIME_ZONE } from "./constants";
+
+const dayFormatter = new Intl.DateTimeFormat("en-CA", {
+  timeZone: MEETING_TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+const fullFormatter = new Intl.DateTimeFormat("en-US", {
+  timeZone: MEETING_TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hourCycle: "h23",
+});
+
+type DayBounds = {
+  startMs: number;
+  length: number;
+};
+
+const dayBoundsCache = new Map<string, DayBounds>();
+
+function getPartValue(
+  parts: Intl.DateTimeFormatPart[],
+  type: Intl.DateTimeFormatPartTypes,
+  fallback = 0,
+): number {
+  const match = parts.find((part) => part.type === type);
+  return match ? Number(match.value) : fallback;
+}
+
+function computeDayStart(dateKey: string): number {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  let guess = new Date(Date.UTC(year, (month ?? 1) - 1, day ?? 1, 0, 0, 0));
+
+  for (let index = 0; index < 6; index += 1) {
+    const parts = fullFormatter.formatToParts(guess);
+    const partYear = getPartValue(parts, "year", year ?? guess.getUTCFullYear());
+    const partMonth = getPartValue(parts, "month", month ?? guess.getUTCMonth() + 1);
+    const partDay = getPartValue(parts, "day", day ?? guess.getUTCDate());
+    const partHour = getPartValue(parts, "hour");
+    const partMinute = getPartValue(parts, "minute");
+    const partSecond = getPartValue(parts, "second");
+
+    const localUtcMs = Date.UTC(
+      partYear,
+      (partMonth ?? 1) - 1,
+      partDay ?? 1,
+      partHour,
+      partMinute,
+      partSecond,
+    );
+    const targetUtcMs = Date.UTC(year ?? partYear, (month ?? 1) - 1, day ?? 1, 0, 0, 0);
+    const diff = localUtcMs - targetUtcMs;
+
+    if (Math.abs(diff) <= 30_000) {
+      break;
+    }
+
+    guess = new Date(guess.getTime() - diff);
+  }
+
+  return guess.getTime();
+}
+
+function getDayBounds(dateKey: string): DayBounds {
+  let cached = dayBoundsCache.get(dateKey);
+
+  if (!cached) {
+    const startMs = computeDayStart(dateKey);
+    const nextDateKey = getMeetingDateKey(
+      addDays(getDateFromMeetingKey(dateKey), 1),
+    );
+    const nextStartMs = computeDayStart(nextDateKey);
+    const length = Math.max(
+      1,
+      Math.round((nextStartMs - startMs) / 60_000),
+    );
+
+    cached = { startMs, length } satisfies DayBounds;
+    dayBoundsCache.set(dateKey, cached);
+  }
+
+  return cached;
+}
+
+export function getMeetingDateKey(date: Date): string {
+  return dayFormatter.format(date);
+}
+
+export function getDateFromMeetingKey(key: string): Date {
+  const [year, month, day] = key.split("-").map(Number);
+  return new Date(Date.UTC(year, (month ?? 1) - 1, day ?? 1));
+}
+
+export function createMeetingDayRange(
+  start: Date,
+  days: number = MEETING_DAY_RANGE,
+): { date: Date; dateKey: string }[] {
+  const normalizedStart = getDateFromMeetingKey(getMeetingDateKey(start));
+  return Array.from({ length: days }, (_, index) => {
+    const date = addDays(normalizedStart, index);
+    return { date, dateKey: getMeetingDateKey(date) };
+  });
+}
+
+export function getMeetingDayLengthMinutes(dateKey: string): number {
+  return getDayBounds(dateKey).length;
+}
+
+export function getMeetingMinutesFromIso(iso: string): number {
+  const date = new Date(iso);
+  const dateKey = getMeetingDateKey(date);
+  const { startMs } = getDayBounds(dateKey);
+  return Math.round((date.getTime() - startMs) / 60_000);
+}
+
+export function meetingMinutesToIso(dateKey: string, minutes: number): string {
+  const { startMs, length } = getDayBounds(dateKey);
+  const clamped = Math.min(Math.max(Math.round(minutes), 0), length);
+  const instant = new Date(startMs + clamped * 60_000);
+  return instant.toISOString();
+}

--- a/apps/www/lib/meetings/validation.ts
+++ b/apps/www/lib/meetings/validation.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+import { MEETING_SLOT_INCREMENT_MINUTES } from "./constants";
+
+const dateValueSchema = z
+  .union([z.date(), z.string().datetime({ offset: true })])
+  .transform((value) => (value instanceof Date ? value : new Date(value)));
+
+const slotTimingObjectSchema = z.object({
+  startAt: dateValueSchema,
+  endAt: dateValueSchema,
+});
+
+function validateSlotTiming(
+  value: z.infer<typeof slotTimingObjectSchema>,
+  ctx: z.RefinementCtx,
+) {
+  if (value.endAt.getTime() <= value.startAt.getTime()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["endAt"],
+      message: "End time must be after start time",
+    });
+  }
+
+  const duration = (value.endAt.getTime() - value.startAt.getTime()) / (1000 * 60);
+  if (duration < MEETING_SLOT_INCREMENT_MINUTES) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["endAt"],
+      message: "Slot duration must be at least 15 minutes",
+    });
+  }
+}
+
+export const meetingBookingSchema = z.object({
+  slotId: z.string().min(1),
+  reason: z.string().min(3).max(240),
+  company: z
+    .string()
+    .trim()
+    .min(1)
+    .max(160)
+    .optional()
+    .or(z.literal(""))
+    .transform((value) => value?.trim() || undefined),
+  personName: z.string().min(2).max(160),
+  email: z.string().email().max(320),
+  description: z.string().min(10).max(1000),
+  locale: z.string().min(2).max(8),
+});
+
+export const slotTimingSchema = slotTimingObjectSchema.superRefine(
+  validateSlotTiming,
+);
+
+export const slotMetadataSchema = z.object({
+  publicDescription: z
+    .string()
+    .max(280)
+    .optional()
+    .or(z.literal(""))
+    .transform((value) => value?.trim() || undefined),
+  assignedStaffId: z
+    .string()
+    .min(1)
+    .optional()
+    .or(z.literal(""))
+    .transform((value) => value?.trim() || undefined),
+  assignedStaffName: z
+    .string()
+    .max(160)
+    .optional()
+    .or(z.literal(""))
+    .transform((value) => value?.trim() || undefined),
+  isPublished: z.boolean().optional(),
+});
+
+const createSlotObjectSchema = slotTimingObjectSchema
+  .merge(slotMetadataSchema)
+  .extend({
+    status: z
+      .enum(["available", "booked", "unavailable"] as const)
+      .optional()
+      .default("available"),
+  });
+
+export const createSlotSchema = createSlotObjectSchema.superRefine(
+  validateSlotTiming,
+);
+
+export const updateSlotSchema = createSlotObjectSchema
+  .extend({
+    slotId: z.string().min(1),
+  })
+  .superRefine(validateSlotTiming);

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -50,6 +50,155 @@
       "discord": "Discord"
     }
   },
+  "Meeting": {
+    "meta": {
+      "title": "Schedule a meeting",
+      "description": "Reserve a TransformAI strategy session within the next two weeks."
+    },
+    "Hero": {
+      "badge": "Schedule a meeting for free",
+      "title": "Book a TransformAI intro session",
+      "subtitle": "Pick a time that fits your agenda. We'll confirm the details and pair you with the right specialist."
+    },
+    "Calendar": {
+      "heading": "Availability",
+      "caption": "Tap a date to review remaining blocks. Colours update in real time as teams book in.",
+      "status": {
+        "available": "Open",
+        "limited": "Nearly full",
+        "full": "Fully booked"
+      },
+      "slotsCount": "{available}/{total} slots open",
+      "noSlots": "No open blocks"
+    },
+    "Slots": {
+      "badge": "Choose your moment",
+      "heading": "Times on {day}",
+      "empty": "This day is fully booked. Try another date to find open time blocks.",
+      "selectError": "Select a time block to continue."
+    },
+    "Form": {
+      "heading": "Tell us a little more",
+      "caption": "We’ll use these details to prepare the agenda and send the meeting link.",
+      "submit": "Schedule meeting",
+      "submitPending": "Scheduling…",
+      "privacy": "We only use your email to share the meeting link and follow-up notes.",
+      "success": {
+        "title": "Meeting confirmed",
+        "message": "The meeting will take place through Google Zoom on {date}. Ten minutes before the meeting you will receive a link to the meeting."
+      },
+      "errors": {
+        "unavailable": "This block was just booked. Please choose another time.",
+        "generic": "We couldn’t schedule this meeting. Please try again."
+      },
+      "fields": {
+        "reason": {
+          "label": "Reason for the meeting",
+          "placeholder": "Share what you’d like to cover"
+        },
+        "company": {
+          "label": "Company (optional)",
+          "placeholder": "Organisation name"
+        },
+        "personName": {
+          "label": "Your name",
+          "placeholder": "Who should we greet?"
+        },
+        "email": {
+          "label": "Email address",
+          "placeholder": "you@company.com"
+        },
+        "description": {
+          "label": "Additional context",
+          "placeholder": "Describe priorities, goals, or questions for this call"
+        }
+      }
+    }
+  },
+  "Planning": {
+    "eyebrow": "Staff planning",
+    "title": "Coordinate availability",
+    "subtitle": "Drag to open new slots, assign teammates, and manage bookings in real time.",
+    "calendar": {
+      "heading": "Team calendar",
+      "caption": "Select a day to view and edit blocks. Availability updates instantly for the public page.",
+      "status": {
+        "available": "Open",
+        "limited": "Limited",
+        "full": "Full"
+      },
+      "count": {
+        "available": "{count, plural, one {# open block} other {# open blocks}}",
+        "booked": "{count, plural, one {# booked} other {# booked}}",
+        "blocked": "{count, plural, one {# blocked} other {# blocked}}",
+        "hidden": "{count, plural, one {# hidden} other {# hidden}}"
+      },
+      "metrics": {
+        "available": "Open: {count}",
+        "booked": "Booked: {count}",
+        "blocked": "Blocked: {count}",
+        "hidden": "Hidden: {count}",
+        "total": "Total: {count}"
+      }
+    },
+    "legend": {
+      "title": "Legend",
+      "available": "Available",
+      "booked": "Booked",
+      "blocked": "Blocked",
+      "hidden": "Hidden"
+    },
+    "timeline": {
+      "heading": "Daily timeline",
+      "createHint": "Drag on the grid to add a new availability block.",
+      "updateHint": "Grab the top or bottom edge to extend or shorten an existing slot.",
+      "availableLabel": "Available block"
+    },
+    "form": {
+      "heading": "Slot details",
+      "empty": "Select a block to manage its settings.",
+      "error": "We couldn’t save these changes. Please try again.",
+      "instructions": "Select a block in the timeline to edit details, assign staff, or remove it.",
+      "booking": {
+        "heading": "Meeting details",
+        "person": "Contact",
+        "company": "Company",
+        "reason": "Reason",
+        "email": "Email"
+      },
+      "labels": {
+        "staff": "Assign staff member",
+        "customStaff": "Display name",
+        "status": "Status",
+        "published": "Visible to clients",
+        "description": "Description shown publicly"
+      },
+      "placeholders": {
+        "customStaff": "Optional name visible to clients",
+        "description": "Add context clients will see when picking this block"
+      },
+      "staff": {
+        "unassigned": "No assignment"
+      },
+      "status": {
+        "available": "Available",
+        "unavailable": "Unavailable"
+      },
+      "alerts": {
+        "bookedLocked": "Booked meetings can’t switch status while confirmed.",
+        "deleteDisabled": "Booked meetings can’t be removed."
+      },
+      "errors": {
+        "deleteBooked": "This block already has a confirmed meeting and can’t be removed."
+      },
+      "actions": {
+        "save": "Save changes",
+        "saving": "Saving…",
+        "delete": "Remove block",
+        "deleting": "Removing…"
+      }
+    }
+  },
   "Contact": {
     "Hero": {
       "eyebrow": "Let’s talk",
@@ -1076,6 +1225,17 @@
       "ratio": {
         "title": "Client-to-staff ratio",
         "caption": "Healthy coverage is between 4:1 and 8:1 so every project has a partner lead."
+      }
+    },
+    "meetings": {
+      "title": "Upcoming meetings",
+      "empty": "No meetings scheduled yet. New bookings will appear here instantly.",
+      "fields": {
+        "when": "When",
+        "reason": "Reason",
+        "contact": "Contact",
+        "staff": "Owner",
+        "notes": "Slot notes"
       }
     },
     "nextSteps": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -50,6 +50,155 @@
       "discord": "Discord"
     }
   },
+  "Meeting": {
+    "meta": {
+      "title": "Plan een afspraak",
+      "description": "Reserveer een TransformAI-strategiesessie in de komende twee weken."
+    },
+    "Hero": {
+      "badge": "Plan gratis een afspraak",
+      "title": "Boek een TransformAI-introsessie",
+      "subtitle": "Kies een moment dat in jouw agenda past. Wij bevestigen de details en koppelen je aan de juiste specialist."
+    },
+    "Calendar": {
+      "heading": "Beschikbaarheid",
+      "caption": "Klik op een datum om de overgebleven blokken te bekijken. Kleuren worden live bijgewerkt zodra teams boeken.",
+      "status": {
+        "available": "Open",
+        "limited": "Bijna vol",
+        "full": "Volgeboekt"
+      },
+      "slotsCount": "Vrij: {available}/{total}",
+      "noSlots": "Geen vrije blokken"
+    },
+    "Slots": {
+      "badge": "Kies je moment",
+      "heading": "Tijden op {day}",
+      "empty": "Deze dag is volgeboekt. Probeer een andere datum om vrije blokken te vinden.",
+      "selectError": "Selecteer een tijdsblok om verder te gaan."
+    },
+    "Form": {
+      "heading": "Vertel ons iets meer",
+      "caption": "Met deze gegevens bereiden we de agenda voor en sturen we de meetinglink.",
+      "submit": "Afspraak inplannen",
+      "submitPending": "Bezig met plannen…",
+      "privacy": "We gebruiken je e-mail alleen voor de meetinglink en opvolging.",
+      "success": {
+        "title": "Meeting bevestigd",
+        "message": "De meeting vindt plaats via Google Zoom op {date}. Tien minuten voor de meeting ontvang je een link."
+      },
+      "errors": {
+        "unavailable": "Dit blok is zojuist geboekt. Kies een ander tijdstip.",
+        "generic": "Het plannen is mislukt. Probeer het opnieuw."
+      },
+      "fields": {
+        "reason": {
+          "label": "Reden voor de meeting",
+          "placeholder": "Waar wil je het over hebben?"
+        },
+        "company": {
+          "label": "Bedrijf (optioneel)",
+          "placeholder": "Naam van de organisatie"
+        },
+        "personName": {
+          "label": "Jouw naam",
+          "placeholder": "Wie mogen we verwelkomen?"
+        },
+        "email": {
+          "label": "E-mailadres",
+          "placeholder": "jij@bedrijf.nl"
+        },
+        "description": {
+          "label": "Aanvullende context",
+          "placeholder": "Beschrijf prioriteiten, doelen of vragen voor dit gesprek"
+        }
+      }
+    }
+  },
+  "Planning": {
+    "eyebrow": "Teamplanning",
+    "title": "Beschikbaarheid afstemmen",
+    "subtitle": "Sleep om nieuwe blokken te openen, wijs teamleden toe en beheer boekingen in realtime.",
+    "calendar": {
+      "heading": "Teamkalender",
+      "caption": "Selecteer een dag om blokken te bekijken en te bewerken. Beschikbaarheid wordt direct doorgezet naar de publieke pagina.",
+      "status": {
+        "available": "Beschikbaar",
+        "limited": "Beperkt",
+        "full": "Vol"
+      },
+      "count": {
+        "available": "{count, plural, one {# open blok} other {# open blokken}}",
+        "booked": "{count, plural, one {# geboekt} other {# geboekt}}",
+        "blocked": "{count, plural, one {# geblokkeerd} other {# geblokkeerd}}",
+        "hidden": "{count, plural, one {# verborgen} other {# verborgen}}"
+      },
+      "metrics": {
+        "available": "Vrij: {count}",
+        "booked": "Bezet: {count}",
+        "blocked": "Geblokkeerd: {count}",
+        "hidden": "Verborgen: {count}",
+        "total": "Totaal: {count}"
+      }
+    },
+    "legend": {
+      "title": "Legenda",
+      "available": "Beschikbaar",
+      "booked": "Geboekt",
+      "blocked": "Niet beschikbaar",
+      "hidden": "Verborgen"
+    },
+    "timeline": {
+      "heading": "Dagindeling",
+      "createHint": "Sleep over het raster om een nieuw beschikbaarheidsblok aan te maken.",
+      "updateHint": "Pak de boven- of onderkant om een slot te verlengen of te verkorten.",
+      "availableLabel": "Beschikbaar blok"
+    },
+    "form": {
+      "heading": "Slotdetails",
+      "empty": "Selecteer een blok om de instellingen te beheren.",
+      "error": "Opslaan is niet gelukt. Probeer het opnieuw.",
+      "instructions": "Selecteer een blok in de tijdlijn om details te bewerken, teamleden toe te wijzen of het te verwijderen.",
+      "booking": {
+        "heading": "Meetingdetails",
+        "person": "Contactpersoon",
+        "company": "Bedrijf",
+        "reason": "Reden",
+        "email": "E-mail"
+      },
+      "labels": {
+        "staff": "Wijs teamlid toe",
+        "customStaff": "Weergavenaam",
+        "status": "Status",
+        "published": "Zichtbaar voor klanten",
+        "description": "Omschrijving voor bezoekers"
+      },
+      "placeholders": {
+        "customStaff": "Optionele naam die klanten zien",
+        "description": "Voeg context toe die zichtbaar is bij dit blok"
+      },
+      "staff": {
+        "unassigned": "Geen toewijzing"
+      },
+      "status": {
+        "available": "Beschikbaar",
+        "unavailable": "Niet beschikbaar"
+      },
+      "alerts": {
+        "bookedLocked": "Geboekte meetings kunnen niet van status veranderen.",
+        "deleteDisabled": "Geboekte meetings kunnen niet worden verwijderd."
+      },
+      "errors": {
+        "deleteBooked": "Dit blok heeft nu een bevestigde meeting en kan niet worden verwijderd."
+      },
+      "actions": {
+        "save": "Wijzigingen opslaan",
+        "saving": "Opslaan…",
+        "delete": "Blok verwijderen",
+        "deleting": "Verwijderen…"
+      }
+    }
+  },
   "Contact": {
     "Hero": {
       "eyebrow": "Laten we praten",
@@ -1033,6 +1182,17 @@
       "ratio": {
         "title": "Verhouding klant/staff",
         "caption": "Een gezonde dekking ligt tussen 4:1 en 8:1 zodat elk project een partnerlead heeft."
+      }
+    },
+    "meetings": {
+      "title": "Aankomende meetings",
+      "empty": "Er staan nog geen meetings gepland. Nieuwe boekingen verschijnen hier direct.",
+      "fields": {
+        "when": "Wanneer",
+        "reason": "Reden",
+        "contact": "Contact",
+        "staff": "Eigenaar",
+        "notes": "Slotnotities"
       }
     },
     "nextSteps": {


### PR DESCRIPTION
## Plan
- adjust the meeting calendar normalization so unavailable yet published slots are counted in daily totals
- surface blocked-slot counts and legend treatment in the staff planner UI with updated translations
- record the fix in WRITE_HERE for continuity

## Summary
- include unavailable meeting blocks in the shared calendar summaries so they appear as taken time on public and staff views
- add blocked-slot metrics and legend entries to the staff planner plus refresh English/Dutch copy to describe the new state
- note the resolved visibility bug in WRITE_HERE/FIXES/2025-11-28T1700--meeting-unavailable-visibility.md

## Testing
- `pnpm --filter www run lint` *(fails: missing `next-intl` package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de6f61dfec832a974b30f7404a842f