### PR TITLE
Restore daily visitor chart visibility

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-28T2100--visitor-session-cookie-registration.md
+++ b/WRITE_HERE/FIXES/2025-11-28T2100--visitor-session-cookie-registration.md
@@ -1,0 +1,6 @@
+# Restore visitor session tracking without layout cookie mutation
+
+- **What:** Replaced the layout-level `cookies().set` call with a client-side initializer that posts to a dedicated `/api/visitor-sessions` route, which records the visit and sets the tracking cookie legally. Shared cookie constants across server and client and reused the logging helper.
+- **Why:** Next.js forbids mutating cookies directly inside layouts, causing runtime crashes on the staff dashboard. The new API route + client bootstrap keeps analytics functional without violating framework constraints.
+- **Files:** `apps/www/app/[locale]/layout.tsx`, `apps/www/app/visitor-session-initializer.tsx`, `apps/www/app/api/visitor-sessions/route.ts`, `apps/www/lib/visitors.ts`, `apps/www/lib/visitors/constants.ts`.
+- **Follow-ups:** Consider batching visitor writes or adding bot filtering once production traffic patterns are known.

--- a/WRITE_HERE/UPDATES/2025-10-02T1452--staff-dashboard-account-and-visitor-insights.md
+++ b/WRITE_HERE/UPDATES/2025-10-02T1452--staff-dashboard-account-and-visitor-insights.md
@@ -1,0 +1,6 @@
+# Added staff dashboard account and visitor insights
+
+- **What:** Added interactive roster dialogs for client and staff counts, began recording visitor sessions, and surfaced hourly/daily traffic charts in the staff dashboard.
+- **Why:** Staff requested visibility into individual accounts and visitor momentum to better monitor platform adoption.
+- **Files:** `apps/www/app/[locale]/(site)/dashboard/page.tsx`, `apps/www/app/[locale]/(site)/dashboard/components/visitors-chart.tsx`, `apps/www/lib/visitors.ts`, `apps/www/lib/db/schema.ts`, `apps/www/messages/*.json`, `apps/www/drizzle/0002_add_visitor_sessions.sql`, layout updates.
+- **Follow-ups:** Backfill historical visitor data if available and consider richer segmentation once real traffic accumulates.

--- a/WRITE_HERE/UPDATES/2025-11-29T1200--visitor-chart-scroll-and-24h-format.md
+++ b/WRITE_HERE/UPDATES/2025-11-29T1200--visitor-chart-scroll-and-24h-format.md
@@ -1,0 +1,10 @@
+# Visitor traffic chart gains scrollable layout and 24-hour labels
+
+- **What:** Added a horizontal scroll rail with axis ticks to the visitor chart so long time ranges stay legible, scaled bar
+  heights to the active tab's maximum, and switched hourly labels/tooltips to a 24-hour clock.
+- **Why:** The staff team asked for easier comparison between periods, better visual differentiation of traffic spikes, and
+  European-style time formatting in the dashboard overview.
+- **Files:** `apps/www/app/[locale]/(site)/dashboard/components/visitors-chart.tsx`,
+  `apps/www/app/[locale]/(site)/dashboard/page.tsx`.
+- **Follow-ups:** Consider persisting user tab preference and expanding analytics with visitor sources once tracking data
+  grows.

--- a/WRITE_HERE/UPDATES/2025-11-29T1605--visitor-chart-percentage-axis-and-horizontal-scroll.md
+++ b/WRITE_HERE/UPDATES/2025-11-29T1605--visitor-chart-percentage-axis-and-horizontal-scroll.md
@@ -1,0 +1,9 @@
+# Visitor chart percentage scaling and horizontal scroll polish
+
+- **What:** Reworked the visitor traffic chart with a true horizontal scroll rail, a percentage-based axis that normalizes each
+  bucket between the minimum and maximum values, and hidden bar chrome for zero-count intervals so flat periods no longer draw
+  ghost bars.
+- **Why:** Followed up on feedback that only a vertical scrollbar appeared previously and that zero-value entries still looked
+  active despite carrying no visits.
+- **Files:** `apps/www/app/[locale]/(site)/dashboard/components/visitors-chart.tsx`.
+- **Follow-ups:** Consider persisting the last selected tab so returning staff members land on their preferred range.

