### PR TITLE
refactor: redesign hours saved planner

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-30T0900--ensure-hours-saved-migration.md
+++ b/WRITE_HERE/FIXES/2025-11-30T0900--ensure-hours-saved-migration.md
@@ -1,0 +1,6 @@
+# Restore hours-saved schema for randomized ticker
+
+- **What:** Added a defensive migration that creates the hours saved tables when missing, backfills required columns like `scheduled_for`, and reinstates the foreign key and indexes used by the randomized ticker.
+- **Why:** The homepage crashed because Postgres lacked the `scheduled_for` column the ticker now queries, so the new automation could not load.
+- **Files:** `apps/www/drizzle/0003_hours_saved_tables.sql`
+- **Follow-ups:** Run the new migration in each environment and confirm future schema tweaks ship with migrations alongside Drizzle models.

--- a/WRITE_HERE/FIXES/2025-11-30T1015--hours-saved-dashboard-overhaul.md
+++ b/WRITE_HERE/FIXES/2025-11-30T1015--hours-saved-dashboard-overhaul.md
@@ -1,0 +1,6 @@
+# Streamlined hours saved dashboard editing
+
+- **What:** Rebuilt the staff planner with day-by-day navigation, granular hour editing, and copy-day tooling so the schedule is usable instead of the previous cluttered grid.
+- **Why:** The earlier square matrix was unreadable and made it impossible for staff to configure hourly automation, as reported by the team.
+- **Files:** `apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx`, `apps/www/app/[locale]/(site)/dashboard/page.tsx`, `apps/www/lib/hours-saved/constants.ts`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Monitor feedback on the copy workflow; consider batch-applying presets like weekdays vs. weekends.

--- a/WRITE_HERE/UPDATES/2025-11-29T2105--hours-saved-staff-controls.md
+++ b/WRITE_HERE/UPDATES/2025-11-29T2105--hours-saved-staff-controls.md
@@ -1,0 +1,6 @@
+# Hours saved metric is now configurable
+
+- **What:** Added persistent tables and APIs to manage the automatic “hours saved by AI” ticker, exposed a staff dashboard dialog to edit the next 24 hourly increments and starting amount, and animated the homepage ticker when new hours are applied. The hero now pulls live data via `/api/hours-saved`.
+- **Why:** Staff need to tweak the hourly automation and reset the counter without touching code while visitors should see a polished, animated number as it updates.
+- **Files:** `apps/www/lib/db/schema.ts`, `apps/www/lib/hours-saved/**`, `apps/www/app/[locale]/(site)/dashboard/**`, `apps/www/app/api/hours-saved/route.ts`, `apps/www/components/hero/**`, `apps/www/messages/*.json`.
+- **Follow-ups:** Consider adding auth around the API if exposed publicly, and revisit long-term retention of historical increment rows.

--- a/WRITE_HERE/UPDATES/2025-11-29T2235--hours-saved-randomized-distribution.md
+++ b/WRITE_HERE/UPDATES/2025-11-29T2235--hours-saved-randomized-distribution.md
@@ -1,0 +1,6 @@
+# Randomized hours saved scheduler refinements
+
+- **What:** Spread hourly additions across randomized minute-level updates, expose zero-amount placeholders, and refresh the staff editor with quick controls and translations.
+- **Why:** Prevent the ticker from jumping in a single lump and make it faster for staff to tune day/night automation.
+- **Files:** `apps/www/lib/hours-saved/*`, `apps/www/app/[locale]/(site)/dashboard/*`, `apps/www/messages/*`.
+- **Follow-ups:** Consider adding integration coverage once database migrations for hours-saved tables run in production.

