### PR TITLE
feat: add configurable hours saved counter

### DIFF
--- a/WRITE_HERE/UPDATES/2025-10-02T1620--hours-saved-controls-and-animation.md
+++ b/WRITE_HERE/UPDATES/2025-10-02T1620--hours-saved-controls-and-animation.md
@@ -1,0 +1,6 @@
+# Hours-saved counter is configurable and animated
+
+- **What:** Added a database-backed automation plan for the hero's "hours saved" counter, a staff dashboard panel to adjust the starting value and hourly increments, an API endpoint powering the homepage counter with animated updates, and documentation of the defaults in both locales.
+- **Why:** Staff need to steer the hourly AI savings narrative and set the live total without code changes while the marketing site reflects the new value with a polished animation.
+- **Files:** `apps/www/lib/db/schema.ts`, `apps/www/lib/hours-saved.ts`, `apps/www/app/[locale]/(site)/dashboard/*`, `apps/www/components/hero/*`, `apps/www/app/api/hours-saved/route.ts`, translations, and a new migration.
+- **Follow-ups:** Run pending database migrations in the target environment and ensure the missing `next-intl`/`drizzle-orm` packages are available so lint/typecheck succeed in CI.

--- a/apps/www/app/[locale]/(site)/dashboard/actions/hours-saved.ts
+++ b/apps/www/app/[locale]/(site)/dashboard/actions/hours-saved.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { getAuthSession } from "@/lib/auth";
+import {
+  regenerateHoursSavedPlan,
+  saveHoursSavedSettings,
+  updateHoursSavedAdjustment,
+} from "@/lib/hours-saved";
+
+const settingsSchema = z.object({
+  baseAmount: z.coerce.number().min(0).max(1_000_000_000),
+  dayIncrement: z.coerce.number().min(0).max(1_000_000),
+  nightIncrement: z.coerce.number().min(0).max(1_000_000),
+  locale: z.string().min(2).max(10),
+});
+
+const regenerateSchema = z.object({
+  locale: z.string().min(2).max(10),
+});
+
+const adjustmentSchema = z.object({
+  id: z.string().min(1),
+  amount: z.coerce.number().min(0).max(1_000_000),
+  locale: z.string().min(2).max(10),
+});
+
+async function assertStaffRole() {
+  const session = await getAuthSession();
+  if (session?.user?.role !== "staff") {
+    throw new Error("Unauthorized");
+  }
+}
+
+export async function updateHoursSavedSettingsAction(formData: FormData) {
+  await assertStaffRole();
+  const parsed = settingsSchema.parse({
+    baseAmount: formData.get("baseAmount"),
+    dayIncrement: formData.get("dayIncrement"),
+    nightIncrement: formData.get("nightIncrement"),
+    locale: formData.get("locale"),
+  });
+
+  await saveHoursSavedSettings({
+    baseAmount: parsed.baseAmount,
+    dayIncrement: parsed.dayIncrement,
+    nightIncrement: parsed.nightIncrement,
+  });
+
+  revalidatePath(`/${parsed.locale}/dashboard`);
+}
+
+export async function regenerateHoursSavedPlanAction(formData: FormData) {
+  await assertStaffRole();
+  const parsed = regenerateSchema.parse({
+    locale: formData.get("locale"),
+  });
+
+  await regenerateHoursSavedPlan();
+
+  revalidatePath(`/${parsed.locale}/dashboard`);
+}
+
+export async function updateHoursSavedAdjustmentAction(formData: FormData) {
+  await assertStaffRole();
+  const parsed = adjustmentSchema.parse({
+    id: formData.get("id"),
+    amount: formData.get("amount"),
+    locale: formData.get("locale"),
+  });
+
+  await updateHoursSavedAdjustment({ id: parsed.id, amount: parsed.amount });
+
+  revalidatePath(`/${parsed.locale}/dashboard`);
+}