--- a/WRITE_HERE/UPDATES/2025-11-29T1730--visitor-chart-daily-scroll-access.md
+++ b/WRITE_HERE/UPDATES/2025-11-29T1730--visitor-chart-daily-scroll-access.md
@@ -1,0 +1,6 @@
+# Daily visitor chart shows all buckets
+
+- **What:** Adjusted the visitor traffic component so the scroller spans the available width, removed the forced 960px baseline for the daily view, and kept horizontal scrolling for the hourly dataset only when needed.
+- **Why:** Daily analytics buckets were clipped without a horizontal scrollbar, preventing staff from reviewing all days at once.
+- **Files:** `apps/www/app/[locale]/(site)/dashboard/components/visitors-chart.tsx`.
+- **Follow-ups:** Consider persisting the active tab and last scroll position for returning staff members.

--- a/apps/www/app/[locale]/(site)/dashboard/components/visitors-chart.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/components/visitors-chart.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+export type VisitorsChartBucket = {
+  id: string;
+  label: string;
+  count: number;
+  tooltip: string;
+};
+
+type VisitorsChartSectionProps = {
+  hourly: VisitorsChartBucket[];
+  daily: VisitorsChartBucket[];
+  tabLabels: {
+    hourly: string;
+    daily: string;
+  };
+  emptyMessages: {
+    hourly: string;
+    daily: string;
+  };
+};
+
+export function VisitorsChartSection({ hourly, daily, tabLabels, emptyMessages }: VisitorsChartSectionProps) {
+  const [activeTab, setActiveTab] = useState<"hourly" | "daily">("hourly");
+
+  const data = activeTab === "hourly" ? hourly : daily;
+  const emptyMessage = activeTab === "hourly" ? emptyMessages.hourly : emptyMessages.daily;
+  const maxValue = data.reduce((max, bucket) => Math.max(max, bucket.count), 0);
+  const minValue = data.reduce((min, bucket) => Math.min(min, bucket.count), Number.POSITIVE_INFINITY);
+  const effectiveMin = Number.isFinite(minValue) ? Math.min(minValue, maxValue) : 0;
+  const normalizedRange = maxValue - effectiveMin;
+  const allZero = data.every((bucket) => bucket.count === 0);
+  const yAxisTicks = [100, 75, 50, 25, 0];
+  const minBarWidth = 40;
+  const baseMinWidth = activeTab === "hourly" ? 960 : 0;
+  const chartMinWidth = Math.max(data.length * minBarWidth, baseMinWidth);
+
+  return (
+    <div className="space-y-6">
+      <div className="inline-flex rounded-full bg-white/10 p-1 text-xs">
+        <button
+          type="button"
+          onClick={() => setActiveTab("hourly")}
+          aria-pressed={activeTab === "hourly"}
+          className={cn(
+            "rounded-full px-4 py-2 font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950",
+            activeTab === "hourly" ? "bg-white/25 text-white" : "text-white/60 hover:text-white/80",
+          )}
+        >
+          {tabLabels.hourly}
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab("daily")}
+          aria-pressed={activeTab === "daily"}
+          className={cn(
+            "rounded-full px-4 py-2 font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950",
+            activeTab === "daily" ? "bg-white/25 text-white" : "text-white/60 hover:text-white/80",
+          )}
+        >
+          {tabLabels.daily}
+        </button>
+      </div>
+
+      <TooltipProvider delayDuration={0}>
+        <div className="flex h-64 gap-4">
+          <div className="flex h-52 flex-col justify-between py-1 text-right text-xs uppercase tracking-[0.12em] text-white/40">
+            {yAxisTicks.map((tick) => (
+              <span key={`${activeTab}-tick-${tick}`}>{`${tick}%`}</span>
+            ))}
+          </div>
+          <div className="w-full overflow-x-auto overflow-y-hidden pb-2">
+            <div
+              className="flex h-64 items-end gap-2 sm:gap-3"
+              style={{ minWidth: `${chartMinWidth}px` }}
+            >
+              {data.map((bucket) => {
+                const rawHeightPercent =
+                  normalizedRange > 0
+                    ? ((bucket.count - effectiveMin) / normalizedRange) * 100
+                    : bucket.count > 0
+                      ? 100
+                      : 0;
+                const heightPercent = Math.max(0, Math.min(rawHeightPercent, 100));
+                const showBar = bucket.count > 0;
+
+                return (
+                  <Tooltip key={`${activeTab}-${bucket.id}`}>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className="group relative flex min-w-[2.5rem] flex-1 cursor-default flex-col items-center gap-2 focus:outline-none"
+                        aria-label={bucket.tooltip}
+                      >
+                        <div
+                          className={cn(
+                            "flex h-52 w-full items-end overflow-hidden rounded-xl border border-white/10 bg-white/5",
+                            !showBar && "border-transparent bg-transparent",
+                          )}
+                        >
+                          <div
+                            className="w-full rounded-t-xl bg-gradient-to-t from-blue-500/40 via-blue-400/70 to-blue-200/90 shadow-[0_0_25px_rgba(59,130,246,0.35)] transition-all duration-300 ease-out group-hover:from-blue-400/60 group-hover:to-blue-100/90"
+                            style={{ height: `${heightPercent}%` }}
+                          />
+                        </div>
+                        <span className="block text-xs font-medium uppercase tracking-[0.2em] text-white/50">
+                          {bucket.label}
+                        </span>
+                        <span className="sr-only">{bucket.count}</span>
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent className="border-white/20 bg-neutral-900 text-white">
+                      {bucket.tooltip}
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </TooltipProvider>
+
+      {allZero ? (
+        <p className="text-sm text-white/60">{emptyMessage}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/www/app/[locale]/(site)/dashboard/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/page.tsx
@@ -1,12 +1,29 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { getAuthSession } from "@/lib/auth";
 import { db } from "@/lib/db/client";
 import { users } from "@/lib/db/schema";
 import { formatDateWithZone } from "@/lib/date";
 import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
 import { getUpcomingMeetings } from "@/lib/meetings/queries";
-import { cn } from "@/lib/utils";
-import { sql } from "drizzle-orm";
+import { getVisitorOverview, type VisitorOverview } from "@/lib/visitors";
+import { VisitorsChartSection, type VisitorsChartBucket } from "./components/visitors-chart";
+import { desc, eq, sql } from "drizzle-orm";
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
 
@@ -26,41 +43,102 @@ export default async function DashboardPage({ params }: PageProps) {
 
   const t = await getTranslations({ locale, namespace: "Dashboard" });
 
-  const roleCounts = await db
-    .select({
-      role: users.role,
-      total: sql<number>`count(*)`,
-    })
-    .from(users)
-    .groupBy(users.role);
+  const [roleCounts, upcomingMeetings, clientAccounts, staffAccounts, visitorOverview] =
+    await Promise.all([
+      db
+        .select({
+          role: users.role,
+          total: sql<number>`count(*)`,
+        })
+        .from(users)
+        .groupBy(users.role),
+      getUpcomingMeetings(8),
+      db
+        .select({
+          id: users.id,
+          name: users.name,
+          email: users.email,
+          createdAt: users.createdAt,
+        })
+        .from(users)
+        .where(eq(users.role, "client"))
+        .orderBy(desc(users.createdAt)),
+      db
+        .select({
+          id: users.id,
+          name: users.name,
+          email: users.email,
+          createdAt: users.createdAt,
+        })
+        .from(users)
+        .where(eq(users.role, "staff"))
+        .orderBy(desc(users.createdAt)),
+      getVisitorOverview(),
+    ]);
+
+  type UpcomingMeeting = (typeof upcomingMeetings)[number];
 
   const totals: Record<string, number> = { client: 0, staff: 0 };
   for (const row of roleCounts) {
     totals[row.role] = Number(row.total);
   }
 
-  const upcomingMeetings = await getUpcomingMeetings(8);
+  const visitorTabs = {
+    hourly: t("visitors.tabs.hourly"),
+    daily: t("visitors.tabs.daily"),
+  } as const;
 
-  const metrics = [
-    {
-      key: "client",
-      title: t("metrics.clients.title"),
-      value: totals.client,
-      caption: t("metrics.clients.caption", { count: totals.client }),
-    },
-    {
-      key: "staff",
-      title: t("metrics.staff.title"),
-      value: totals.staff,
-      caption: t("metrics.staff.caption", { count: totals.staff }),
-    },
-    {
-      key: "ratio",
-      title: t("metrics.ratio.title"),
-      value: totals.staff === 0 ? "–" : `${(totals.client / totals.staff).toFixed(1)} : 1`,
-      caption: t("metrics.ratio.caption"),
-    },
-  ];
+  const visitorEmptyMessages = {
+    hourly: t("visitors.empty.hourly"),
+    daily: t("visitors.empty.daily"),
+  } as const;
+
+  const hourLabelFormatter = new Intl.DateTimeFormat(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const dayLabelFormatter = new Intl.DateTimeFormat(locale, {
+    weekday: "short",
+    day: "numeric",
+  });
+  const dayTooltipFormatter = new Intl.DateTimeFormat(locale, {
+    dateStyle: "full",
+  });
+
+  const hourlyChartData = visitorOverview.hourly.map(
+    (bucket: VisitorOverview["hourly"][number]): VisitorsChartBucket => ({
+      id: bucket.start.toISOString(),
+      label: hourLabelFormatter.format(bucket.start),
+      count: bucket.count,
+      tooltip: t("visitors.tooltip.hour", {
+        count: bucket.count,
+        start: hourLabelFormatter.format(bucket.start),
+        end: hourLabelFormatter.format(bucket.end),
+      }),
+    }),
+  );
+
+  const dailyChartData = visitorOverview.daily.map(
+    (bucket: VisitorOverview["daily"][number]): VisitorsChartBucket => ({
+      id: bucket.day.toISOString(),
+      label: dayLabelFormatter.format(bucket.day),
+      count: bucket.count,
+      tooltip: t("visitors.tooltip.day", {
+        count: bucket.count,
+        day: dayTooltipFormatter.format(bucket.day),
+      }),
+    }),
+  );
+
+  const accountColumnLabels = {
+    name: t("accounts.columns.name"),
+    email: t("accounts.columns.email"),
+    createdAt: t("accounts.columns.createdAt"),
+  } as const;
+
+  const ratioValue =
+    totals.staff === 0 ? "–" : `${(totals.client / Math.max(totals.staff, 1)).toFixed(1)} : 1`;
 
   return (
     <div className="relative isolate min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top,_rgba(37,99,235,0.22),_transparent_55%)] py-28">
@@ -80,28 +158,127 @@ export default async function DashboardPage({ params }: PageProps) {
           </div>
         </div>
 
-        <div className="mt-16 grid gap-6 md:grid-cols-3">
-          {metrics.map((metric, index) => (
-            <Card
-              key={metric.key}
-              className={cn(
-                "relative overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition",
-                index === 0 ? "md:col-span-1" : "",
-              )}
-            >
-              <CardHeader className="pb-4">
-                <CardTitle className="text-lg font-semibold text-white/70">
-                  {metric.title}
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="pb-6">
-                <p className="text-4xl font-semibold tracking-tight text-white">
-                  {typeof metric.value === "number" ? metric.value.toLocaleString(locale) : metric.value}
-                </p>
-                <p className="mt-2 text-sm text-white/60">{metric.caption}</p>
-              </CardContent>
-            </Card>
-          ))}
+        <div className="mt-16 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+          <Dialog>
+            <DialogTrigger asChild>
+              <button
+                type="button"
+                className="text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              >
+                <Card className="relative overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition hover:border-white/20">
+                  <CardHeader className="pb-4">
+                    <CardTitle className="text-lg font-semibold text-white/70">
+                      {t("metrics.clients.title")}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="pb-6">
+                    <p className="text-4xl font-semibold tracking-tight text-white">
+                      {totals.client.toLocaleString(locale)}
+                    </p>
+                    <p className="mt-2 text-sm text-white/60">
+                      {t("metrics.clients.caption", { count: totals.client })}
+                    </p>
+                  </CardContent>
+                </Card>
+              </button>
+            </DialogTrigger>
+            <AccountListDialog
+              title={t("accounts.clients.title")}
+              description={t("accounts.clients.description")}
+              emptyLabel={t("accounts.clients.empty")}
+              accounts={clientAccounts}
+              locale={locale}
+              columns={accountColumnLabels}
+            />
+          </Dialog>
+
+          <Dialog>
+            <DialogTrigger asChild>
+              <button
+                type="button"
+                className="text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              >
+                <Card className="relative overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition hover:border-white/20">
+                  <CardHeader className="pb-4">
+                    <CardTitle className="text-lg font-semibold text-white/70">
+                      {t("metrics.staff.title")}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="pb-6">
+                    <p className="text-4xl font-semibold tracking-tight text-white">
+                      {totals.staff.toLocaleString(locale)}
+                    </p>
+                    <p className="mt-2 text-sm text-white/60">
+                      {t("metrics.staff.caption", { count: totals.staff })}
+                    </p>
+                  </CardContent>
+                </Card>
+              </button>
+            </DialogTrigger>
+            <AccountListDialog
+              title={t("accounts.staff.title")}
+              description={t("accounts.staff.description")}
+              emptyLabel={t("accounts.staff.empty")}
+              accounts={staffAccounts}
+              locale={locale}
+              columns={accountColumnLabels}
+            />
+          </Dialog>
+
+          <Dialog>
+            <DialogTrigger asChild>
+              <button
+                type="button"
+                className="text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              >
+                <Card className="relative overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition hover:border-white/20">
+                  <CardHeader className="pb-4">
+                    <CardTitle className="text-lg font-semibold text-white/70">
+                      {t("metrics.visitors.title")}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="pb-6">
+                    <p className="text-4xl font-semibold tracking-tight text-white">
+                      {visitorOverview.total.toLocaleString(locale)}
+                    </p>
+                    <p className="mt-2 text-sm text-white/60">
+                      {t("metrics.visitors.caption", { count: visitorOverview.total })}
+                    </p>
+                  </CardContent>
+                </Card>
+              </button>
+            </DialogTrigger>
+            <DialogContent className="max-w-3xl bg-neutral-950 text-white">
+              <DialogHeader>
+                <DialogTitle className="text-white">
+                  {t("visitors.title")}
+                </DialogTitle>
+                <DialogDescription className="text-white/60">
+                  {t("visitors.description")}
+                </DialogDescription>
+              </DialogHeader>
+              <div className="mt-6">
+                <VisitorsChartSection
+                  hourly={hourlyChartData}
+                  daily={dailyChartData}
+                  tabLabels={visitorTabs}
+                  emptyMessages={visitorEmptyMessages}
+                />
+              </div>
+            </DialogContent>
+          </Dialog>
+
+          <Card className="relative overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl">
+            <CardHeader className="pb-4">
+              <CardTitle className="text-lg font-semibold text-white/70">
+                {t("metrics.ratio.title")}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="pb-6">
+              <p className="text-4xl font-semibold tracking-tight text-white">{ratioValue}</p>
+              <p className="mt-2 text-sm text-white/60">{t("metrics.ratio.caption")}</p>
+            </CardContent>
+          </Card>
         </div>
 
         <div className="mt-16 space-y-6">
@@ -115,7 +292,7 @@ export default async function DashboardPage({ params }: PageProps) {
               </p>
             ) : (
               <div className="mt-4 grid gap-4">
-                {upcomingMeetings.map((meeting) => {
+                {upcomingMeetings.map((meeting: UpcomingMeeting) => {
                   const startLabel = formatDateWithZone(
                     meeting.startAt,
                     {
@@ -198,6 +375,90 @@ type DashboardMeetingFieldProps = {
   label: string;
   value: string;
 };
+
+type AccountSummary = {
+  id: string;
+  name: string | null;
+  email: string;
+  createdAt: Date | null;
+};
+
+type AccountListDialogProps = {
+  title: string;
+  description: string;
+  accounts: AccountSummary[];
+  locale: string;
+  emptyLabel: string;
+  columns: {
+    name: string;
+    email: string;
+    createdAt: string;
+  };
+};
+
+function AccountListDialog({
+  title,
+  description,
+  accounts,
+  locale,
+  emptyLabel,
+  columns,
+}: AccountListDialogProps) {
+  const dateFormatter = new Intl.DateTimeFormat(locale, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+
+  return (
+    <DialogContent className="max-w-2xl bg-neutral-950 text-white sm:max-w-3xl">
+      <DialogHeader>
+        <DialogTitle className="text-white">{title}</DialogTitle>
+        <DialogDescription className="text-white/60">{description}</DialogDescription>
+      </DialogHeader>
+
+      {accounts.length === 0 ? (
+        <p className="mt-6 rounded-xl border border-white/10 bg-white/5 px-4 py-6 text-sm text-white/60">{emptyLabel}</p>
+      ) : (
+        <div className="mt-6 rounded-xl border border-white/10 bg-black/30">
+          <div className="max-h-[320px] overflow-y-auto">
+            <Table className="min-w-full text-sm text-white/80">
+              <TableHeader>
+                <TableRow className="border-white/10 text-white/50">
+                  <TableHead className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+                    {columns.name}
+                  </TableHead>
+                  <TableHead className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+                    {columns.email}
+                  </TableHead>
+                  <TableHead className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+                    {columns.createdAt}
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {accounts.map((account) => {
+                  const createdAt = account.createdAt ? new Date(account.createdAt) : null;
+
+                  return (
+                    <TableRow key={account.id} className="border-white/10 text-white/80">
+                      <TableCell className="align-top font-medium text-white">
+                        {account.name?.trim() || "–"}
+                      </TableCell>
+                      <TableCell className="align-top text-white/70">{account.email}</TableCell>
+                      <TableCell className="align-top text-white/60">
+                        {createdAt ? dateFormatter.format(createdAt) : "–"}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      )}
+    </DialogContent>
+  );
+}
 
 function DashboardMeetingField({ label, value }: DashboardMeetingFieldProps) {
   return (

--- a/apps/www/app/[locale]/layout.tsx
+++ b/apps/www/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import type { ReactNode } from "react";
 
 import { ConsentBanner } from "../consent-banner";
 import { Tracking } from "../tracking";
+import { VisitorSessionInitializer } from "../visitor-session-initializer";
 
 const parsedEnv = env();
 
@@ -106,6 +107,7 @@ export default async function LocaleLayout({
 
         <div className="relative overflow-x-clip">
           <Navigation />
+          <VisitorSessionInitializer />
           {children}
           <Tracking />
           {process.env.NODE_ENV !== "production" ? (

--- a/apps/www/app/api/visitor-sessions/route.ts
+++ b/apps/www/app/api/visitor-sessions/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  VISITOR_COOKIE_MAX_AGE_SECONDS,
+  VISITOR_COOKIE_NAME,
+} from "@/lib/visitors/constants";
+import { recordVisitorSession } from "@/lib/visitors";
+
+export async function POST(request: NextRequest) {
+  const existing = request.cookies.get(VISITOR_COOKIE_NAME);
+
+  if (existing?.value) {
+    return NextResponse.json({ visitorId: existing.value, created: false });
+  }
+
+  const visitorId = crypto.randomUUID();
+  const response = NextResponse.json({ visitorId, created: true });
+
+  response.cookies.set({
+    name: VISITOR_COOKIE_NAME,
+    value: visitorId,
+    path: "/",
+    sameSite: "lax",
+    httpOnly: false,
+    secure: process.env.NODE_ENV === "production",
+    maxAge: VISITOR_COOKIE_MAX_AGE_SECONDS,
+  });
+
+  await recordVisitorSession(visitorId);
+
+  return response;
+}

--- a/apps/www/app/visitor-session-initializer.tsx
+++ b/apps/www/app/visitor-session-initializer.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { VISITOR_COOKIE_NAME } from "@/lib/visitors/constants";
+
+const STORAGE_KEY = "transformai:visitor-session:initialized";
+
+export function VisitorSessionInitializer() {
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const hasVisitorCookie = document.cookie
+      .split(";")
+      .some((cookie) => cookie.trim().startsWith(`${VISITOR_COOKIE_NAME}=`));
+
+    try {
+      if (hasVisitorCookie) {
+        sessionStorage.setItem(STORAGE_KEY, "1");
+        return;
+      }
+
+      if (sessionStorage.getItem(STORAGE_KEY) === "1") {
+        return;
+      }
+    } catch (error) {
+      if (process.env.NODE_ENV !== "production") {
+        console.error("Visitor session storage unavailable", error);
+      }
+    }
+
+    const controller = new AbortController();
+
+    async function registerVisitor() {
+      try {
+        const response = await fetch("/api/visitor-sessions", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          signal: controller.signal,
+          keepalive: true,
+        });
+
+        if (response.ok) {
+          const cookieRegistered = document.cookie
+            .split(";")
+            .some((cookie) =>
+              cookie.trim().startsWith(`${VISITOR_COOKIE_NAME}=`),
+            );
+
+          if (!cookieRegistered) {
+            return;
+          }
+
+          try {
+            sessionStorage.setItem(STORAGE_KEY, "1");
+          } catch (error) {
+            if (process.env.NODE_ENV !== "production") {
+              console.error("Visitor session storage unavailable", error);
+            }
+          }
+        }
+      } catch (error) {
+        if (process.env.NODE_ENV !== "production") {
+          console.error("Failed to register visitor session", error);
+        }
+      }
+    }
+
+    registerVisitor();
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/www/drizzle/0002_add_visitor_sessions.sql
+++ b/apps/www/drizzle/0002_add_visitor_sessions.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS "visitor_sessions" (
+  "id" text PRIMARY KEY NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "visitor_sessions_created_at_idx" ON "visitor_sessions" ("created_at");

--- a/apps/www/lib/db/schema.ts
+++ b/apps/www/lib/db/schema.ts
@@ -146,6 +146,19 @@ export const meetingBookings = pgTable(
   }),
 );
 
+export const visitorSessions = pgTable(
+  "visitor_sessions",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+  },
+  (table) => ({
+    createdAtIdx: index("visitor_sessions_created_at_idx").on(table.createdAt),
+  }),
+);
+
 export const usersRelations = relations(users, ({ many }) => ({
   accounts: many(accounts),
   sessions: many(sessions),

--- a/apps/www/lib/visitors.ts
+++ b/apps/www/lib/visitors.ts
@@ -1,0 +1,124 @@
+import { sql } from "drizzle-orm";
+
+import { db } from "@/lib/db/client";
+import { visitorSessions } from "@/lib/db/schema";
+
+export async function recordVisitorSession(
+  visitorId: string,
+): Promise<void> {
+  try {
+    await db
+      .insert(visitorSessions)
+      .values({ id: visitorId })
+      .onConflictDoNothing();
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("Failed to record visitor session", error);
+    }
+  }
+}
+
+type HourlyVisitorBucket = {
+  start: Date;
+  end: Date;
+  count: number;
+};
+
+type DailyVisitorBucket = {
+  day: Date;
+  count: number;
+};
+
+export type VisitorOverview = {
+  total: number;
+  hourly: HourlyVisitorBucket[];
+  daily: DailyVisitorBucket[];
+};
+
+function formatHourKey(date: Date): string {
+  return date.toISOString().slice(0, 13);
+}
+
+function formatDayKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export async function getVisitorOverview(): Promise<VisitorOverview> {
+  const now = new Date();
+  const hourAnchor = new Date(now);
+  hourAnchor.setMinutes(0, 0, 0);
+
+  const dayAnchor = new Date(hourAnchor);
+  dayAnchor.setHours(0, 0, 0, 0);
+
+  const [totalResult, hourlyResult, dailyResult] = await Promise.all([
+    db.execute<{ count: number }>(
+      sql`select count(*)::int as count from ${visitorSessions}`,
+    ),
+    db.execute<{ bucket: Date; total: number }>(
+      sql`
+        select
+          date_trunc('hour', ${visitorSessions.createdAt}) as bucket,
+          count(*)::int as total
+        from ${visitorSessions}
+        where ${visitorSessions.createdAt} >= now() - interval '24 hours'
+        group by bucket
+        order by bucket asc
+      `,
+    ),
+    db.execute<{ bucket: Date; total: number }>(
+      sql`
+        select
+          date_trunc('day', ${visitorSessions.createdAt}) as bucket,
+          count(*)::int as total
+        from ${visitorSessions}
+        where ${visitorSessions.createdAt} >= now() - interval '7 days'
+        group by bucket
+        order by bucket asc
+      `,
+    ),
+  ]);
+
+  const total = Number(totalResult.rows.at(0)?.count ?? 0);
+
+  const hourlyMap = new Map<string, number>();
+  for (const row of hourlyResult.rows) {
+    const bucket = new Date(row.bucket);
+    hourlyMap.set(formatHourKey(bucket), Number(row.total));
+  }
+
+  const hourlyBuckets: HourlyVisitorBucket[] = [];
+  for (let offset = 23; offset >= 0; offset -= 1) {
+    const start = new Date(hourAnchor);
+    start.setHours(hourAnchor.getHours() - offset);
+    const end = new Date(start);
+    end.setHours(start.getHours() + 1);
+
+    const key = formatHourKey(start);
+    const count = hourlyMap.get(key) ?? 0;
+
+    hourlyBuckets.push({ start, end, count });
+  }
+
+  const dailyMap = new Map<string, number>();
+  for (const row of dailyResult.rows) {
+    const bucket = new Date(row.bucket);
+    dailyMap.set(formatDayKey(bucket), Number(row.total));
+  }
+
+  const dailyBuckets: DailyVisitorBucket[] = [];
+  for (let offset = 6; offset >= 0; offset -= 1) {
+    const day = new Date(dayAnchor);
+    day.setDate(dayAnchor.getDate() - offset);
+    const key = formatDayKey(day);
+    const count = dailyMap.get(key) ?? 0;
+
+    dailyBuckets.push({ day, count });
+  }
+
+  return {
+    total,
+    hourly: hourlyBuckets,
+    daily: dailyBuckets,
+  };
+}

--- a/apps/www/lib/visitors/constants.ts
+++ b/apps/www/lib/visitors/constants.ts
@@ -1,0 +1,2 @@
+export const VISITOR_COOKIE_NAME = "transformai_visit_id";
+export const VISITOR_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 180;

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -1226,9 +1226,46 @@
         "title": "Staff accounts",
         "caption": "{count, plural, one {# internal teammate online} other {# internal teammates online}}"
       },
+      "visitors": {
+        "title": "Unique visitors",
+        "caption": "{count, plural, one {# visitor session recorded} other {# visitor sessions recorded}}"
+      },
       "ratio": {
         "title": "Client-to-staff ratio",
         "caption": "Healthy coverage is between 4:1 and 8:1 so every project has a partner lead."
+      }
+    },
+    "accounts": {
+      "clients": {
+        "title": "Client account roster",
+        "description": "Review every client profile that has been provisioned.",
+        "empty": "No client accounts have been created yet."
+      },
+      "staff": {
+        "title": "Staff workspace roster",
+        "description": "See the teammates who can access internal tooling.",
+        "empty": "No staff accounts have been created yet."
+      },
+      "columns": {
+        "name": "Name",
+        "email": "Email",
+        "createdAt": "Created"
+      }
+    },
+    "visitors": {
+      "title": "Visitor traffic",
+      "description": "We count a visitor the moment a new analytics cookie is issued.",
+      "tabs": {
+        "hourly": "Last 24 hours",
+        "daily": "Last 7 days"
+      },
+      "empty": {
+        "hourly": "No new visitor sessions were recorded in the last 24 hours.",
+        "daily": "No new visitor sessions were recorded in the last 7 days."
+      },
+      "tooltip": {
+        "hour": "{count, plural, one {{count} visitor between {start}–{end}} other {{count} visitors between {start}–{end}}}",
+        "day": "{count, plural, one {{count} visitor on {day}} other {{count} visitors on {day}}}"
       }
     },
     "meetings": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -1183,9 +1183,46 @@
         "title": "Staff-accounts",
         "caption": "{count, plural, one {# collega online} other {# collega's online}}"
       },
+      "visitors": {
+        "title": "Unieke bezoekers",
+        "caption": "{count, plural, one {# bezoekersessie geregistreerd} other {# bezoekersessies geregistreerd}}"
+      },
       "ratio": {
         "title": "Verhouding klant/staff",
         "caption": "Een gezonde dekking ligt tussen 4:1 en 8:1 zodat elk project een partnerlead heeft."
+      }
+    },
+    "accounts": {
+      "clients": {
+        "title": "Overzicht klantaccounts",
+        "description": "Bekijk alle klantprofielen die zijn aangemaakt.",
+        "empty": "Er zijn nog geen klantaccounts aangemaakt."
+      },
+      "staff": {
+        "title": "Overzicht teamaccounts",
+        "description": "Zie welke teamleden toegang hebben tot de interne tooling.",
+        "empty": "Er zijn nog geen teamaccounts aangemaakt."
+      },
+      "columns": {
+        "name": "Naam",
+        "email": "E-mail",
+        "createdAt": "Aangemaakt"
+      }
+    },
+    "visitors": {
+      "title": "Bezoekersverkeer",
+      "description": "We tellen een bezoeker zodra er een nieuwe analytische cookie wordt uitgegeven.",
+      "tabs": {
+        "hourly": "Laatste 24 uur",
+        "daily": "Laatste 7 dagen"
+      },
+      "empty": {
+        "hourly": "Er zijn de afgelopen 24 uur geen nieuwe bezoekersessies geregistreerd.",
+        "daily": "Er zijn de afgelopen 7 dagen geen nieuwe bezoekersessies geregistreerd."
+      },
+      "tooltip": {
+        "hour": "{count, plural, one {{count} bezoeker tussen {start}–{end}} other {{count} bezoekers tussen {start}–{end}}}",
+        "day": "{count, plural, one {{count} bezoeker op {day}} other {{count} bezoekers op {day}}}"
       }
     },
     "meetings": {


### PR DESCRIPTION
## Plan
- Inspect the visitor traffic component to understand why the daily bars overflow without a scroll rail.
- Adjust the layout sizing so hourly data keeps its horizontal scroll while daily buckets stay fully visible.
- Record the dashboard refinement in the updates log for continuity.

## Summary
- Added a full-width scroller wrapper and limited the minimum chart width to the hourly view so daily buckets are no longer clipped off screen.
- Captured the change in WRITE_HERE/UPDATES to document the dashboard accessibility improvement.

## Testing
- `pnpm --filter www run typecheck` *(hangs during the build-content-collections bootstrap in this environment, so the run was aborted once it stalled).* 
- `pnpm --filter www run lint` *(fails: Next.js config imports `next-intl`, which is unavailable in the workspace).*

------
https://chatgpt.com/codex/tasks/task_e_68de8ef4ea88832a85413353820c444d