--- a/WRITE_HERE/UPDATES/2025-11-30T1015--hours-saved-seven-day-planner.md
+++ b/WRITE_HERE/UPDATES/2025-11-30T1015--hours-saved-seven-day-planner.md
@@ -1,0 +1,6 @@
+# Seven-day hours saved planner redesign
+
+- **What:** Replaced the crowded grid with a two-pane planner that groups hours by day, exposes seven-day navigation, per-hour editing, and a copy-day workflow while expanding the automation window to a full week.
+- **Why:** Staff needed a clear, efficient way to stage hourly automation without the previous cluttered card matrix.
+- **Files:** `apps/www/lib/hours-saved/constants.ts`, `apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx`, `apps/www/app/[locale]/(site)/dashboard/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Consider surfacing a history view so staff can audit prior hour configurations.

--- a/apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx
@@ -1,0 +1,685 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { DialogClose, DialogFooter } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import { updateHoursSavedScheduleAction } from "../hours-saved-actions";
+
+import { cn } from "@/lib/utils";
+
+
+type ScheduleRowState = {
+  scheduledFor: Date;
+  input: string;
+};
+
+type DaySlot = {
+  index: number;
+  slot: ScheduleRowState;
+};
+
+type DayGroup = {
+  key: string;
+  label: string;
+  date: Date;
+  slots: DaySlot[];
+  isToday: boolean;
+};
+
+type HoursSavedManagerStrings = {
+  baseLabel: string;
+  baseHelper: string;
+  scheduleHeading: string;
+  scheduleDescription: string;
+  dayListLabel: string;
+  todayBadge: string;
+  nextBadge: string;
+  hoursPlannedLabel: string;
+  hourDetailHeading: string;
+  hourDetailTimeLabel: string;
+  hourDetailAmountLabel: string;
+  hourDetailHelper: string;
+  hourDetailEmpty: string;
+  copyButtonLabel: string;
+  copyPanelTitle: string;
+  copyPanelDescription: string;
+  copySourceLabel: string;
+  copyTargetLabel: string;
+  copyApplyLabel: string;
+  copyCancelLabel: string;
+  submitLabel: string;
+  savingLabel: string;
+  cancelLabel: string;
+  successMessage: string;
+  errorMessage: string;
+  validationError: string;
+  amountSuffix: string;
+};
+
+type HoursSavedManagerProps = {
+  locale: string;
+  timeZone: string;
+  baseAmount: number;
+  schedule: { scheduledFor: string; amount: number }[];
+  strings: HoursSavedManagerStrings;
+};
+
+function sortSchedule(entries: { scheduledFor: string; amount: number }[]): ScheduleRowState[] {
+  return [...entries]
+    .sort((a, b) => new Date(a.scheduledFor).getTime() - new Date(b.scheduledFor).getTime())
+    .map((entry) => ({
+      scheduledFor: new Date(entry.scheduledFor),
+      input: entry.amount.toString(),
+    }));
+}
+
+function parsePositiveInteger(value: string, fallback: number) {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+export function HoursSavedManager({
+  locale,
+  timeZone,
+  baseAmount,
+  schedule,
+  strings,
+}: HoursSavedManagerProps) {
+  const initialRows = useMemo(() => sortSchedule(schedule), [schedule]);
+  const [baseValue, setBaseValue] = useState(baseAmount.toString());
+  const [rows, setRows] = useState<ScheduleRowState[]>(initialRows);
+  const [selectedDayIndex, setSelectedDayIndex] = useState(0);
+  const [selectedSlotIndex, setSelectedSlotIndex] = useState(initialRows.length > 0 ? 0 : -1);
+  const [copyMode, setCopyMode] = useState(false);
+  const [copySource, setCopySource] = useState<string | null>(null);
+  const [copyTargets, setCopyTargets] = useState<string[]>([]);
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const isoFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat("en-CA", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        timeZone,
+      }),
+    [timeZone],
+  );
+
+  const dayLabelFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        timeZone,
+      }),
+    [locale, timeZone],
+  );
+
+  const timeLabelFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+        timeZone,
+      }),
+    [locale, timeZone],
+  );
+
+  const longTimeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+        timeZone,
+      }),
+    [locale, timeZone],
+  );
+
+  const numberFormatter = useMemo(() => new Intl.NumberFormat(locale), [locale]);
+
+  useEffect(() => {
+    setRows(initialRows);
+  }, [initialRows]);
+
+  useEffect(() => {
+    setBaseValue(baseAmount.toString());
+  }, [baseAmount]);
+
+  const dayGroups = useMemo(() => {
+    const todayKey = isoFormatter.format(new Date());
+    const grouped = new Map<string, DayGroup>();
+
+    rows.forEach((row, index) => {
+      const key = isoFormatter.format(row.scheduledFor);
+      const existing = grouped.get(key);
+
+      if (existing) {
+        existing.slots.push({ index, slot: row });
+        return;
+      }
+
+      grouped.set(key, {
+        key,
+        label: dayLabelFormatter.format(row.scheduledFor),
+        date: new Date(row.scheduledFor),
+        slots: [{ index, slot: row }],
+        isToday: key === todayKey,
+      });
+    });
+
+    return Array.from(grouped.values()).sort((a, b) => a.date.getTime() - b.date.getTime());
+  }, [dayLabelFormatter, isoFormatter, rows]);
+
+  useEffect(() => {
+    if (dayGroups.length === 0) {
+      setSelectedDayIndex(0);
+      setSelectedSlotIndex(-1);
+      return;
+    }
+
+    if (selectedDayIndex >= dayGroups.length) {
+      setSelectedDayIndex(0);
+      return;
+    }
+
+    const selectedGroup = dayGroups[selectedDayIndex];
+    if (!selectedGroup) {
+      setSelectedSlotIndex(-1);
+      return;
+    }
+
+    if (!selectedGroup.slots.some((item) => item.index === selectedSlotIndex)) {
+      setSelectedSlotIndex(selectedGroup.slots[0]?.index ?? -1);
+    }
+  }, [dayGroups, selectedDayIndex, selectedSlotIndex]);
+
+  useEffect(() => {
+    if (!copyMode) {
+      return;
+    }
+
+    const availableKeys = new Set(dayGroups.map((group) => group.key));
+    const fallback = dayGroups[selectedDayIndex]?.key ?? dayGroups[0]?.key ?? null;
+
+    if (!copySource || !availableKeys.has(copySource)) {
+      if (fallback !== copySource) {
+        setCopySource(fallback);
+      }
+      return;
+    }
+
+    setCopyTargets((current) => {
+      const filtered = current.filter((key) => availableKeys.has(key) && key !== copySource);
+      if (filtered.length === current.length && filtered.every((value, index) => value === current[index])) {
+        return current;
+      }
+      return filtered;
+    });
+  }, [copyMode, copySource, dayGroups, selectedDayIndex]);
+
+  const resetStatus = () => {
+    setStatus("idle");
+    setStatusMessage(null);
+  };
+
+  const handleBaseChange = (value: string) => {
+    setBaseValue(value);
+    resetStatus();
+  };
+
+  const handleSlotChange = (index: number, value: string) => {
+    setRows((current) => {
+      const next = [...current];
+      next[index] = { ...next[index], input: value };
+      return next;
+    });
+    resetStatus();
+  };
+
+  const handleSelectDay = (index: number) => {
+    setSelectedDayIndex(index);
+    const firstSlot = dayGroups[index]?.slots[0];
+    if (firstSlot) {
+      setSelectedSlotIndex(firstSlot.index);
+    }
+    resetStatus();
+  };
+
+  const handleSelectSlot = (index: number) => {
+    setSelectedSlotIndex(index);
+    resetStatus();
+  };
+
+  const toggleCopyMode = () => {
+    if (copyMode) {
+      setCopyMode(false);
+      setCopyTargets([]);
+      resetStatus();
+      return;
+    }
+
+    const defaultSource = dayGroups[selectedDayIndex]?.key ?? dayGroups[0]?.key ?? null;
+    setCopyMode(true);
+    setCopySource(defaultSource);
+    setCopyTargets([]);
+    resetStatus();
+  };
+
+  const handleCopySourceChange = (key: string) => {
+    setCopySource(key);
+    setCopyTargets((current) => current.filter((target) => target !== key));
+    resetStatus();
+  };
+
+  const handleCopyTargetToggle = (key: string) => {
+    setCopyTargets((current) => {
+      if (current.includes(key)) {
+        return current.filter((item) => item !== key);
+      }
+      return [...current, key];
+    });
+    resetStatus();
+  };
+
+  const applyCopySelection = () => {
+    if (!copySource) {
+      return;
+    }
+
+    const sourceGroup = dayGroups.find((group) => group.key === copySource);
+    const targets = dayGroups.filter((group) => copyTargets.includes(group.key));
+
+    if (!sourceGroup || targets.length === 0) {
+      return;
+    }
+
+    setRows((current) => {
+      const next = [...current];
+      for (const target of targets) {
+        const limit = Math.min(sourceGroup.slots.length, target.slots.length);
+        for (let index = 0; index < limit; index += 1) {
+          const sourceValue = sourceGroup.slots[index].slot.input;
+          const targetIndex = target.slots[index].index;
+          next[targetIndex] = { ...next[targetIndex], input: sourceValue };
+        }
+      }
+      return next;
+    });
+
+    setCopyMode(false);
+    setCopyTargets([]);
+    resetStatus();
+  };
+
+  const cancelCopySelection = () => {
+    setCopyMode(false);
+    setCopyTargets([]);
+    resetStatus();
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    resetStatus();
+
+    const parsedBase = Number.parseInt(baseValue, 10);
+
+    if (Number.isNaN(parsedBase) || parsedBase < 0) {
+      setStatus("error");
+      setStatusMessage(strings.validationError);
+      return;
+    }
+
+    const schedulePayload = rows.map((row) => ({
+      scheduledFor: row.scheduledFor.toISOString(),
+      amount: parsePositiveInteger(row.input, 0),
+    }));
+
+    startTransition(async () => {
+      const result = await updateHoursSavedScheduleAction(locale, {
+        baseAmount: parsedBase,
+        schedule: schedulePayload,
+      });
+
+      if (!result.success) {
+        setStatus("error");
+        setStatusMessage(result.error === "validation" ? strings.validationError : strings.errorMessage);
+        return;
+      }
+
+      try {
+        const response = await fetch("/api/hours-saved", { cache: "no-store" });
+        if (response.ok) {
+          const data = await response.json();
+          const nextRows = sortSchedule(data.schedule);
+          setRows(nextRows);
+          setBaseValue(data.baseAmount.toString());
+          setSelectedDayIndex(0);
+          setSelectedSlotIndex(nextRows.length > 0 ? 0 : -1);
+        }
+      } catch (error) {
+        console.error("Failed to refresh hours saved overview", error);
+      }
+
+      setCopyMode(false);
+      setCopyTargets([]);
+      setStatus("success");
+      setStatusMessage(strings.successMessage);
+    });
+  };
+
+  const selectedGroup = dayGroups[selectedDayIndex];
+  const selectedSlot = selectedSlotIndex >= 0 ? rows[selectedSlotIndex] : null;
+  const nextSlotIndex = selectedGroup?.slots[0]?.index ?? -1;
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-8">
+      <div className="space-y-2">
+        <Label className="text-sm font-medium text-white/80">{strings.baseLabel}</Label>
+        <Input
+          type="number"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          value={baseValue}
+          min={0}
+          onChange={(event) => handleBaseChange(event.target.value)}
+          className="border-white/15 bg-white/5 text-white placeholder:text-white/40 focus-visible:ring-white/40"
+        />
+        <p className="text-xs text-white/55">{strings.baseHelper}</p>
+      </div>
+
+      <div className="space-y-5 rounded-2xl border border-white/10 bg-white/[0.04] p-5 shadow-[0_0_30px_rgba(15,15,40,0.25)]">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-sm font-semibold text-white">{strings.scheduleHeading}</p>
+            <p className="text-xs text-white/55">{strings.scheduleDescription}</p>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={toggleCopyMode}
+            className={cn(
+              "h-9 rounded-full border border-white/15 bg-white/10 px-4 text-xs font-semibold uppercase tracking-[0.28em] text-white/70 transition hover:bg-white/20",
+              copyMode && "border-white/40 bg-white/20 text-white",
+            )}
+            disabled={isPending}
+          >
+            {strings.copyButtonLabel}
+          </Button>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.32em] text-white/50">{strings.dayListLabel}</p>
+            <div className="mt-3 flex gap-2 overflow-x-auto pb-1">
+              {dayGroups.map((group, index) => {
+                const isSelected = index === selectedDayIndex;
+                const plannedText = strings.hoursPlannedLabel.replace(
+                  "{count}",
+                  numberFormatter.format(group.slots.length),
+                );
+                return (
+                  <Button
+                    key={group.key}
+                    type="button"
+                    variant="ghost"
+                    onClick={() => handleSelectDay(index)}
+                    className={cn(
+                      "min-w-[8rem] rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-left text-sm font-medium text-white/70 transition hover:border-white/25 hover:text-white",
+                      isSelected && "border-white/50 bg-white/10 text-white",
+                    )}
+                    disabled={isPending}
+                  >
+                    <span className="block text-[12px] font-semibold uppercase tracking-[0.28em] text-white/45">
+                      {group.label}
+                    </span>
+                    <span className="mt-1 block text-xs text-white/70">{plannedText}</span>
+                    {group.isToday ? (
+                      <span className="mt-2 inline-flex items-center rounded-full border border-white/20 bg-white/10 px-2 py-[2px] text-[10px] font-semibold uppercase tracking-[0.3em] text-white/70">
+                        {strings.todayBadge}
+                      </span>
+                    ) : null}
+                  </Button>
+                );
+              })}
+            </div>
+          </div>
+
+          {selectedGroup ? (
+            <p className="text-xs text-white/55">
+              {strings.hoursPlannedLabel.replace(
+                "{count}",
+                numberFormatter.format(selectedGroup.slots.length),
+              )}
+            </p>
+          ) : null}
+
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+            <div className="rounded-2xl border border-white/10 bg-black/40 p-4">
+              <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 lg:grid-cols-6">
+                {selectedGroup?.slots.map((item) => {
+                  const slot = rows[item.index];
+                  const label = timeLabelFormatter.format(slot.scheduledFor);
+                  const isSelected = item.index === selectedSlotIndex;
+                  const isNext = selectedGroup?.isToday && item.index === nextSlotIndex;
+                  const amount = slot.input === "" ? "0" : slot.input;
+
+                  return (
+                    <button
+                      key={slot.scheduledFor.toISOString()}
+                      type="button"
+                      onClick={() => handleSelectSlot(item.index)}
+                      className={cn(
+                        "group rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-left transition hover:border-white/40 hover:bg-white/10",
+                        isSelected && "border-white bg-white text-black hover:border-white hover:bg-white",
+                      )}
+                      disabled={isPending}
+                    >
+                      <span
+                        className={cn(
+                          "font-mono text-[11px] tracking-[0.28em] text-white/60 transition group-hover:text-white",
+                          isSelected && "text-black/60",
+                        )}
+                      >
+                        {label}
+                      </span>
+                      <span
+                        className={cn(
+                          "mt-2 block text-sm font-semibold text-white transition group-hover:text-white",
+                          isSelected && "text-black",
+                        )}
+                      >
+                        {amount}
+                        <span className="ml-1 text-[10px] uppercase tracking-[0.3em] text-white/45 group-hover:text-white/60">
+                          {strings.amountSuffix}
+                        </span>
+                      </span>
+                      {isNext ? (
+                        <span
+                          className={cn(
+                            "mt-2 inline-flex items-center rounded-full border border-white/15 bg-white/10 px-2 py-[2px] text-[10px] font-semibold uppercase tracking-[0.3em] text-white/70",
+                            isSelected && "border-black/20 bg-black/10 text-black/70",
+                          )}
+                        >
+                          {strings.nextBadge}
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-black/40 p-4">
+              <p className="text-sm font-semibold text-white">{strings.hourDetailHeading}</p>
+              {selectedSlot ? (
+                <div className="mt-4 space-y-4">
+                  <div className="space-y-2">
+                    <Label className="text-xs font-semibold uppercase tracking-[0.28em] text-white/55">
+                      {strings.hourDetailTimeLabel}
+                    </Label>
+                    <div className="rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 font-mono text-sm tracking-[0.18em] text-white/70">
+                      {longTimeFormatter.format(selectedSlot.scheduledFor)}
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-xs font-semibold uppercase tracking-[0.28em] text-white/55">
+                      {strings.hourDetailAmountLabel}
+                    </Label>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        inputMode="numeric"
+                        pattern="[0-9]*"
+                        min={0}
+                        value={selectedSlot.input}
+                        onChange={(event) => handleSlotChange(selectedSlotIndex, event.target.value)}
+                        className="h-11 flex-1 border-white/15 bg-white/5 text-right text-sm text-white focus-visible:ring-white/40"
+                      />
+                      <span className="text-xs uppercase tracking-[0.32em] text-white/50">{strings.amountSuffix}</span>
+                    </div>
+                    <p className="text-xs text-white/45">{strings.hourDetailHelper}</p>
+                  </div>
+                </div>
+              ) : (
+                <p className="mt-4 text-xs text-white/55">{strings.hourDetailEmpty}</p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {copyMode ? (
+          <div className="space-y-4 rounded-2xl border border-white/15 bg-black/50 p-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <p className="text-sm font-semibold text-white">{strings.copyPanelTitle}</p>
+                <p className="text-xs text-white/55">{strings.copyPanelDescription}</p>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={cancelCopySelection}
+                className="h-8 rounded-full border border-white/15 bg-white/5 px-3 text-[11px] font-semibold uppercase tracking-[0.3em] text-white/65 transition hover:bg-white/15"
+              >
+                {strings.copyCancelLabel}
+              </Button>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-white/50">
+                  {strings.copySourceLabel}
+                </p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {dayGroups.map((group) => {
+                    const isActive = group.key === copySource;
+                    return (
+                      <Button
+                        key={group.key}
+                        type="button"
+                        variant="ghost"
+                        onClick={() => handleCopySourceChange(group.key)}
+                        className={cn(
+                          "rounded-xl border border-white/15 bg-white/5 px-3 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/65 transition hover:bg-white/15",
+                          isActive && "border-white/40 bg-white/20 text-white",
+                        )}
+                      >
+                        {group.label}
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-white/50">
+                  {strings.copyTargetLabel}
+                </p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {dayGroups.map((group) => {
+                    const isDisabled = group.key === copySource;
+                    const isActive = copyTargets.includes(group.key);
+                    return (
+                      <Button
+                        key={group.key}
+                        type="button"
+                        variant="ghost"
+                        onClick={() => handleCopyTargetToggle(group.key)}
+                        disabled={isDisabled}
+                        className={cn(
+                          "rounded-xl border border-white/15 bg-white/5 px-3 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/65 transition hover:bg-white/15 disabled:opacity-40",
+                          isActive && "border-white/40 bg-white/20 text-white",
+                        )}
+                      >
+                        {group.label}
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                onClick={applyCopySelection}
+                disabled={!copySource || copyTargets.length === 0 || isPending}
+                className="h-9 rounded-full bg-white px-5 text-xs font-semibold uppercase tracking-[0.3em] text-black transition hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {strings.copyApplyLabel}
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      {statusMessage ? (
+        <p
+          className={cn(
+            "text-xs",
+            status === "success"
+              ? "text-emerald-400"
+              : status === "error"
+              ? "text-rose-400"
+              : "text-white/60",
+          )}
+        >
+          {statusMessage}
+        </p>
+      ) : null}
+
+      <DialogFooter className="gap-2 sm:gap-3">
+        <DialogClose asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            className="h-10 rounded-full border border-white/10 bg-white/5 px-6 text-xs font-semibold uppercase tracking-[0.24em] text-white/70 hover:bg-white/10"
+            disabled={isPending}
+          >
+            {strings.cancelLabel}
+          </Button>
+        </DialogClose>
+        <Button
+          type="submit"
+          className="h-10 rounded-full bg-white px-6 text-xs font-semibold uppercase tracking-[0.3em] text-black hover:bg-white/90"
+          disabled={isPending}
+        >
+          {isPending ? strings.savingLabel : strings.submitLabel}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}

--- a/apps/www/app/[locale]/(site)/dashboard/hours-saved-actions.ts
+++ b/apps/www/app/[locale]/(site)/dashboard/hours-saved-actions.ts
@@ -1,0 +1,71 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { getAuthSession } from "@/lib/auth";
+import { updateHoursSavedSettings } from "@/lib/hours-saved";
+import {
+  HOURS_SAVED_WINDOW_HOURS,
+  addHours,
+  nextHour,
+} from "@/lib/hours-saved/constants";
+
+const scheduleItemSchema = z.object({
+  scheduledFor: z.string().datetime(),
+  amount: z.number().int().min(0).max(1_000_000),
+});
+
+const payloadSchema = z.object({
+  baseAmount: z.number().int().min(0).max(1_000_000_000),
+  schedule: z.array(scheduleItemSchema).length(HOURS_SAVED_WINDOW_HOURS),
+});
+
+export async function updateHoursSavedScheduleAction(locale: string, payload: unknown) {
+  const session = await getAuthSession();
+
+  if (session?.user?.role !== "staff") {
+    return { success: false as const, error: "unauthorized" as const };
+  }
+
+  const parsed = payloadSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return {
+      success: false as const,
+      error: "validation" as const,
+      issues: parsed.error.flatten().fieldErrors,
+    };
+  }
+
+  const reference = new Date();
+  const windowStart = nextHour(reference);
+
+  const sortedEntries = parsed.data.schedule
+    .map((entry) => ({
+      scheduledFor: new Date(entry.scheduledFor),
+      amount: entry.amount,
+    }))
+    .sort((a, b) => a.scheduledFor.getTime() - b.scheduledFor.getTime());
+
+  const normalizedSchedule = sortedEntries.map((entry, index) => ({
+    scheduledFor: addHours(windowStart, index),
+    amount: entry.amount,
+  }));
+
+  try {
+    await updateHoursSavedSettings({
+      baseAmount: parsed.data.baseAmount,
+      schedule: normalizedSchedule,
+      now: reference,
+    });
+  } catch (error) {
+    console.error("Failed to update hours saved schedule", error);
+    return { success: false as const, error: "unknown" as const };
+  }
+
+  await revalidatePath(`/${locale}`);
+  await revalidatePath(`/${locale}/dashboard`);
+
+  return { success: true as const };
+}

--- a/apps/www/app/[locale]/(site)/dashboard/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/page.tsx
@@ -22,7 +22,10 @@ import { formatDateWithZone } from "@/lib/date";
 import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
 import { getUpcomingMeetings } from "@/lib/meetings/queries";
 import { getVisitorOverview, type VisitorOverview } from "@/lib/visitors";
+import { getHoursSavedOverview, type HoursSavedScheduleEntry } from "@/lib/hours-saved";
+import { HOURS_SAVED_TIME_ZONE } from "@/lib/hours-saved/constants";
 import { VisitorsChartSection, type VisitorsChartBucket } from "./components/visitors-chart";
+import { HoursSavedManager } from "./components/hours-saved-manager";
 import { desc, eq, sql } from "drizzle-orm";
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
@@ -43,7 +46,14 @@ export default async function DashboardPage({ params }: PageProps) {
 
   const t = await getTranslations({ locale, namespace: "Dashboard" });
 
-  const [roleCounts, upcomingMeetings, clientAccounts, staffAccounts, visitorOverview] =
+  const [
+    roleCounts,
+    upcomingMeetings,
+    clientAccounts,
+    staffAccounts,
+    visitorOverview,
+    hoursSavedOverview,
+  ] =
     await Promise.all([
       db
         .select({
@@ -74,6 +84,7 @@ export default async function DashboardPage({ params }: PageProps) {
         .where(eq(users.role, "staff"))
         .orderBy(desc(users.createdAt)),
       getVisitorOverview(),
+      getHoursSavedOverview(),
     ]);
 
   type UpcomingMeeting = (typeof upcomingMeetings)[number];
@@ -135,6 +146,41 @@ export default async function DashboardPage({ params }: PageProps) {
     name: t("accounts.columns.name"),
     email: t("accounts.columns.email"),
     createdAt: t("accounts.columns.createdAt"),
+  } as const;
+
+  const hoursSavedSchedule = hoursSavedOverview.schedule.map((entry: HoursSavedScheduleEntry) => ({
+    scheduledFor: entry.scheduledFor.toISOString(),
+    amount: entry.amount,
+  }));
+
+  const hoursSavedDialogStrings = {
+    baseLabel: t("hoursSaved.dialog.baseLabel"),
+    baseHelper: t("hoursSaved.dialog.baseHelper"),
+    scheduleHeading: t("hoursSaved.dialog.scheduleHeading"),
+    scheduleDescription: t("hoursSaved.dialog.scheduleDescription", { timeZone: HOURS_SAVED_TIME_ZONE }),
+    dayListLabel: t("hoursSaved.dialog.dayListLabel"),
+    todayBadge: t("hoursSaved.dialog.todayBadge"),
+    nextBadge: t("hoursSaved.dialog.nextBadge"),
+    hoursPlannedLabel: t("hoursSaved.dialog.hoursPlanned"),
+    hourDetailHeading: t("hoursSaved.dialog.hourDetailHeading"),
+    hourDetailTimeLabel: t("hoursSaved.dialog.hourDetailTimeLabel"),
+    hourDetailAmountLabel: t("hoursSaved.dialog.hourDetailAmountLabel"),
+    hourDetailHelper: t("hoursSaved.dialog.hourDetailHelper"),
+    hourDetailEmpty: t("hoursSaved.dialog.hourDetailEmpty"),
+    copyButtonLabel: t("hoursSaved.dialog.copyButton"),
+    copyPanelTitle: t("hoursSaved.dialog.copyPanelTitle"),
+    copyPanelDescription: t("hoursSaved.dialog.copyPanelDescription"),
+    copySourceLabel: t("hoursSaved.dialog.copySourceLabel"),
+    copyTargetLabel: t("hoursSaved.dialog.copyTargetLabel"),
+    copyApplyLabel: t("hoursSaved.dialog.copyApply"),
+    copyCancelLabel: t("hoursSaved.dialog.copyCancel"),
+    submitLabel: t("hoursSaved.dialog.submit"),
+    savingLabel: t("hoursSaved.dialog.saving"),
+    cancelLabel: t("hoursSaved.dialog.cancel"),
+    successMessage: t("hoursSaved.dialog.success"),
+    errorMessage: t("hoursSaved.dialog.error"),
+    validationError: t("hoursSaved.dialog.validation"),
+    amountSuffix: t("hoursSaved.dialog.amountSuffix"),
   } as const;
 
   const ratioValue =
@@ -263,6 +309,48 @@ export default async function DashboardPage({ params }: PageProps) {
                   daily={dailyChartData}
                   tabLabels={visitorTabs}
                   emptyMessages={visitorEmptyMessages}
+                />
+              </div>
+            </DialogContent>
+          </Dialog>
+
+          <Dialog>
+            <DialogTrigger asChild>
+              <button
+                type="button"
+                className="text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              >
+                <Card className="relative overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition hover:border-white/20">
+                  <CardHeader className="pb-4">
+                    <CardTitle className="text-lg font-semibold text-white/70">
+                      {t("metrics.hoursSaved.title")}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="pb-6">
+                    <p className="text-4xl font-semibold tracking-tight text-white">
+                      {hoursSavedOverview.currentAmount.toLocaleString(locale)}
+                    </p>
+                    <p className="mt-2 text-sm text-white/60">
+                      {t("metrics.hoursSaved.caption", { count: hoursSavedOverview.currentAmount })}
+                    </p>
+                  </CardContent>
+                </Card>
+              </button>
+            </DialogTrigger>
+            <DialogContent className="max-w-3xl bg-neutral-950 text-white">
+              <DialogHeader>
+                <DialogTitle className="text-white">{t("hoursSaved.dialog.title")}</DialogTitle>
+                <DialogDescription className="text-white/60">
+                  {t("hoursSaved.dialog.description", { timeZone: HOURS_SAVED_TIME_ZONE })}
+                </DialogDescription>
+              </DialogHeader>
+              <div className="mt-6">
+                <HoursSavedManager
+                  locale={locale}
+                  timeZone={HOURS_SAVED_TIME_ZONE}
+                  baseAmount={hoursSavedOverview.baseAmount}
+                  schedule={hoursSavedSchedule}
+                  strings={hoursSavedDialogStrings}
                 />
               </div>
             </DialogContent>

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -16,6 +16,7 @@ import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/hero
 import { OssLight } from "@/components/svg/oss-light";
 import { UsageBento } from "@/components/usage-bento";
 import { isLocale } from "@/i18n/routing";
+import { getHoursSavedOverview } from "@/lib/hours-saved";
 import {
   BarChart3,
   ChevronRight,
@@ -106,6 +107,8 @@ export default async function Landing({
     getTranslations({ locale, namespace: "FeatureSection" }),
   ]);
 
+  const hoursSavedOverview = await getHoursSavedOverview();
+
   const featureBoxes = [
     { key: "futureProofWorkforce", icon: GraduationCap },
     { key: "revenueStreamAnalysis", icon: BarChart3 },
@@ -139,7 +142,14 @@ export default async function Landing({
         </div>
         <div className="container relative flex flex-col mx-auto space-y-16 md:space-y-32">
           <Section>
-            <Hero />
+            <Hero
+              initialHoursSavedAmount={hoursSavedOverview.currentAmount}
+              initialHoursSavedNextUpdateAt={
+                hoursSavedOverview.nextUpdateAt
+                  ? hoursSavedOverview.nextUpdateAt.toISOString()
+                  : null
+              }
+            />
           </Section>
           <Section className="mt-16 md:mt-32">
             <DesktopLogoCloud />

--- a/apps/www/app/api/hours-saved/route.ts
+++ b/apps/www/app/api/hours-saved/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+import { getHoursSavedOverview } from "@/lib/hours-saved";
+
+export async function GET() {
+  try {
+    const overview = await getHoursSavedOverview();
+
+    return NextResponse.json(
+      {
+        baseAmount: overview.baseAmount,
+        baseSetAt: overview.baseSetAt.toISOString(),
+        currentAmount: overview.currentAmount,
+        nextUpdateAt: overview.nextUpdateAt ? overview.nextUpdateAt.toISOString() : null,
+        schedule: overview.schedule.map((entry) => ({
+          scheduledFor: entry.scheduledFor.toISOString(),
+          amount: entry.amount,
+        })),
+      },
+      {
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  } catch (error) {
+    console.error("Failed to load hours saved overview", error);
+    return NextResponse.json(
+      { error: "internal_error" },
+      {
+        status: 500,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+}

--- a/apps/www/components/hero/hero-main-section.tsx
+++ b/apps/www/components/hero/hero-main-section.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { PrimaryButton, SecondaryButton } from "@/components/button";
 import { BookOpen, ChevronRight, LogIn } from "lucide-react";
 
+import { HoursSavedTicker } from "./hours-saved-ticker";
+
 type HeroMainSectionProps = {
   title: string;
   body: string;
@@ -10,7 +12,9 @@ type HeroMainSectionProps = {
   primaryCtaHref: string;
   secondaryCtaLabel: string;
   hoursSavedLabel: string;
-  hoursSavedAmount: string;
+  hoursSavedInitialAmount: number;
+  hoursSavedNextUpdateAt: string | null;
+  locale: string;
 };
 
 export function HeroMainSection({
@@ -20,7 +24,9 @@ export function HeroMainSection({
   primaryCtaHref,
   secondaryCtaLabel,
   hoursSavedLabel,
-  hoursSavedAmount,
+  hoursSavedInitialAmount,
+  hoursSavedNextUpdateAt,
+  locale,
 }: HeroMainSectionProps) {
   return (
     <div className="relative flex flex-col items-center text-center">
@@ -44,7 +50,12 @@ export function HeroMainSection({
         <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-6 py-2 font-semibold uppercase text-white/70 backdrop-blur-sm sm:gap-3 sm:px-8 sm:py-2.5 whitespace-nowrap">
           <span className="text-[0.75rem] tracking-[0.35em] text-white/60 sm:text-xs">{hoursSavedLabel}</span>
           <span className="text-white/40">:</span>
-          <span className="text-sm tracking-[0.2em] text-white sm:text-base">{hoursSavedAmount}</span>
+          <HoursSavedTicker
+            initialAmount={hoursSavedInitialAmount}
+            initialNextUpdateAt={hoursSavedNextUpdateAt}
+            locale={locale}
+            className="text-sm tracking-[0.2em] text-white sm:text-base"
+          />
         </div>
         <Link href="/docs" className="hidden w-full sm:inline-flex sm:w-auto sm:flex-shrink-0">
           <SecondaryButton

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -6,7 +6,15 @@ import { HeroMainSection } from "./hero-main-section";
 
 import mainboard from "@/images/mainboard.svg";
 import { SubHeroMainboard } from "./hero-sub-mainboard";
-export const Hero: React.FC = () => {
+type HeroProps = {
+  initialHoursSavedAmount: number;
+  initialHoursSavedNextUpdateAt: string | null;
+};
+
+export const Hero: React.FC<HeroProps> = ({
+  initialHoursSavedAmount,
+  initialHoursSavedNextUpdateAt,
+}) => {
   const hero = useTranslations("Hero");
   const cta = useTranslations("CTA");
   const locale = useLocale();
@@ -45,7 +53,9 @@ export const Hero: React.FC = () => {
           primaryCtaHref={meetingHref}
           secondaryCtaLabel={cta("exploreProjects")}
           hoursSavedLabel={cta("hoursSavedLabel")}
-          hoursSavedAmount={cta("hoursSavedAmount")}
+          hoursSavedInitialAmount={initialHoursSavedAmount}
+          hoursSavedNextUpdateAt={initialHoursSavedNextUpdateAt}
+          locale={locale}
         />
       </motion.div>
 

--- a/apps/www/components/hero/hours-saved-ticker.tsx
+++ b/apps/www/components/hero/hours-saved-ticker.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { animate, useAnimate, useMotionValue, useReducedMotion } from "framer-motion";
+
+import { cn } from "@/lib/utils";
+
+type HoursSavedTickerProps = {
+  initialAmount: number;
+  initialNextUpdateAt: string | null;
+  locale: string;
+  className?: string;
+};
+
+type HoursSavedState = {
+  amount: number;
+  nextUpdateAt: string | null;
+};
+
+const FALLBACK_REFRESH_INTERVAL_MS = 60_000;
+
+export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, className }: HoursSavedTickerProps) {
+  const [state, setState] = useState<HoursSavedState>({
+    amount: initialAmount,
+    nextUpdateAt: initialNextUpdateAt,
+  });
+  const motionValue = useMotionValue(initialAmount);
+  const [displayValue, setDisplayValue] = useState(initialAmount);
+  const reducedMotion = useReducedMotion();
+  const [scope, animateScope] = useAnimate<HTMLSpanElement>();
+
+  useEffect(() => {
+    setState({ amount: initialAmount, nextUpdateAt: initialNextUpdateAt });
+    setDisplayValue(initialAmount);
+    motionValue.set(initialAmount);
+  }, [initialAmount, initialNextUpdateAt, motionValue]);
+
+  useEffect(() => {
+    const unsubscribe = motionValue.on("change", (latest) => {
+      setDisplayValue(Math.round(latest));
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [motionValue]);
+
+  useEffect(() => {
+    if (reducedMotion) {
+      motionValue.set(state.amount);
+      setDisplayValue(state.amount);
+      return;
+    }
+
+    const controls = animate(motionValue, state.amount, {
+      duration: 0.8,
+      ease: "easeOut",
+    });
+
+    if (scope.current) {
+      void animateScope(scope.current, { scale: [1, 1.05, 1] }, { duration: 0.6, ease: "easeOut" });
+    }
+
+    return () => {
+      controls.stop();
+    };
+  }, [state.amount, animateScope, motionValue, reducedMotion, scope]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    const fetchLatest = async () => {
+      try {
+        const response = await fetch("/api/hours-saved", { cache: "no-store" });
+        if (!response.ok) {
+          return;
+        }
+
+        const data = (await response.json()) as {
+          currentAmount: number;
+          nextUpdateAt: string | null;
+        };
+
+        if (!cancelled) {
+          setState({ amount: data.currentAmount, nextUpdateAt: data.nextUpdateAt });
+        }
+      } catch (error) {
+        console.error("Failed to refresh hours saved ticker", error);
+      }
+    };
+
+    const scheduleNextFetch = () => {
+      if (!state.nextUpdateAt) {
+        return;
+      }
+
+      const targetTime = new Date(state.nextUpdateAt).getTime() - Date.now();
+      const delay = Math.max(targetTime, 0) + 1200;
+      timeoutId = setTimeout(fetchLatest, delay);
+    };
+
+    scheduleNextFetch();
+    intervalId = setInterval(fetchLatest, FALLBACK_REFRESH_INTERVAL_MS);
+
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        void fetchLatest();
+      }
+    };
+
+    const handleFocus = () => {
+      void fetchLatest();
+    };
+
+    window.addEventListener("focus", handleFocus);
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      cancelled = true;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+      window.removeEventListener("focus", handleFocus);
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [state.nextUpdateAt]);
+
+  const formatter = useMemo(() => new Intl.NumberFormat(locale), [locale]);
+  const formatted = formatter.format(displayValue);
+
+  return (
+    <span ref={scope} className={cn("inline-flex items-center font-medium text-white", className)} aria-live="polite">
+      {formatted}
+    </span>
+  );
+}

--- a/apps/www/drizzle/0003_hours_saved_tables.sql
+++ b/apps/www/drizzle/0003_hours_saved_tables.sql
@@ -1,0 +1,165 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE IF NOT EXISTS "hours_saved_states" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid(),
+  "base_amount" integer NOT NULL DEFAULT 0,
+  "base_set_at" timestamptz NOT NULL DEFAULT now(),
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS "hours_saved_increments" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid(),
+  "state_id" text NOT NULL,
+  "scheduled_for" timestamptz NOT NULL,
+  "amount" integer NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE "hours_saved_states"
+  ADD COLUMN IF NOT EXISTS "base_amount" integer;
+
+ALTER TABLE "hours_saved_states"
+  ADD COLUMN IF NOT EXISTS "base_set_at" timestamptz;
+
+ALTER TABLE "hours_saved_states"
+  ADD COLUMN IF NOT EXISTS "created_at" timestamptz;
+
+ALTER TABLE "hours_saved_states"
+  ADD COLUMN IF NOT EXISTS "updated_at" timestamptz;
+
+ALTER TABLE "hours_saved_states"
+  ALTER COLUMN "base_amount" SET DEFAULT 0;
+
+ALTER TABLE "hours_saved_states"
+  ALTER COLUMN "base_amount" TYPE integer USING "base_amount"::integer;
+
+UPDATE "hours_saved_states"
+SET "base_amount" = 0
+WHERE "base_amount" IS NULL;
+
+ALTER TABLE "hours_saved_states"
+  ALTER COLUMN "base_amount" SET NOT NULL;
+
+ALTER TABLE "hours_saved_states"
+  ALTER COLUMN "base_set_at" SET DEFAULT now();
+
+UPDATE "hours_saved_states"
+SET "base_set_at" = now()
+WHERE "base_set_at" IS NULL;
+
+ALTER TABLE "hours_saved_states"
+  ALTER COLUMN "base_set_at" TYPE timestamptz USING "base_set_at"::timestamptz;
+
+ALTER TABLE "hours_saved_states"
+  ALTER COLUMN "base_set_at" SET NOT NULL;
+
+ALTER TABLE "hours_saved_states"
+  ALTER COLUMN "created_at" SET DEFAULT now();
+
+UPDATE "hours_saved_states"
+SET "created_at" = now()
+WHERE "created_at" IS NULL;
+
+ALTER TABLE "hours_saved_states"
+  ALTER COLUMN "created_at" TYPE timestamptz USING "created_at"::timestamptz;
+
+ALTER TABLE "hours_saved_states"
+  ALTER COLUMN "created_at" SET NOT NULL;
+
+ALTER TABLE "hours_saved_states"
+  ALTER COLUMN "updated_at" SET DEFAULT now();
+
+UPDATE "hours_saved_states"
+SET "updated_at" = now()
+WHERE "updated_at" IS NULL;
+
+ALTER TABLE "hours_saved_states"
+  ALTER COLUMN "updated_at" TYPE timestamptz USING "updated_at"::timestamptz;
+
+ALTER TABLE "hours_saved_states"
+  ALTER COLUMN "updated_at" SET NOT NULL;
+
+ALTER TABLE "hours_saved_increments"
+  ADD COLUMN IF NOT EXISTS "state_id" text;
+
+ALTER TABLE "hours_saved_increments"
+  ADD COLUMN IF NOT EXISTS "scheduled_for" timestamptz;
+
+ALTER TABLE "hours_saved_increments"
+  ADD COLUMN IF NOT EXISTS "amount" integer;
+
+ALTER TABLE "hours_saved_increments"
+  ADD COLUMN IF NOT EXISTS "created_at" timestamptz;
+
+ALTER TABLE "hours_saved_increments"
+  ADD COLUMN IF NOT EXISTS "updated_at" timestamptz;
+
+ALTER TABLE "hours_saved_increments"
+  ALTER COLUMN "state_id" SET NOT NULL;
+
+UPDATE "hours_saved_increments"
+SET "scheduled_for" = now()
+WHERE "scheduled_for" IS NULL;
+
+ALTER TABLE "hours_saved_increments"
+  ALTER COLUMN "scheduled_for" TYPE timestamptz USING "scheduled_for"::timestamptz;
+
+ALTER TABLE "hours_saved_increments"
+  ALTER COLUMN "scheduled_for" SET NOT NULL;
+
+ALTER TABLE "hours_saved_increments"
+  ALTER COLUMN "state_id" TYPE text USING "state_id"::text;
+
+ALTER TABLE "hours_saved_increments"
+  ALTER COLUMN "amount" TYPE integer USING "amount"::integer;
+
+ALTER TABLE "hours_saved_increments"
+  ALTER COLUMN "amount" SET DEFAULT 0;
+
+UPDATE "hours_saved_increments"
+SET "amount" = 0
+WHERE "amount" IS NULL;
+
+ALTER TABLE "hours_saved_increments"
+  ALTER COLUMN "amount" SET NOT NULL;
+
+ALTER TABLE "hours_saved_increments"
+  ALTER COLUMN "created_at" SET DEFAULT now();
+
+UPDATE "hours_saved_increments"
+SET "created_at" = now()
+WHERE "created_at" IS NULL;
+
+ALTER TABLE "hours_saved_increments"
+  ALTER COLUMN "created_at" SET NOT NULL;
+
+ALTER TABLE "hours_saved_increments"
+  ALTER COLUMN "updated_at" SET DEFAULT now();
+
+UPDATE "hours_saved_increments"
+SET "updated_at" = now()
+WHERE "updated_at" IS NULL;
+
+ALTER TABLE "hours_saved_increments"
+  ALTER COLUMN "updated_at" SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'hours_saved_increments_state_id_fkey'
+      AND table_name = 'hours_saved_increments'
+  ) THEN
+    ALTER TABLE "hours_saved_increments"
+      ADD CONSTRAINT "hours_saved_increments_state_id_fkey"
+      FOREIGN KEY ("state_id") REFERENCES "hours_saved_states"("id") ON DELETE CASCADE;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "hours_saved_increments_state_time_idx"
+  ON "hours_saved_increments" ("state_id", "scheduled_for");
+
+CREATE INDEX IF NOT EXISTS "hours_saved_increments_scheduled_for_idx"
+  ON "hours_saved_increments" ("scheduled_for");

--- a/apps/www/lib/db/schema.ts
+++ b/apps/www/lib/db/schema.ts
@@ -159,6 +159,49 @@ export const visitorSessions = pgTable(
   }),
 );
 
+export const hoursSavedStates = pgTable("hours_saved_states", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  baseAmount: integer("base_amount").notNull().default(0),
+  baseSetAt: timestamp("base_set_at", { mode: "date", withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export const hoursSavedIncrements = pgTable(
+  "hours_saved_increments",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    stateId: text("state_id")
+      .notNull()
+      .references(() => hoursSavedStates.id, { onDelete: "cascade" }),
+    scheduledFor: timestamp("scheduled_for", { mode: "date", withTimezone: true }).notNull(),
+    amount: integer("amount").notNull(),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => ({
+    scheduleTimeIdx: uniqueIndex("hours_saved_increments_state_time_idx").on(
+      table.stateId,
+      table.scheduledFor,
+    ),
+    scheduledForIdx: index("hours_saved_increments_scheduled_for_idx").on(table.scheduledFor),
+  }),
+);
+
 export const usersRelations = relations(users, ({ many }) => ({
   accounts: many(accounts),
   sessions: many(sessions),
@@ -195,6 +238,17 @@ export const meetingBookingsRelations = relations(meetingBookings, ({ one }) => 
   slot: one(meetingSlots, {
     fields: [meetingBookings.slotId],
     references: [meetingSlots.id],
+  }),
+}));
+
+export const hoursSavedStatesRelations = relations(hoursSavedStates, ({ many }) => ({
+  increments: many(hoursSavedIncrements),
+}));
+
+export const hoursSavedIncrementsRelations = relations(hoursSavedIncrements, ({ one }) => ({
+  state: one(hoursSavedStates, {
+    fields: [hoursSavedIncrements.stateId],
+    references: [hoursSavedStates.id],
   }),
 }));
 

--- a/apps/www/lib/hours-saved/constants.ts
+++ b/apps/www/lib/hours-saved/constants.ts
@@ -1,0 +1,48 @@
+import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
+
+export const HOURS_SAVED_WINDOW_DAYS = 7;
+export const HOURS_SAVED_WINDOW_HOURS = 24 * HOURS_SAVED_WINDOW_DAYS;
+export const HOURS_SAVED_DEFAULT_DAY_INCREMENT = 104;
+export const HOURS_SAVED_DEFAULT_NIGHT_INCREMENT = 65;
+export const HOURS_SAVED_DAY_START_HOUR = 8;
+export const HOURS_SAVED_DAY_END_HOUR = 20;
+export const HOURS_SAVED_MIN_EVENTS_PER_HOUR = 3;
+export const HOURS_SAVED_MAX_EVENTS_PER_HOUR = 6;
+export const HOURS_SAVED_TIME_ZONE = MEETING_TIME_ZONE;
+
+const hourFormatter = new Intl.DateTimeFormat("en-US", {
+  hour: "numeric",
+  hour12: false,
+  timeZone: HOURS_SAVED_TIME_ZONE,
+});
+
+export function startOfHour(date: Date): Date {
+  const copy = new Date(date);
+  copy.setMinutes(0, 0, 0);
+  return copy;
+}
+
+export function addHours(date: Date, hours: number): Date {
+  const copy = new Date(date);
+  copy.setHours(copy.getHours() + hours);
+  return copy;
+}
+
+export function nextHour(date: Date): Date {
+  return addHours(startOfHour(date), 1);
+}
+
+export function getZoneHour(date: Date): number {
+  const parts = hourFormatter.formatToParts(date);
+  const hourPart = parts.find((part) => part.type === "hour");
+  return hourPart ? Number.parseInt(hourPart.value, 10) : Number.parseInt(hourFormatter.format(date), 10);
+}
+
+export function isDaytimeInZone(date: Date): boolean {
+  const hour = getZoneHour(date);
+  return hour >= HOURS_SAVED_DAY_START_HOUR && hour < HOURS_SAVED_DAY_END_HOUR;
+}
+
+export function getDefaultIncrementFor(date: Date): number {
+  return isDaytimeInZone(date) ? HOURS_SAVED_DEFAULT_DAY_INCREMENT : HOURS_SAVED_DEFAULT_NIGHT_INCREMENT;
+}

--- a/apps/www/lib/hours-saved/index.ts
+++ b/apps/www/lib/hours-saved/index.ts
@@ -1,0 +1,364 @@
+import { and, asc, eq, gte, lt, lte } from "drizzle-orm";
+
+import { db, type DrizzleDB } from "@/lib/db/client";
+import { hoursSavedIncrements, hoursSavedStates } from "@/lib/db/schema";
+
+import {
+  HOURS_SAVED_MAX_EVENTS_PER_HOUR,
+  HOURS_SAVED_MIN_EVENTS_PER_HOUR,
+  HOURS_SAVED_WINDOW_HOURS,
+  addHours,
+  getDefaultIncrementFor,
+  nextHour,
+  startOfHour,
+} from "./constants";
+
+export type HoursSavedScheduleEntry = {
+  scheduledFor: Date;
+  amount: number;
+};
+
+export type HoursSavedOverview = {
+  baseAmount: number;
+  baseSetAt: Date;
+  currentAmount: number;
+  nextUpdateAt: Date | null;
+  schedule: HoursSavedScheduleEntry[];
+};
+
+type DbExecutor = DrizzleDB;
+
+type GeneratedIncrement = { scheduledFor: Date; amount: number };
+
+function randomInt(min: number, max: number): number {
+  const low = Math.ceil(min);
+  const high = Math.floor(max);
+  return Math.floor(Math.random() * (high - low + 1)) + low;
+}
+
+function distributeAmounts(total: number, count: number): number[] {
+  if (count <= 0) {
+    return [];
+  }
+
+  if (count === 1) {
+    return [total];
+  }
+
+  const breakpoints = Array.from({ length: count - 1 }, () => Math.random()).sort((a, b) => a - b);
+  const fractions: number[] = [];
+  let previous = 0;
+
+  for (const point of breakpoints) {
+    fractions.push(point - previous);
+    previous = point;
+  }
+  fractions.push(1 - previous);
+
+  let amounts = fractions.map((fraction) => Math.max(0, Math.round(fraction * total)));
+  let sum = amounts.reduce((acc, value) => acc + value, 0);
+
+  if (total >= count) {
+    amounts = amounts.map((value) => (value <= 0 ? 1 : value));
+    sum = amounts.reduce((acc, value) => acc + value, 0);
+  }
+
+  while (sum > total) {
+    for (let index = 0; index < amounts.length && sum > total; index += 1) {
+      if (amounts[index] > 1) {
+        amounts[index] -= 1;
+        sum -= 1;
+      }
+    }
+    if (sum === total) {
+      break;
+    }
+  }
+
+  let cursor = 0;
+  while (sum < total) {
+    amounts[cursor % amounts.length] += 1;
+    sum += 1;
+    cursor += 1;
+  }
+
+  return amounts;
+}
+
+function generateRandomizedIncrements(total: number, hourStart: Date): GeneratedIncrement[] {
+  if (total <= 0) {
+    return [
+      {
+        scheduledFor: new Date(hourStart),
+        amount: 0,
+      },
+    ];
+  }
+
+  const maxEvents = Math.max(1, Math.min(HOURS_SAVED_MAX_EVENTS_PER_HOUR, total));
+  const minEvents = Math.max(1, Math.min(HOURS_SAVED_MIN_EVENTS_PER_HOUR, maxEvents));
+  const eventCount = total < minEvents ? total : randomInt(minEvents, maxEvents);
+
+  const amounts = distributeAmounts(total, Math.max(1, eventCount));
+  const scheduled: GeneratedIncrement[] = [];
+  const usedSlots = new Set<string>();
+
+  for (const amount of amounts) {
+    const scheduledFor = new Date(hourStart);
+
+    if (amount === 0 && amounts.length > 1) {
+      // Skip zero entries when there are other positive chunks to avoid unnecessary updates.
+      continue;
+    }
+
+    if (amount === 0) {
+      scheduled.push({ scheduledFor, amount });
+      continue;
+    }
+
+    let minute = 0;
+    let second = 0;
+    let key = "";
+
+    do {
+      minute = randomInt(0, 59);
+      second = randomInt(0, 59);
+      key = `${minute}:${second}`;
+    } while (usedSlots.has(key));
+
+    usedSlots.add(key);
+    scheduledFor.setMinutes(minute, second, 0);
+    scheduled.push({ scheduledFor, amount });
+  }
+
+  scheduled.sort((a, b) => a.scheduledFor.getTime() - b.scheduledFor.getTime());
+
+  return scheduled;
+}
+
+async function ensureState(executor: DbExecutor = db) {
+  const existing = await executor.query.hoursSavedStates.findFirst();
+
+  if (existing) {
+    return existing;
+  }
+
+  const [created] = await executor
+    .insert(hoursSavedStates)
+    .values({
+      baseAmount: 0,
+      baseSetAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .returning();
+
+  if (!created) {
+    throw new Error("Failed to initialize hours saved state");
+  }
+
+  return created;
+}
+
+async function ensureUpcomingSchedule(
+  executor: DbExecutor,
+  stateId: string,
+  now: Date,
+) {
+  const windowStart = nextHour(now);
+  const windowEnd = addHours(windowStart, HOURS_SAVED_WINDOW_HOURS);
+
+  const existing = await executor
+    .select({ scheduledFor: hoursSavedIncrements.scheduledFor })
+    .from(hoursSavedIncrements)
+    .where(
+      and(
+        eq(hoursSavedIncrements.stateId, stateId),
+        gte(hoursSavedIncrements.scheduledFor, windowStart),
+        lt(hoursSavedIncrements.scheduledFor, windowEnd),
+      ),
+    )
+    .orderBy(asc(hoursSavedIncrements.scheduledFor));
+
+  const existingByHour = new Map<string, number>();
+  for (const row of existing) {
+    const hourStart = startOfHour(row.scheduledFor);
+    existingByHour.set(hourStart.toISOString(), 1);
+  }
+
+  const inserts: { stateId: string; scheduledFor: Date; amount: number }[] = [];
+
+  for (let offset = 0; offset < HOURS_SAVED_WINDOW_HOURS; offset += 1) {
+    const hourStart = addHours(windowStart, offset);
+    const key = hourStart.toISOString();
+
+    if (existingByHour.has(key)) {
+      continue;
+    }
+
+    const total = getDefaultIncrementFor(hourStart);
+    const generated = generateRandomizedIncrements(total, hourStart);
+
+    for (const entry of generated) {
+      inserts.push({
+        stateId,
+        scheduledFor: entry.scheduledFor,
+        amount: entry.amount,
+      });
+    }
+  }
+
+  if (inserts.length > 0) {
+    await executor.insert(hoursSavedIncrements).values(inserts);
+  }
+}
+
+async function sumAppliedIncrements(
+  executor: DbExecutor,
+  stateId: string,
+  baseSetAt: Date,
+  now: Date,
+) {
+  const rows = await executor
+    .select({ amount: hoursSavedIncrements.amount })
+    .from(hoursSavedIncrements)
+    .where(
+      and(
+        eq(hoursSavedIncrements.stateId, stateId),
+        gte(hoursSavedIncrements.scheduledFor, baseSetAt),
+        lte(hoursSavedIncrements.scheduledFor, now),
+      ),
+    );
+
+  return rows.reduce((total, row) => total + row.amount, 0);
+}
+
+export async function getHoursSavedOverview(now: Date = new Date()): Promise<HoursSavedOverview> {
+  const state = await ensureState();
+
+  await ensureUpcomingSchedule(db, state.id, now);
+
+  const applied = await sumAppliedIncrements(db, state.id, state.baseSetAt, now);
+
+  const windowStart = nextHour(now);
+  const windowEnd = addHours(windowStart, HOURS_SAVED_WINDOW_HOURS);
+
+  const scheduleRows = await db
+    .select({ scheduledFor: hoursSavedIncrements.scheduledFor, amount: hoursSavedIncrements.amount })
+    .from(hoursSavedIncrements)
+    .where(
+      and(
+        eq(hoursSavedIncrements.stateId, state.id),
+        gte(hoursSavedIncrements.scheduledFor, windowStart),
+        lt(hoursSavedIncrements.scheduledFor, windowEnd),
+      ),
+    )
+    .orderBy(asc(hoursSavedIncrements.scheduledFor));
+
+  const aggregated = new Map<string, HoursSavedScheduleEntry>();
+
+  for (const row of scheduleRows) {
+    const hourStart = startOfHour(row.scheduledFor);
+    const key = hourStart.toISOString();
+    const existingEntry = aggregated.get(key);
+
+    if (existingEntry) {
+      existingEntry.amount += row.amount;
+    } else {
+      aggregated.set(key, {
+        scheduledFor: hourStart,
+        amount: row.amount,
+      });
+    }
+  }
+
+  const schedule: HoursSavedScheduleEntry[] = [];
+  for (let offset = 0; offset < HOURS_SAVED_WINDOW_HOURS; offset += 1) {
+    const hourStart = addHours(windowStart, offset);
+    const key = hourStart.toISOString();
+    const entry = aggregated.get(key);
+    schedule.push({
+      scheduledFor: hourStart,
+      amount: entry?.amount ?? 0,
+    });
+  }
+
+  const nextUpdateRow = scheduleRows.find((row) => row.scheduledFor.getTime() > now.getTime() && row.amount > 0);
+
+  return {
+    baseAmount: state.baseAmount,
+    baseSetAt: state.baseSetAt,
+    currentAmount: state.baseAmount + applied,
+    nextUpdateAt: nextUpdateRow?.scheduledFor ?? null,
+    schedule,
+  };
+}
+
+export async function updateHoursSavedSettings(input: {
+  baseAmount: number;
+  schedule: HoursSavedScheduleEntry[];
+  now?: Date;
+}): Promise<HoursSavedOverview> {
+  const reference = input.now ?? new Date();
+
+  await db.transaction(async (tx) => {
+    const executor = tx as unknown as DbExecutor;
+    const state = await ensureState(executor);
+
+    const baseSetAt = reference;
+
+    await executor
+      .update(hoursSavedStates)
+      .set({
+        baseAmount: input.baseAmount,
+        baseSetAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(hoursSavedStates.id, state.id));
+
+    await executor
+      .delete(hoursSavedIncrements)
+      .where(
+        and(
+          eq(hoursSavedIncrements.stateId, state.id),
+          lt(hoursSavedIncrements.scheduledFor, baseSetAt),
+        ),
+      );
+
+    const windowStart = nextHour(reference);
+    const windowEnd = addHours(windowStart, HOURS_SAVED_WINDOW_HOURS);
+
+    await executor
+      .delete(hoursSavedIncrements)
+      .where(
+        and(
+          eq(hoursSavedIncrements.stateId, state.id),
+          gte(hoursSavedIncrements.scheduledFor, windowStart),
+          lt(hoursSavedIncrements.scheduledFor, windowEnd),
+        ),
+      );
+
+    if (input.schedule.length > 0) {
+      const generatedValues = input.schedule.flatMap((entry) => {
+        const hourStart = startOfHour(entry.scheduledFor);
+        const normalizedAmount = Math.max(0, Math.round(entry.amount));
+        const generated = generateRandomizedIncrements(normalizedAmount, hourStart);
+
+        return generated.map((item) => ({
+          stateId: state.id,
+          scheduledFor: item.scheduledFor,
+          amount: item.amount,
+          updatedAt: new Date(),
+        }));
+      });
+
+      if (generatedValues.length > 0) {
+        await executor.insert(hoursSavedIncrements).values(generatedValues);
+      }
+    }
+
+    await ensureUpcomingSchedule(executor, state.id, reference);
+  });
+
+  return getHoursSavedOverview(reference);
+}

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -1218,24 +1218,28 @@
     "title": "TransformAI account health",
     "subtitle": "Monitor how many client and staff seats are active across the platform.",
     "currentUser": "Signed in as {email}",
-    "metrics": {
-      "clients": {
-        "title": "Client accounts",
-        "caption": "{count, plural, one {# client live} other {# clients live}}"
-      },
-      "staff": {
-        "title": "Staff accounts",
-        "caption": "{count, plural, one {# internal teammate online} other {# internal teammates online}}"
-      },
-      "visitors": {
-        "title": "Unique visitors",
-        "caption": "{count, plural, one {# visitor session recorded} other {# visitor sessions recorded}}"
-      },
-      "ratio": {
-        "title": "Client-to-staff ratio",
-        "caption": "Healthy coverage is between 4:1 and 8:1 so every project has a partner lead."
-      }
+  "metrics": {
+    "clients": {
+      "title": "Client accounts",
+      "caption": "{count, plural, one {# client live} other {# clients live}}"
     },
+    "staff": {
+      "title": "Staff accounts",
+      "caption": "{count, plural, one {# internal teammate online} other {# internal teammates online}}"
+    },
+    "visitors": {
+      "title": "Unique visitors",
+      "caption": "{count, plural, one {# visitor session recorded} other {# visitor sessions recorded}}"
+  },
+  "hoursSaved": {
+      "title": "Hours saved with AI",
+      "caption": "{count, plural, one {# hour automated} other {# hours automated}}"
+    },
+    "ratio": {
+      "title": "Client-to-staff ratio",
+      "caption": "Healthy coverage is between 4:1 and 8:1 so every project has a partner lead."
+    }
+  },
     "accounts": {
       "clients": {
         "title": "Client account roster",
@@ -1287,6 +1291,39 @@
         "outreach": "Coordinate with delivery leads to share the new AI maturity playbook with their accounts.",
         "briefings": "Prepare January leadership briefings showcasing ROI metrics from automation pilots."
       }
+    }
+  },
+  "hoursSaved": {
+    "dialog": {
+      "title": "Automate the hours saved ticker",
+      "description": "Plan the upcoming automation. Times use {timeZone}.",
+      "baseLabel": "Starting amount",
+      "baseHelper": "Resets the ticker to this total immediately.",
+      "scheduleHeading": "Plan upcoming hours",
+      "scheduleDescription": "Preview the next seven days. Times use {timeZone}.",
+      "dayListLabel": "Next seven days",
+      "todayBadge": "Today",
+      "nextBadge": "Next",
+      "hoursPlanned": "Queued {count} hrs",
+      "hourDetailHeading": "Edit hour",
+      "hourDetailTimeLabel": "Scheduled time",
+      "hourDetailAmountLabel": "Hours added",
+      "hourDetailHelper": "Set how many hours should be added when this block triggers.",
+      "hourDetailEmpty": "Select an hour from the grid to edit its amount.",
+      "copyButton": "Copy day",
+      "copyPanelTitle": "Reuse a day",
+      "copyPanelDescription": "Choose a source day and the days that should inherit its hourly amounts.",
+      "copySourceLabel": "Source day",
+      "copyTargetLabel": "Apply to days",
+      "copyApply": "Apply copy",
+      "copyCancel": "Cancel copy",
+      "submit": "Push changes",
+      "saving": "Saving…",
+      "cancel": "Cancel",
+      "success": "Hours saved schedule updated.",
+      "error": "We couldn’t update the schedule. Try again.",
+      "validation": "Enter a non-negative value for each field.",
+      "amountSuffix": "hrs"
     }
   }
 }

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -1175,24 +1175,28 @@
     "title": "Gezondheid van TransformAI-accounts",
     "subtitle": "Volg hoeveel klant- en staff-accounts actief zijn op het platform.",
     "currentUser": "Ingelogd als {email}",
-    "metrics": {
-      "clients": {
-        "title": "Klantaccounts",
-        "caption": "{count, plural, one {# klant actief} other {# klanten actief}}"
-      },
-      "staff": {
-        "title": "Staff-accounts",
-        "caption": "{count, plural, one {# collega online} other {# collega's online}}"
-      },
-      "visitors": {
-        "title": "Unieke bezoekers",
-        "caption": "{count, plural, one {# bezoekersessie geregistreerd} other {# bezoekersessies geregistreerd}}"
-      },
-      "ratio": {
-        "title": "Verhouding klant/staff",
-        "caption": "Een gezonde dekking ligt tussen 4:1 en 8:1 zodat elk project een partnerlead heeft."
-      }
+  "metrics": {
+    "clients": {
+      "title": "Klantaccounts",
+      "caption": "{count, plural, one {# klant actief} other {# klanten actief}}"
     },
+    "staff": {
+      "title": "Staff-accounts",
+      "caption": "{count, plural, one {# collega online} other {# collega's online}}"
+    },
+    "visitors": {
+      "title": "Unieke bezoekers",
+      "caption": "{count, plural, one {# bezoekersessie geregistreerd} other {# bezoekersessies geregistreerd}}"
+    },
+    "hoursSaved": {
+      "title": "Bespaarde uren met AI",
+      "caption": "{count, plural, one {# uur geautomatiseerd} other {# uren geautomatiseerd}}"
+    },
+    "ratio": {
+      "title": "Verhouding klant/staff",
+      "caption": "Een gezonde dekking ligt tussen 4:1 en 8:1 zodat elk project een partnerlead heeft."
+    }
+  },
     "accounts": {
       "clients": {
         "title": "Overzicht klantaccounts",
@@ -1244,6 +1248,39 @@
         "outreach": "Stem met delivery leads af om het nieuwe AI-maturiteitsplaybook bij hun accounts te delen.",
         "briefings": "Bereid leiderschapsbriefings voor januari voor met ROI-cijfers uit de automatiseringspilots."
       }
+    }
+  },
+  "hoursSaved": {
+    "dialog": {
+      "title": "Automatiseer de teller voor bespaarde uren",
+      "description": "Plan de komende automatisering. Tijden gebruiken {timeZone}.",
+      "baseLabel": "Startwaarde",
+      "baseHelper": "Zet de teller direct op dit totaal.",
+      "scheduleHeading": "Komende uren plannen",
+      "scheduleDescription": "Bekijk de komende zeven dagen. Tijden gebruiken {timeZone}.",
+      "dayListLabel": "Komende zeven dagen",
+      "todayBadge": "Vandaag",
+      "nextBadge": "Volgende",
+      "hoursPlanned": "Ingepland: {count} uur",
+      "hourDetailHeading": "Uur bewerken",
+      "hourDetailTimeLabel": "Geplande tijd",
+      "hourDetailAmountLabel": "Toe te voegen uren",
+      "hourDetailHelper": "Bepaal hoeveel uren dit blok moet bijschrijven.",
+      "hourDetailEmpty": "Kies een uur in het raster om het aantal aan te passen.",
+      "copyButton": "Dag kopiëren",
+      "copyPanelTitle": "Dag hergebruiken",
+      "copyPanelDescription": "Selecteer een brondag en de dagen die dezelfde uren moeten krijgen.",
+      "copySourceLabel": "Brondag",
+      "copyTargetLabel": "Toepassen op dagen",
+      "copyApply": "Kopie toepassen",
+      "copyCancel": "Kopie annuleren",
+      "submit": "Wijzigingen doorvoeren",
+      "saving": "Bezig…",
+      "cancel": "Annuleren",
+      "success": "Schema voor bespaarde uren bijgewerkt.",
+      "error": "Bijwerken is mislukt. Probeer het opnieuw.",
+      "validation": "Voer voor elk veld een niet-negatieve waarde in.",
+      "amountSuffix": "uur"
     }
   }
 }


### PR DESCRIPTION
## Summary
- expand the hours-saved automation window to a seven-day horizon so staff can stage an entire week at once
- replace the overloaded card grid with a two-pane planner that groups hours by day, highlights the next update, and provides per-slot editing plus copy-day tooling
- refresh locale strings and project logs to reflect the streamlined workflow

## Plan
- widen the scheduler constants and backend expectations to cover 7 days / 168 hours
- rebuild the staff planner UI around day navigation, hour selection, and copy workflows using the updated data model
- update translations and WRITE_HERE notes to document the change and ensure i18n coverage

## Testing
- pnpm --filter www run typecheck *(hangs without completing; existing workspace issues prevent finishing the run)*

------
https://chatgpt.com/codex/tasks/task_e_68dea3895d04832aa1e2b2d77b34729a