### PR TITLE
Route Get started CTAs to meeting scheduler

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-28T1900--linked-get-started-ctas-to-meeting.md
+++ b/WRITE_HERE/FIXES/2025-11-28T1900--linked-get-started-ctas-to-meeting.md
@@ -1,0 +1,6 @@
+# Get started CTAs route to meeting scheduler
+
+- **What:** Updated every "Get Started" button across the marketing experience to link to the localized meeting scheduler instead of the legacy Unkey app URL.
+- **Why:** The site now uses a dedicated meeting spot for onboarding conversations and the CTA needed to align with that flow.
+- **Files:** `apps/www/components/hero/hero.tsx`, `apps/www/components/hero/hero-main-section.tsx`, `apps/www/app/[locale]/(site)/page.tsx`, `apps/www/app/code-examples.tsx`, `apps/www/components/cta.tsx`, `apps/www/app/[locale]/(site)/glossary/client.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/glossary/client.tsx
+++ b/apps/www/app/[locale]/(site)/glossary/client.tsx
@@ -10,9 +10,12 @@ import { MeteorLinesAngular } from "@/components/ui/meteorLines";
 import { LogIn } from "lucide-react";
 import { Zap } from "lucide-react";
 import Link from "next/link";
+import { useLocale } from "next-intl";
 
 export function GlossaryClient() {
   const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
+  const locale = useLocale();
+  const meetingHref = `/${locale}/meeting`;
 
   const groupedTerms = allGlossaries.reduce(
     (acc, term) => {
@@ -107,7 +110,7 @@ export function GlossaryClient() {
         </div>
         <div className="flex justify-center gap-6">
           <p className="mt-6 text-base about-founders-text-gradient ">Ready to protect your API?</p>
-          <Link href="https://app.unkey.com" className="group self-end">
+          <Link href={meetingHref} className="group self-end">
             <PrimaryButton shiny IconLeft={LogIn} label="Get started" className="h-8" />
           </Link>
         </div>

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -97,6 +97,8 @@ export default async function Landing({
     notFound();
   }
 
+  const meetingHref = `/${locale}/meeting` as const;
+
   const [cta, platform, hero, featureSection] = await Promise.all([
     getTranslations({ locale, namespace: "CTA" }),
     getTranslations({ locale, namespace: "Platform" }),
@@ -177,7 +179,7 @@ export default async function Landing({
               align="center"
             >
               <div className="flex mt-10 mb-10 space-x-6">
-                <Link href="https://app.unkey.com" className="group">
+                <Link href={meetingHref} className="group">
                   <PrimaryButton
                     shiny
                     IconLeft={LogIn}
@@ -228,7 +230,7 @@ export default async function Landing({
                 text={featureSection("text")}
               >
                 <div className="flex mt-10 mb-10 space-x-6">
-                  <Link href="https://app.unkey.com" className="group">
+                  <Link href={meetingHref} className="group">
                     <PrimaryButton
                       shiny
                       IconLeft={LogIn}

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -517,6 +517,8 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
   const t = useTranslations("CodeExamples");
   const cta = useTranslations("CTA");
   const projectCopy = useTranslations("CodeExamples.projects");
+  const locale = useLocale();
+  const meetingHref = `/${locale}/meeting`;
   const [language, setLanguage] = useState<Language>("AI integration pt1");
   const [framework, setFramework] = useState<FrameworkName>("AI transformation");
   const [languageHover, setLanguageHover] = useState("AI integration pt1");
@@ -630,7 +632,7 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
         </div>
       </div>
       <div className="flex flex-wrap items-center justify-center gap-4 mt-12">
-        <Link key="get-started" href="https://app.unkey.com">
+        <Link key="get-started" href={meetingHref}>
           <PrimaryButton
             shiny
             label={cta("getStarted")}

--- a/apps/www/components/cta.tsx
+++ b/apps/www/components/cta.tsx
@@ -2,13 +2,15 @@
 import { SectionTitle } from "@/components/section";
 import { track } from "@vercel/analytics/server";
 import { CalendarDays, ChevronRight } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import Link from "next/link";
 import type React from "react";
 import { PrimaryButton, SecondaryButton } from "./button";
 
 export const CTA: React.FC = () => {
   const t = useTranslations("Cta");
+  const locale = useLocale();
+  const meetingHref = `/${locale}/meeting`;
 
   return (
     <div className="w-full h-full overflow-hidden">
@@ -33,7 +35,7 @@ export const CTA: React.FC = () => {
               onClick={async () => {
                 await track("sign up", { location: "CTA" });
               }}
-              href="https://app.unkey.com"
+              href={meetingHref}
             >
               <PrimaryButton shiny label={t("secondary")} IconRight={ChevronRight} />
             </Link>

--- a/apps/www/components/hero/hero-main-section.tsx
+++ b/apps/www/components/hero/hero-main-section.tsx
@@ -7,6 +7,7 @@ type HeroMainSectionProps = {
   title: string;
   body: string;
   primaryCtaLabel: string;
+  primaryCtaHref: string;
   secondaryCtaLabel: string;
   hoursSavedLabel: string;
   hoursSavedAmount: string;
@@ -16,6 +17,7 @@ export function HeroMainSection({
   title,
   body,
   primaryCtaLabel,
+  primaryCtaHref,
   secondaryCtaLabel,
   hoursSavedLabel,
   hoursSavedAmount,
@@ -31,7 +33,7 @@ export function HeroMainSection({
       </p>
 
       <div className="mt-16 flex w-full flex-col items-center gap-4 sm:flex-row sm:items-center sm:justify-center sm:gap-8">
-        <Link href="https://app.unkey.com" className="group block w-full sm:inline-flex sm:w-auto sm:flex-shrink-0">
+        <Link href={primaryCtaHref} className="group block w-full sm:inline-flex sm:w-auto sm:flex-shrink-0">
           <PrimaryButton
             shiny
             IconLeft={LogIn}

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { motion } from "framer-motion";
 import Image from "next/image";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { HeroMainSection } from "./hero-main-section";
 
 import mainboard from "@/images/mainboard.svg";
@@ -9,6 +9,8 @@ import { SubHeroMainboard } from "./hero-sub-mainboard";
 export const Hero: React.FC = () => {
   const hero = useTranslations("Hero");
   const cta = useTranslations("CTA");
+  const locale = useLocale();
+  const meetingHref = `/${locale}/meeting`;
 
   const containerVariants = {
     hidden: {},
@@ -40,6 +42,7 @@ export const Hero: React.FC = () => {
           title={hero("title")}
           body={hero("body")}
           primaryCtaLabel={cta("getStarted")}
+          primaryCtaHref={meetingHref}
           secondaryCtaLabel={cta("exploreProjects")}
           hoursSavedLabel={cta("hoursSavedLabel")}
           hoursSavedAmount={cta("hoursSavedAmount")}


### PR DESCRIPTION
## Summary
- compute a locale-aware meeting scheduler href for hero, landing CTAs, glossary promo, code examples, and the global CTA block
- thread the new href into existing button components so every “Get Started” action now routes to the meeting experience
- log the change in WRITE_HERE/FIXES to capture the updated CTA destination

## Plan
- inventory every "Get started" button that still pointed at the legacy Unkey dashboard
- add locale-aware meeting scheduler hrefs in each surface that renders the CTA
- thread the hrefs through the hero component tree and other client sections that render the button label
- verify related analytics hooks remain intact and document the fix

## Testing
- pnpm --filter www run lint *(fails: missing dependency `next-intl` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de8a86d1a8832abd02de5ae27708ce