--- a/apps/www/app/[locale]/(site)/dashboard/components/hours-saved-panel.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/components/hours-saved-panel.tsx
@@ -1,0 +1,228 @@
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { HOURS_SAVED_TIME_ZONE, getHoursSavedDashboardData } from "@/lib/hours-saved";
+import { cn } from "@/lib/utils";
+import { getTranslations } from "next-intl/server";
+
+import {
+  regenerateHoursSavedPlanAction,
+  updateHoursSavedAdjustmentAction,
+  updateHoursSavedSettingsAction,
+} from "../actions/hours-saved";
+
+type HoursSavedPanelProps = {
+  locale: string;
+};
+
+export async function HoursSavedPanel({ locale }: HoursSavedPanelProps) {
+  const dashboardData = await getHoursSavedDashboardData();
+  const t = await getTranslations({ locale, namespace: "Dashboard.hoursSaved" });
+
+  const { config, summary, upcoming } = dashboardData;
+
+  const numberFormatter = new Intl.NumberFormat(locale);
+  const timeFormatter = new Intl.DateTimeFormat(locale, {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: HOURS_SAVED_TIME_ZONE,
+  });
+
+  return (
+    <Card className="border-white/10 bg-white/5 text-white backdrop-blur-xl">
+      <CardHeader className="pb-6">
+        <CardTitle className="text-lg font-semibold text-white/80">
+          {t("title")}
+        </CardTitle>
+        <p className="mt-2 text-sm text-white/60">{t("description")}</p>
+      </CardHeader>
+      <CardContent className="space-y-8">
+        <div className="grid gap-4 rounded-2xl border border-white/10 bg-white/[0.03] p-6">
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+                {t("summary.current")}
+              </p>
+              <p className="mt-2 text-2xl font-semibold tracking-tight text-white">
+                {numberFormatter.format(summary.total)}+
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+                {t("summary.lastApplied")}
+              </p>
+              <p className="mt-2 text-sm text-white/70">
+                {timeFormatter.format(summary.lastAppliedAt)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+                {t("summary.nextUpdate")}
+              </p>
+              <p className="mt-2 text-sm text-white/70">
+                {summary.nextUpdateAt ? timeFormatter.format(summary.nextUpdateAt) : t("summary.noUpcoming")}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <form
+          action={updateHoursSavedSettingsAction}
+          className="grid gap-4 rounded-2xl border border-white/10 bg-white/[0.03] p-6"
+        >
+          <input type="hidden" name="locale" value={locale} />
+          <div className="grid gap-4 md:grid-cols-3">
+            <Field
+              id="hours-saved-base"
+              label={t("fields.baseAmount.label")}
+              description={t("fields.baseAmount.help")}
+            >
+              <Input
+                id="hours-saved-base"
+                name="baseAmount"
+                type="number"
+                min={0}
+                step={1}
+                defaultValue={Math.round(config.baseAmount)}
+                className="bg-black/50 text-white"
+              />
+            </Field>
+            <Field
+              id="hours-saved-day"
+              label={t("fields.dayIncrement.label")}
+              description={t("fields.dayIncrement.help")}
+            >
+              <Input
+                id="hours-saved-day"
+                name="dayIncrement"
+                type="number"
+                min={0}
+                step={1}
+                defaultValue={config.dayIncrement}
+                className="bg-black/50 text-white"
+              />
+            </Field>
+            <Field
+              id="hours-saved-night"
+              label={t("fields.nightIncrement.label")}
+              description={t("fields.nightIncrement.help")}
+            >
+              <Input
+                id="hours-saved-night"
+                name="nightIncrement"
+                type="number"
+                min={0}
+                step={1}
+                defaultValue={config.nightIncrement}
+                className="bg-black/50 text-white"
+              />
+            </Field>
+          </div>
+          <Button type="submit" variant="secondary" className="w-full bg-white/10 text-white hover:bg-white/20 sm:w-auto">
+            {t("actions.saveSettings")}
+          </Button>
+        </form>
+
+        <form
+          action={regenerateHoursSavedPlanAction}
+          className="inline-flex w-full flex-wrap items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-6 sm:justify-between"
+        >
+          <div className="space-y-1">
+            <p className="text-sm font-semibold text-white">{t("regenerate.title")}</p>
+            <p className="text-xs text-white/60">{t("regenerate.description")}</p>
+          </div>
+          <div className="flex w-full flex-wrap gap-3 sm:w-auto sm:flex-nowrap">
+            <input type="hidden" name="locale" value={locale} />
+            <Button
+              type="submit"
+              variant="outline"
+              className="w-full border-white/30 text-white hover:bg-white/10 hover:text-white sm:w-auto"
+            >
+              {t("actions.regenerate")}
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm font-semibold text-white">{t("schedule.title")}</p>
+              <p className="text-xs text-white/60">{t("schedule.description")}</p>
+            </div>
+          </div>
+          {upcoming.length === 0 ? (
+            <p className="rounded-2xl border border-white/10 bg-white/[0.03] p-6 text-sm text-white/60">
+              {t("schedule.empty")}
+            </p>
+          ) : (
+            <div className="grid gap-3">
+              {upcoming.map((entry) => (
+                <form
+                  key={entry.id}
+                  action={updateHoursSavedAdjustmentAction}
+                  className="grid gap-4 rounded-2xl border border-white/10 bg-white/[0.04] p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center"
+                >
+                  <input type="hidden" name="locale" value={locale} />
+                  <input type="hidden" name="id" value={entry.id} />
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-white">
+                      {timeFormatter.format(entry.applyAt)}
+                    </p>
+                    <p className="text-xs text-white/60">
+                      {t(`schedule.period.${entry.period}`)}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <Label htmlFor={`hours-saved-amount-${entry.id}`} className="sr-only">
+                      {t("fields.overrideLabel")}
+                    </Label>
+                    <Input
+                      id={`hours-saved-amount-${entry.id}`}
+                      name="amount"
+                      type="number"
+                      min={0}
+                      step={1}
+                      defaultValue={entry.amount}
+                      className="w-28 bg-black/50 text-white"
+                    />
+                    <Button
+                      type="submit"
+                      size="sm"
+                      variant="secondary"
+                      className="bg-white/10 text-white hover:bg-white/20"
+                    >
+                      {t("actions.updateHour")}
+                    </Button>
+                  </div>
+                </form>
+              ))}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+type FieldProps = {
+  id: string;
+  label: string;
+  description?: string;
+  children: ReactNode;
+  className?: string;
+};
+
+function Field({ id, label, description, children, className }: FieldProps) {
+  return (
+    <div className={cn("space-y-2", className)}>
+      <Label htmlFor={id} className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+        {label}
+      </Label>
+      {children}
+      {description ? <p className="text-xs text-white/50">{description}</p> : null}
+    </div>
+  );
+}

--- a/apps/www/app/[locale]/(site)/dashboard/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/page.tsx
@@ -22,6 +22,7 @@ import { formatDateWithZone } from "@/lib/date";
 import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
 import { getUpcomingMeetings } from "@/lib/meetings/queries";
 import { getVisitorOverview, type VisitorOverview } from "@/lib/visitors";
+import { HoursSavedPanel } from "./components/hours-saved-panel";
 import { VisitorsChartSection, type VisitorsChartBucket } from "./components/visitors-chart";
 import { desc, eq, sql } from "drizzle-orm";
 import { getTranslations } from "next-intl/server";
@@ -156,6 +157,10 @@ export default async function DashboardPage({ params }: PageProps) {
           <div className="rounded-xl border border-white/10 bg-white/10 px-5 py-3 text-xs text-white/70">
             {t("currentUser", { email: session.user.email ?? "" })}
           </div>
+        </div>
+
+        <div className="mt-12">
+          <HoursSavedPanel locale={locale} />
         </div>
 
         <div className="mt-16 grid gap-6 md:grid-cols-2 xl:grid-cols-4">

--- a/apps/www/app/api/hours-saved/route.ts
+++ b/apps/www/app/api/hours-saved/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+import { getHoursSavedSummary } from "@/lib/hours-saved";
+
+export const revalidate = 0;
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const summary = await getHoursSavedSummary();
+
+    return NextResponse.json({
+      total: summary.total,
+      updatedAt: summary.lastAppliedAt.toISOString(),
+      nextUpdateAt: summary.nextUpdateAt ? summary.nextUpdateAt.toISOString() : null,
+    });
+  } catch (error) {
+    console.error("Failed to load hours saved summary", error);
+    return NextResponse.json({ error: "Unable to load hours saved." }, { status: 500 });
+  }
+}

--- a/apps/www/components/hero/hero-main-section.tsx
+++ b/apps/www/components/hero/hero-main-section.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
-
 import { PrimaryButton, SecondaryButton } from "@/components/button";
 import { BookOpen, ChevronRight, LogIn } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
 
 type HeroMainSectionProps = {
   title: string;
@@ -10,7 +10,7 @@ type HeroMainSectionProps = {
   primaryCtaHref: string;
   secondaryCtaLabel: string;
   hoursSavedLabel: string;
-  hoursSavedAmount: string;
+  hoursSavedAmount: ReactNode;
 };
 
 export function HeroMainSection({
@@ -44,7 +44,13 @@ export function HeroMainSection({
         <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-6 py-2 font-semibold uppercase text-white/70 backdrop-blur-sm sm:gap-3 sm:px-8 sm:py-2.5 whitespace-nowrap">
           <span className="text-[0.75rem] tracking-[0.35em] text-white/60 sm:text-xs">{hoursSavedLabel}</span>
           <span className="text-white/40">:</span>
-          <span className="text-sm tracking-[0.2em] text-white sm:text-base">{hoursSavedAmount}</span>
+          <span
+            className="text-sm tracking-[0.2em] text-white sm:text-base"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {hoursSavedAmount}
+          </span>
         </div>
         <Link href="/docs" className="hidden w-full sm:inline-flex sm:w-auto sm:flex-shrink-0">
           <SecondaryButton

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -1,16 +1,111 @@
 "use client";
-import { motion } from "framer-motion";
+import { animate, motion, useMotionValue, useReducedMotion } from "framer-motion";
 import Image from "next/image";
 import { useLocale, useTranslations } from "next-intl";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { HeroMainSection } from "./hero-main-section";
 
 import mainboard from "@/images/mainboard.svg";
 import { SubHeroMainboard } from "./hero-sub-mainboard";
+type HoursSavedResponse = {
+  total?: number;
+  nextUpdateAt?: string | null;
+};
+
+const FALLBACK_POLL_INTERVAL = 1000 * 60 * 5;
+
 export const Hero: React.FC = () => {
   const hero = useTranslations("Hero");
   const cta = useTranslations("CTA");
   const locale = useLocale();
   const meetingHref = `/${locale}/meeting`;
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const fallbackAmount = useMemo(() => {
+    const raw = cta("hoursSavedAmount");
+    const digits = Number.parseInt(raw.replace(/[^0-9]/g, ""), 10);
+    return Number.isFinite(digits) ? digits : 0;
+  }, [cta]);
+
+  const [hoursSaved, setHoursSaved] = useState(() => fallbackAmount);
+  const [nextUpdateAt, setNextUpdateAt] = useState<string | null>(null);
+
+  const fetchHoursSaved = useCallback(async () => {
+    try {
+      const response = await fetch("/api/hours-saved", { cache: "no-store" });
+      if (!response.ok) {
+        throw new Error(`Failed to load hours saved: ${response.status}`);
+      }
+
+      const payload = (await response.json()) as HoursSavedResponse;
+
+      if (typeof payload.total === "number" && Number.isFinite(payload.total)) {
+        if (isMountedRef.current) {
+          setHoursSaved(payload.total);
+        }
+      }
+
+      if (isMountedRef.current) {
+        setNextUpdateAt(payload.nextUpdateAt ?? null);
+      }
+    } catch (error) {
+      console.error("Unable to refresh hours saved counter", error);
+    }
+  }, []);
+
+  useEffect(() => {
+    setHoursSaved((current) => {
+      if (!Number.isFinite(current)) {
+        return fallbackAmount;
+      }
+
+      return current;
+    });
+  }, [fallbackAmount]);
+
+  useEffect(() => {
+    void fetchHoursSaved();
+
+    const intervalId = window.setInterval(() => {
+      void fetchHoursSaved();
+    }, FALLBACK_POLL_INTERVAL);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [fetchHoursSaved]);
+
+  useEffect(() => {
+    if (!nextUpdateAt) {
+      return;
+    }
+
+    const nextUpdateMs = new Date(nextUpdateAt).getTime();
+    if (Number.isNaN(nextUpdateMs)) {
+      return;
+    }
+
+    const delay = nextUpdateMs - Date.now();
+    if (delay <= 0) {
+      void fetchHoursSaved();
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      void fetchHoursSaved();
+    }, delay + 1000);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [nextUpdateAt, fetchHoursSaved]);
 
   const containerVariants = {
     hidden: {},
@@ -45,7 +140,7 @@ export const Hero: React.FC = () => {
           primaryCtaHref={meetingHref}
           secondaryCtaLabel={cta("exploreProjects")}
           hoursSavedLabel={cta("hoursSavedLabel")}
-          hoursSavedAmount={cta("hoursSavedAmount")}
+          hoursSavedAmount={<AnimatedHoursSaved value={hoursSaved} locale={locale} />}
         />
       </motion.div>
 
@@ -71,3 +166,48 @@ export const Hero: React.FC = () => {
     </motion.div>
   );
 };
+
+type AnimatedHoursSavedProps = {
+  value: number;
+  locale: string;
+};
+
+function AnimatedHoursSaved({ value, locale }: AnimatedHoursSavedProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const motionValue = useMotionValue(value);
+  const [displayValue, setDisplayValue] = useState(value);
+
+  useEffect(() => {
+    const unsubscribe = motionValue.on("change", (latest) => {
+      setDisplayValue(Math.round(latest));
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [motionValue]);
+
+  useEffect(() => {
+    if (shouldReduceMotion) {
+      motionValue.set(value);
+      setDisplayValue(value);
+      return;
+    }
+
+    const controls = animate(motionValue, value, {
+      duration: 1.1,
+      ease: [0.16, 1, 0.3, 1],
+    });
+
+    return () => {
+      controls.stop();
+    };
+  }, [motionValue, shouldReduceMotion, value]);
+
+  const formattedValue = useMemo(
+    () => new Intl.NumberFormat(locale).format(displayValue),
+    [displayValue, locale],
+  );
+
+  return <>{formattedValue}+</>;
+}

--- a/apps/www/drizzle/0003_hours_saved.sql
+++ b/apps/www/drizzle/0003_hours_saved.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "hours_saved_config" (
+  "id" text PRIMARY KEY NOT NULL DEFAULT 'singleton',
+  "base_amount" bigint NOT NULL,
+  "base_timestamp" timestamptz DEFAULT now() NOT NULL,
+  "day_increment" integer NOT NULL,
+  "night_increment" integer NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "hours_saved_adjustments" (
+  "id" text PRIMARY KEY NOT NULL,
+  "apply_at" timestamptz NOT NULL,
+  "amount" integer NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "hours_saved_adjustments_apply_at_unique" ON "hours_saved_adjustments" ("apply_at");
+CREATE INDEX IF NOT EXISTS "hours_saved_adjustments_apply_at_idx" ON "hours_saved_adjustments" ("apply_at");

--- a/apps/www/lib/db/schema.ts
+++ b/apps/www/lib/db/schema.ts
@@ -1,5 +1,6 @@
 import { relations } from "drizzle-orm";
 import {
+  bigint,
   boolean,
   index,
   integer,
@@ -156,6 +157,36 @@ export const visitorSessions = pgTable(
   },
   (table) => ({
     createdAtIdx: index("visitor_sessions_created_at_idx").on(table.createdAt),
+  }),
+);
+
+export const hoursSavedConfig = pgTable("hours_saved_config", {
+  id: text("id")
+    .primaryKey()
+    .notNull()
+    .default("singleton"),
+  baseAmount: bigint("base_amount", { mode: "number" }).notNull(),
+  baseTimestamp: timestamp("base_timestamp", { mode: "date", withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  dayIncrement: integer("day_increment").notNull(),
+  nightIncrement: integer("night_increment").notNull(),
+  updatedAt: timestamp("updated_at", { mode: "date" }).notNull().defaultNow(),
+});
+
+export const hoursSavedAdjustments = pgTable(
+  "hours_saved_adjustments",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    applyAt: timestamp("apply_at", { mode: "date", withTimezone: true }).notNull(),
+    amount: integer("amount").notNull(),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+  },
+  (table) => ({
+    applyAtUnique: uniqueIndex("hours_saved_adjustments_apply_at_unique").on(table.applyAt),
+    applyAtIdx: index("hours_saved_adjustments_apply_at_idx").on(table.applyAt),
   }),
 );
 

--- a/apps/www/lib/hours-saved.ts
+++ b/apps/www/lib/hours-saved.ts
@@ -1,0 +1,303 @@
+import { and, asc, eq, gt, gte, lt, lte } from "drizzle-orm";
+
+import { db } from "@/lib/db/client";
+import { hoursSavedAdjustments, hoursSavedConfig } from "@/lib/db/schema";
+import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
+
+const HOURS_SAVED_CONFIG_ID = "singleton" as const;
+export const HOURS_SAVED_TIME_ZONE = MEETING_TIME_ZONE;
+const DEFAULT_DAY_INCREMENT = 104;
+const DEFAULT_NIGHT_INCREMENT = 65;
+const DEFAULT_BASE_AMOUNT = 100_000;
+const HOUR_VARIATION_RATIO = 0.15;
+const DAY_START_HOUR = 7;
+const DAY_END_HOUR = 21;
+
+export type HoursSavedConfig = typeof hoursSavedConfig.$inferSelect;
+export type HoursSavedAdjustment = typeof hoursSavedAdjustments.$inferSelect & {
+  period: "day" | "night";
+};
+
+export type HoursSavedSummary = {
+  total: number;
+  lastAppliedAt: Date;
+  nextUpdateAt: Date | null;
+};
+
+type ConfigRecord = typeof hoursSavedConfig.$inferSelect;
+
+export async function getHoursSavedSummary(): Promise<HoursSavedSummary> {
+  const config = await ensureHoursSavedConfig();
+  await ensureUpcomingAdjustments(config);
+  return computeSummary(config);
+}
+
+export async function getHoursSavedDashboardData(): Promise<{
+  config: ConfigRecord;
+  summary: HoursSavedSummary;
+  upcoming: HoursSavedAdjustment[];
+}> {
+  const config = await ensureHoursSavedConfig();
+  await ensureUpcomingAdjustments(config);
+
+  const summary = await computeSummary(config);
+  const upcoming = await getUpcomingAdjustments(config);
+
+  return { config, summary, upcoming };
+}
+
+export async function saveHoursSavedSettings(input: {
+  baseAmount: number;
+  dayIncrement: number;
+  nightIncrement: number;
+}): Promise<void> {
+  const existing = await getHoursSavedConfig();
+  const now = new Date();
+  const baseTimestamp =
+    existing && existing.baseAmount === input.baseAmount
+      ? existing.baseTimestamp
+      : now;
+
+  await db
+    .insert(hoursSavedConfig)
+    .values({
+      id: HOURS_SAVED_CONFIG_ID,
+      baseAmount: input.baseAmount,
+      baseTimestamp,
+      dayIncrement: input.dayIncrement,
+      nightIncrement: input.nightIncrement,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: hoursSavedConfig.id,
+      set: {
+        baseAmount: input.baseAmount,
+        baseTimestamp,
+        dayIncrement: input.dayIncrement,
+        nightIncrement: input.nightIncrement,
+        updatedAt: now,
+      },
+    });
+
+  const nextConfig: ConfigRecord = existing
+    ? {
+        ...existing,
+        baseAmount: input.baseAmount,
+        baseTimestamp,
+        dayIncrement: input.dayIncrement,
+        nightIncrement: input.nightIncrement,
+        updatedAt: now,
+      }
+    : {
+        id: HOURS_SAVED_CONFIG_ID,
+        baseAmount: input.baseAmount,
+        baseTimestamp,
+        dayIncrement: input.dayIncrement,
+        nightIncrement: input.nightIncrement,
+        updatedAt: now,
+      };
+
+  await ensureUpcomingAdjustments(nextConfig);
+}
+
+export async function regenerateHoursSavedPlan(hours = 24): Promise<void> {
+  const config = await ensureHoursSavedConfig();
+  const now = new Date();
+  const nextHour = addHours(startOfHour(now), 1);
+
+  await db
+    .delete(hoursSavedAdjustments)
+    .where(gte(hoursSavedAdjustments.applyAt, nextHour));
+
+  await createAdjustments(config, nextHour, hours);
+}
+
+export async function updateHoursSavedAdjustment(input: {
+  id: string;
+  amount: number;
+}): Promise<void> {
+  await db
+    .update(hoursSavedAdjustments)
+    .set({ amount: input.amount })
+    .where(eq(hoursSavedAdjustments.id, input.id));
+}
+
+async function computeSummary(config: ConfigRecord): Promise<HoursSavedSummary> {
+  const now = new Date();
+  const appliedAdjustments = await db
+    .select({
+      applyAt: hoursSavedAdjustments.applyAt,
+      amount: hoursSavedAdjustments.amount,
+    })
+    .from(hoursSavedAdjustments)
+    .where(
+      and(
+        gte(hoursSavedAdjustments.applyAt, config.baseTimestamp),
+        lte(hoursSavedAdjustments.applyAt, now),
+      ),
+    )
+    .orderBy(asc(hoursSavedAdjustments.applyAt));
+
+  const total = appliedAdjustments.reduce(
+    (acc, adjustment) => acc + adjustment.amount,
+    config.baseAmount,
+  );
+
+  const lastAppliedAt =
+    appliedAdjustments[appliedAdjustments.length - 1]?.applyAt ?? config.baseTimestamp;
+
+  const [nextAdjustment] = await db
+    .select({ applyAt: hoursSavedAdjustments.applyAt })
+    .from(hoursSavedAdjustments)
+    .where(gt(hoursSavedAdjustments.applyAt, now))
+    .orderBy(asc(hoursSavedAdjustments.applyAt))
+    .limit(1);
+
+  return {
+    total,
+    lastAppliedAt,
+    nextUpdateAt: nextAdjustment?.applyAt ?? null,
+  };
+}
+
+async function ensureHoursSavedConfig(): Promise<ConfigRecord> {
+  const existing = await getHoursSavedConfig();
+  if (existing) {
+    return existing;
+  }
+
+  const now = new Date();
+  const [inserted] = await db
+    .insert(hoursSavedConfig)
+    .values({
+      id: HOURS_SAVED_CONFIG_ID,
+      baseAmount: DEFAULT_BASE_AMOUNT,
+      baseTimestamp: now,
+      dayIncrement: DEFAULT_DAY_INCREMENT,
+      nightIncrement: DEFAULT_NIGHT_INCREMENT,
+    })
+    .returning();
+
+  return inserted;
+}
+
+async function getHoursSavedConfig(): Promise<ConfigRecord | null> {
+  return db.query.hoursSavedConfig.findFirst({
+    where: eq(hoursSavedConfig.id, HOURS_SAVED_CONFIG_ID),
+  });
+}
+
+async function ensureUpcomingAdjustments(config: ConfigRecord, hours = 24): Promise<void> {
+  const now = new Date();
+  const nextHour = addHours(startOfHour(now), 1);
+  const horizon = addHours(nextHour, hours);
+
+  const existing = await db
+    .select({ applyAt: hoursSavedAdjustments.applyAt })
+    .from(hoursSavedAdjustments)
+    .where(
+      and(
+        gte(hoursSavedAdjustments.applyAt, nextHour),
+        lt(hoursSavedAdjustments.applyAt, horizon),
+      ),
+    )
+    .orderBy(asc(hoursSavedAdjustments.applyAt));
+
+  const existingSet = new Set(existing.map((item) => item.applyAt.toISOString()));
+  const missingSlots: Date[] = [];
+
+  for (let index = 0; index < hours; index += 1) {
+    const slot = addHours(nextHour, index);
+    if (!existingSet.has(slot.toISOString())) {
+      missingSlots.push(slot);
+    }
+  }
+
+  if (missingSlots.length === 0) {
+    return;
+  }
+
+  await createAdjustments(config, missingSlots[0], missingSlots.length, missingSlots);
+}
+
+async function getUpcomingAdjustments(config: ConfigRecord, hours = 24): Promise<HoursSavedAdjustment[]> {
+  const now = new Date();
+  const nextHour = addHours(startOfHour(now), 1);
+  const horizon = addHours(nextHour, hours);
+
+  const results = await db
+    .select({
+      id: hoursSavedAdjustments.id,
+      applyAt: hoursSavedAdjustments.applyAt,
+      amount: hoursSavedAdjustments.amount,
+    })
+    .from(hoursSavedAdjustments)
+    .where(
+      and(
+        gte(hoursSavedAdjustments.applyAt, nextHour),
+        lt(hoursSavedAdjustments.applyAt, horizon),
+      ),
+    )
+    .orderBy(asc(hoursSavedAdjustments.applyAt));
+
+  return results.map((record) => ({
+    ...record,
+    period: isDaytime(record.applyAt) ? "day" : "night",
+  }));
+}
+
+async function createAdjustments(
+  config: ConfigRecord,
+  start: Date,
+  hours: number,
+  predefinedSlots?: Date[],
+): Promise<void> {
+  const slots = predefinedSlots ?? Array.from({ length: hours }, (_, index) => addHours(start, index));
+
+  const values = slots.map((slot) => ({
+    applyAt: slot,
+    amount: generateRandomIncrement(isDaytime(slot) ? config.dayIncrement : config.nightIncrement),
+  }));
+
+  if (values.length === 0) {
+    return;
+  }
+
+  await db.insert(hoursSavedAdjustments).values(values);
+}
+
+function generateRandomIncrement(base: number): number {
+  const variation = Math.max(1, Math.round(base * HOUR_VARIATION_RATIO));
+  const min = Math.max(1, base - variation);
+  const max = base + variation;
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function isDaytime(date: Date): boolean {
+  const hour = getHourInTimeZone(date, HOURS_SAVED_TIME_ZONE);
+  return hour >= DAY_START_HOUR && hour < DAY_END_HOUR;
+}
+
+function getHourInTimeZone(date: Date, timeZone: string): number {
+  const formatter = new Intl.DateTimeFormat("en-GB", {
+    hour: "2-digit",
+    hour12: false,
+    timeZone,
+  });
+  const parts = formatter.formatToParts(date);
+  const hourPart = parts.find((part) => part.type === "hour");
+  return hourPart ? Number.parseInt(hourPart.value, 10) : date.getUTCHours();
+}
+
+function startOfHour(date: Date): Date {
+  const clone = new Date(date);
+  clone.setMinutes(0, 0, 0);
+  return clone;
+}
+
+function addHours(date: Date, hours: number): Date {
+  const clone = new Date(date);
+  clone.setHours(clone.getHours() + hours);
+  return clone;
+}
+

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -1218,6 +1218,49 @@
     "title": "TransformAI account health",
     "subtitle": "Monitor how many client and staff seats are active across the platform.",
     "currentUser": "Signed in as {email}",
+    "hoursSaved": {
+      "title": "Homepage hours saved counter",
+      "description": "Control the rolling AI savings counter that appears on the marketing hero.",
+      "summary": {
+        "current": "Current total",
+        "lastApplied": "Last increment",
+        "nextUpdate": "Next scheduled update",
+        "noUpcoming": "No updates queued"
+      },
+      "fields": {
+        "baseAmount": {
+          "label": "Starting amount",
+          "help": "Set the baseline value the counter should anchor to. Updating the value resets the calculation timestamp."
+        },
+        "dayIncrement": {
+          "label": "Daytime hourly increment",
+          "help": "Used to generate random additions between 07:00–21:00 CET."
+        },
+        "nightIncrement": {
+          "label": "Overnight hourly increment",
+          "help": "Used to generate random additions between 21:00–07:00 CET."
+        },
+        "overrideLabel": "Override increment"
+      },
+      "actions": {
+        "saveSettings": "Save settings",
+        "regenerate": "Regenerate next 24 hours",
+        "updateHour": "Update hour"
+      },
+      "regenerate": {
+        "title": "Refresh the upcoming schedule",
+        "description": "Generate a new random plan for the next 24 hours using the saved increments."
+      },
+      "schedule": {
+        "title": "Upcoming hourly additions",
+        "description": "Adjust any hour to override the automated plan.",
+        "empty": "No upcoming increments are scheduled. Generate a new plan above.",
+        "period": {
+          "day": "Daytime increment",
+          "night": "Overnight increment"
+        }
+      }
+    },
     "metrics": {
       "clients": {
         "title": "Client accounts",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -1175,6 +1175,49 @@
     "title": "Gezondheid van TransformAI-accounts",
     "subtitle": "Volg hoeveel klant- en staff-accounts actief zijn op het platform.",
     "currentUser": "Ingelogd als {email}",
+    "hoursSaved": {
+      "title": "Homepage teller bespaarde uren",
+      "description": "Beheer de AI-bespaarteller die in de marketing-hero wordt getoond.",
+      "summary": {
+        "current": "Huidig totaal",
+        "lastApplied": "Laatste toevoeging",
+        "nextUpdate": "Volgende geplande update",
+        "noUpcoming": "Geen updates ingepland"
+      },
+      "fields": {
+        "baseAmount": {
+          "label": "Startwaarde",
+          "help": "Stel de basiswaarde in waarop de teller moet uitkomen. Het aanpassen reset het berekeningsmoment."
+        },
+        "dayIncrement": {
+          "label": "Dagelijkse uurlijkse toename",
+          "help": "Wordt gebruikt voor willekeurige toevoegingen tussen 07:00–21:00 CET."
+        },
+        "nightIncrement": {
+          "label": "Nachtelijke uurlijkse toename",
+          "help": "Wordt gebruikt voor willekeurige toevoegingen tussen 21:00–07:00 CET."
+        },
+        "overrideLabel": "Bedrag overschrijven"
+      },
+      "actions": {
+        "saveSettings": "Instellingen opslaan",
+        "regenerate": "Volgende 24 uur vernieuwen",
+        "updateHour": "Uur bijwerken"
+      },
+      "regenerate": {
+        "title": "Plan voor de komende uren vernieuwen",
+        "description": "Genereer een nieuw willekeurig plan voor de komende 24 uur op basis van de opgeslagen waarden."
+      },
+      "schedule": {
+        "title": "Aankomende uurlijkse toevoegingen",
+        "description": "Pas een uur aan om het automatische plan te overschrijven.",
+        "empty": "Er zijn geen toekomstige toevoegingen gepland. Genereer hierboven een nieuw plan.",
+        "period": {
+          "day": "Dagtoename",
+          "night": "Nachttoename"
+        }
+      }
+    },
     "metrics": {
       "clients": {
         "title": "Klantaccounts",


### PR DESCRIPTION
## Summary
- add dedicated tables and server utilities to track the rolling "hours saved" total
- expose a staff dashboard panel with actions to set the base amount, hourly increments, and regenerate the 24h plan
- animate the homepage hero badge using a new API endpoint for live counter updates and update i18n copy

## Plan
- extend the schema and migrations for hours-saved configuration and adjustments
- implement shared helpers plus API routes and staff actions for managing the hourly schedule
- update the dashboard UI and hero component to consume the data with motion feedback

## Testing
- pnpm --filter www run lint *(fails: missing `next-intl`)*
- pnpm --filter www run typecheck *(fails: missing `next-intl`/`drizzle-orm` typings)*

------
https://chatgpt.com/codex/tasks/task_e_68dea3895d04832aa1e2b2d77b34729a