### PR TITLE
Highlight meeting request form after slot selection

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-28T1800--meeting-form-selection-highlight.md
+++ b/WRITE_HERE/FIXES/2025-11-28T1800--meeting-form-selection-highlight.md
@@ -1,0 +1,5 @@
+# Highlight meeting form when a slot is selected
+- **What:** Added a reactive emerald accent to the meeting request form card so it glows green whenever a time slot is chosen, reinforcing the selected state visually.
+- **Why:** Users reported it was unclear that a slot selection activated the form; the green treatment mirrors the slot highlight for stronger confirmation.
+- **Files:** `apps/www/app/[locale]/(site)/meeting/components/scheduler.tsx`
+- **Follow-ups:** Consider extending the green accent to individual field focus states if additional reinforcement is needed.

--- a/apps/www/app/[locale]/(site)/meeting/components/scheduler.tsx
+++ b/apps/www/app/[locale]/(site)/meeting/components/scheduler.tsx
@@ -393,6 +393,8 @@ export function MeetingScheduler({ days, locale }: SchedulerProps) {
     });
   }, [locale, selectedTimeZone, state, t]);
 
+  const isSlotSelected = Boolean(selectedSlotId);
+
   return (
     <div className="space-y-10">
       <div className="rounded-3xl border border-white/12 bg-white/[0.04] p-6 shadow-[0_32px_120px_rgba(15,23,42,0.45)]">
@@ -507,7 +509,11 @@ export function MeetingScheduler({ days, locale }: SchedulerProps) {
 
         <form
           action={formAction}
-          className="rounded-3xl border border-white/15 bg-white/[0.04] p-6 shadow-[0_32px_120px_rgba(15,23,42,0.45)]"
+          className={cn(
+            "rounded-3xl border border-white/15 bg-white/[0.04] p-6 shadow-[0_32px_120px_rgba(15,23,42,0.45)] transition-all duration-300",
+            isSlotSelected &&
+              "border-emerald-400/60 bg-emerald-500/10 shadow-[0_32px_140px_rgba(16,185,129,0.35)] ring-1 ring-emerald-300/40 ring-offset-0",
+          )}
         >
           <input type="hidden" name="slotId" value={selectedSlotId ?? ""} />
           <input type="hidden" name="locale" value={locale} />


### PR DESCRIPTION
## Summary
- add a green accent state to the meeting request form card when a slot is selected for clearer visual feedback
- document the adjustment in the project FIXES log

## Plan
- review the meeting scheduler component to understand how slot selection state is handled
- toggle accent styling on the form container when a slot has been chosen
- record the change in WRITE_HERE/FIXES for traceability

## Testing
- pnpm --filter www run lint *(fails: missing `next-intl` dependency in the local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de8c904644832a831c4928c167d7b4