### PR TITLE
Rename sign-up staff button to client

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-28T1805--rename-staff-button-to-client.md
+++ b/WRITE_HERE/FIXES/2025-11-28T1805--rename-staff-button-to-client.md
@@ -1,0 +1,5 @@
+# Rename create-account staff button label
+- **What:** Updated the sign-up toggle button label from "Staff" to "Client" via localized message catalogs so only the copy changes.
+- **Why:** The user requested the button read "Client" while keeping the underlying staff verification flow intact.
+- **Files:** `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -1123,7 +1123,7 @@
       "eyebrow": "Members",
       "title": "Create your TransformAI account",
       "subtitle": "Unlock tailored AI news and staff dashboards.",
-      "staffButton": "Staff",
+      "staffButton": "Client",
       "staffModeOn": "Staff mode",
       "staffDialog": {
         "title": "Staff access code",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -1080,7 +1080,7 @@
       "eyebrow": "Leden",
       "title": "Maak je TransformAI-account",
       "subtitle": "Ontvang exclusieve AI-updates en toegang tot het teamdashboard.",
-      "staffButton": "Staff",
+      "staffButton": "Client",
       "staffModeOn": "Staff-modus",
       "staffDialog": {
         "title": "Staff-toegangscode",


### PR DESCRIPTION
## Summary
- rename the create account staff toggle button label to display "Client"
- update both English and Dutch message catalogs to keep translations in sync
- log the user-requested copy tweak in the fixes ledger

## Plan
- review the sign-up form translation keys that drive the staff toggle label
- adjust the relevant message values to show the new "Client" label without changing behavior
- document the copy-only update in WRITE_HERE/FIXES

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de8b062324832aa37616fde78b6527