### PR TITLE
Highlight staff dashboard stats

### DIFF
--- a/WRITE_HERE/FIXES/2025-10-03T0700--hours-saved-dashboard-refresh.md
+++ b/WRITE_HERE/FIXES/2025-10-03T0700--hours-saved-dashboard-refresh.md
@@ -1,0 +1,6 @@
+# Simplified hours saved dashboard scheduler
+
+- **What:** Rebuilt the staff dashboard to show a compact seven-day hours-saved planner with per-hour editing, copy-day workflows, and updated translations while extending the scheduling window to 168 hours.
+- **Why:** The previous bento-style dashboard felt chaotic and surfaced a missing translation error, making it hard for staff to manage the ticker reliably.
+- **Files:** `apps/www/app/[locale]/(site)/dashboard/page.tsx`, `apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx`, `apps/www/lib/hours-saved/constants.ts`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Consider adding automated tests once `next-intl` and database tooling are installed locally to get lint/typecheck passing.

--- a/WRITE_HERE/FIXES/2025-10-03T0718--hours-saved-randomized-schedule.md
+++ b/WRITE_HERE/FIXES/2025-10-03T0718--hours-saved-randomized-schedule.md
@@ -1,0 +1,6 @@
+# Hours saved planner moved and randomized
+
+- **What:** Moved the hours-saved planner to `/dashboard/hours-saved`, refreshed the staff overview tiles, tightened form validation, and randomized each increment within its hour.
+- **Why:** The combined dashboard felt cluttered, the planner rejected valid submissions, and updates occurred at the top of every hour instead of gradually.
+- **Files:** `apps/www/app/[locale]/(site)/dashboard/**`, `apps/www/components/navbar/navigation.tsx`, `apps/www/lib/hours-saved/**`, `apps/www/messages/*.json`.
+- **Follow-ups:** Monitor how the randomized timestamps feel in production and consider exposing range metadata in the API if external tooling needs it.

--- a/WRITE_HERE/FIXES/2025-11-29T2200--hours-saved-schedule-deduplication.md
+++ b/WRITE_HERE/FIXES/2025-11-29T2200--hours-saved-schedule-deduplication.md
@@ -1,0 +1,6 @@
+# Hours-saved planner accepts large increments again
+
+- **What:** Sanitized the dashboard planner to collapse duplicate hourly entries before display and submission, and updated the hours-saved overview API to return one item per hour.
+- **Why:** Duplicate rows from older data made the UI unreadable and caused schedule updates with large positive values to fail validation.
+- **Files:** `apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx`, `apps/www/lib/hours-saved/index.ts`.
+- **Follow-ups:** Consider exposing a maintenance script to purge legacy duplicate increments from the database directly.

--- a/WRITE_HERE/FIXES/2025-11-30T0945--restored-dashboard-stats.md
+++ b/WRITE_HERE/FIXES/2025-11-30T0945--restored-dashboard-stats.md
@@ -1,0 +1,6 @@
+# Restored dashboard account and visitor stats
+
+- **What:** Brought the client, staff, visitor, and hours-saved summaries back to the staff dashboard with their dialogs, kept the new quick links, and refreshed English/Dutch copy for the revived sections.
+- **Why:** The overview lost essential reporting when the hours-saved planner moved to its own tab, and staff still rely on those insights to monitor activity.
+- **Files:** `apps/www/app/[locale]/(site)/dashboard/page.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Re-evaluate the planning tab once its tooling is ready so the overview can surface its status card as well.

--- a/WRITE_HERE/FIXES/2025-11-30T1600--dashboard-stats-highlight.md
+++ b/WRITE_HERE/FIXES/2025-11-30T1600--dashboard-stats-highlight.md
@@ -1,0 +1,6 @@
+# Surfaced dashboard stats in hero
+
+- **What:** Added a top-row highlight grid to the staff dashboard so client, staff, visitor, and hours-saved totals are visible immediately when landing on the page, while keeping the detailed metric cards and dialogs available below.
+- **Why:** Staff could not find the reinstated statistics without scrolling, so the numbers now appear prominently within the hero layout.
+- **Files:** `apps/www/app/[locale]/(site)/dashboard/page.tsx`, `WRITE_HERE/FIXES/2025-11-30T1600--dashboard-stats-highlight.md`.
+- **Follow-ups:** Consider surfacing trend deltas next to the totals once analytics data is available.

--- a/WRITE_HERE/UPDATES/2025-11-29T2105--hours-saved-staff-controls.md
+++ b/WRITE_HERE/UPDATES/2025-11-29T2105--hours-saved-staff-controls.md
@@ -1,0 +1,6 @@
+# Hours saved metric is now configurable
+
+- **What:** Added persistent tables and APIs to manage the automatic “hours saved by AI” ticker, exposed a staff dashboard dialog to edit the next 24 hourly increments and starting amount, and animated the homepage ticker when new hours are applied. The hero now pulls live data via `/api/hours-saved`.
+- **Why:** Staff need to tweak the hourly automation and reset the counter without touching code while visitors should see a polished, animated number as it updates.
+- **Files:** `apps/www/lib/db/schema.ts`, `apps/www/lib/hours-saved/**`, `apps/www/app/[locale]/(site)/dashboard/**`, `apps/www/app/api/hours-saved/route.ts`, `apps/www/components/hero/**`, `apps/www/messages/*.json`.
+- **Follow-ups:** Consider adding auth around the API if exposed publicly, and revisit long-term retention of historical increment rows.

--- a/apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useMemo, useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { DialogClose, DialogFooter } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  HOURS_SAVED_WINDOW_HOURS,
+  addHours,
+  getDefaultIncrementFor,
+  nextHour,
+} from "@/lib/hours-saved/constants";
+import { cn } from "@/lib/utils";
+
+import { updateHoursSavedScheduleAction } from "../hours-saved-actions";
+
+type ScheduleRowState = {
+  scheduledFor: Date;
+  input: string;
+};
+
+type HoursSavedManagerStrings = {
+  baseLabel: string;
+  baseHelper: string;
+  scheduleHeading: string;
+  scheduleDescription: string;
+  timeColumnLabel: string;
+  resetLabel: string;
+  submitLabel: string;
+  savingLabel: string;
+  cancelLabel: string;
+  successMessage: string;
+  errorMessage: string;
+  validationError: string;
+  amountSuffix: string;
+};
+
+type HoursSavedManagerProps = {
+  locale: string;
+  timeZone: string;
+  baseAmount: number;
+  schedule: { scheduledFor: string; amount: number }[];
+  strings: HoursSavedManagerStrings;
+};
+
+function sortSchedule(entries: { scheduledFor: string; amount: number }[]): ScheduleRowState[] {
+  return [...entries]
+    .sort((a, b) => new Date(a.scheduledFor).getTime() - new Date(b.scheduledFor).getTime())
+    .map((entry) => ({
+      scheduledFor: new Date(entry.scheduledFor),
+      input: entry.amount.toString(),
+    }));
+}
+
+export function HoursSavedManager({ locale, timeZone, baseAmount, schedule, strings }: HoursSavedManagerProps) {
+  const [baseValue, setBaseValue] = useState(baseAmount.toString());
+  const [rows, setRows] = useState<ScheduleRowState[]>(() => sortSchedule(schedule));
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const timeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        weekday: "short",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+        timeZone,
+      }),
+    [locale, timeZone],
+  );
+
+  const handleBaseChange = (value: string) => {
+    setBaseValue(value);
+    setStatus("idle");
+    setStatusMessage(null);
+  };
+
+  const handleRowChange = (index: number, value: string) => {
+    setRows((current) => {
+      const next = [...current];
+      next[index] = { ...next[index], input: value };
+      return next;
+    });
+    setStatus("idle");
+    setStatusMessage(null);
+  };
+
+  const resetToDefaults = () => {
+    const reference = new Date();
+    const windowStart = nextHour(reference);
+
+    const defaults: ScheduleRowState[] = Array.from({ length: HOURS_SAVED_WINDOW_HOURS }, (_, index) => {
+      const scheduledFor = addHours(windowStart, index);
+      return {
+        scheduledFor,
+        input: getDefaultIncrementFor(scheduledFor).toString(),
+      };
+    });
+
+    setRows(defaults);
+    setStatus("idle");
+    setStatusMessage(null);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus("idle");
+    setStatusMessage(null);
+
+    const parsedBase = Number.parseInt(baseValue, 10);
+
+    if (Number.isNaN(parsedBase) || parsedBase < 0) {
+      setStatus("error");
+      setStatusMessage(strings.validationError);
+      return;
+    }
+
+    const schedulePayload = rows.map((row) => {
+      const parsed = Number.parseInt(row.input, 10);
+      return {
+        scheduledFor: row.scheduledFor.toISOString(),
+        amount: Number.isNaN(parsed) || parsed < 0 ? 0 : parsed,
+      };
+    });
+
+    startTransition(async () => {
+      const result = await updateHoursSavedScheduleAction(locale, {
+        baseAmount: parsedBase,
+        schedule: schedulePayload,
+      });
+
+      if (!result.success) {
+        setStatus("error");
+        setStatusMessage(result.error === "validation" ? strings.validationError : strings.errorMessage);
+        return;
+      }
+
+      try {
+        const response = await fetch("/api/hours-saved", { cache: "no-store" });
+        if (response.ok) {
+          const data = await response.json();
+          setRows(sortSchedule(data.schedule));
+          setBaseValue(data.baseAmount.toString());
+        }
+      } catch (error) {
+        console.error("Failed to refresh hours saved overview", error);
+      }
+
+      setStatus("success");
+      setStatusMessage(strings.successMessage);
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="space-y-2">
+        <Label className="text-sm font-medium text-white/80">{strings.baseLabel}</Label>
+        <Input
+          type="number"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          value={baseValue}
+          min={0}
+          onChange={(event) => handleBaseChange(event.target.value)}
+          className="border-white/15 bg-white/5 text-white placeholder:text-white/40 focus-visible:ring-white/40"
+        />
+        <p className="text-xs text-white/50">{strings.baseHelper}</p>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-sm font-semibold text-white">{strings.scheduleHeading}</p>
+            <p className="text-xs text-white/50">{strings.scheduleDescription}</p>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={resetToDefaults}
+            className="h-9 rounded-full border border-white/10 bg-white/5 px-4 text-xs font-semibold uppercase tracking-[0.2em] text-white/70 hover:bg-white/10"
+          >
+            {strings.resetLabel}
+          </Button>
+        </div>
+
+        <div className="rounded-2xl border border-white/10 bg-white/5">
+          <div className="grid grid-cols-[1fr_auto] gap-4 border-b border-white/10 px-4 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white/50">
+            <span>{strings.timeColumnLabel}</span>
+            <span className="text-right">{strings.amountSuffix}</span>
+          </div>
+          <ScrollArea className="max-h-72">
+            <div className="divide-y divide-white/5">
+              {rows.map((row, index) => {
+                const label = timeFormatter.format(row.scheduledFor);
+                return (
+                  <div
+                    key={row.scheduledFor.toISOString()}
+                    className="grid grid-cols-[1fr_auto] items-center gap-4 px-4 py-3 text-sm text-white/80"
+                  >
+                    <span className="font-mono text-xs uppercase tracking-[0.25em] text-white/60 sm:text-sm">
+                      {label}
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        inputMode="numeric"
+                        pattern="[0-9]*"
+                        min={0}
+                        value={row.input}
+                        onChange={(event) => handleRowChange(index, event.target.value)}
+                        className="h-9 w-24 border-white/15 bg-black/60 text-right text-sm text-white focus-visible:ring-white/40"
+                      />
+                      <span className="text-xs uppercase tracking-[0.3em] text-white/40">{strings.amountSuffix}</span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </ScrollArea>
+        </div>
+      </div>
+
+      {statusMessage ? (
+        <p
+          className={cn(
+            "text-xs",
+            status === "success" ? "text-emerald-400" : status === "error" ? "text-rose-400" : "text-white/60",
+          )}
+        >
+          {statusMessage}
+        </p>
+      ) : null}
+
+      <DialogFooter className="gap-2 sm:gap-3">
+        <DialogClose asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            className="h-10 rounded-full border border-white/10 bg-white/5 px-6 text-xs font-semibold uppercase tracking-[0.2em] text-white/70 hover:bg-white/10"
+            disabled={isPending}
+          >
+            {strings.cancelLabel}
+          </Button>
+        </DialogClose>
+        <Button
+          type="submit"
+          className="h-10 rounded-full bg-white px-6 text-xs font-semibold uppercase tracking-[0.3em] text-black hover:bg-white/90"
+          disabled={isPending}
+        >
+          {isPending ? strings.savingLabel : strings.submitLabel}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}

--- a/apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx
@@ -1,42 +1,29 @@
 "use client";
 
 import type { FormEvent } from "react";
-import { useMemo, useState, useTransition } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
 
 import { Button } from "@/components/ui/button";
-import { DialogClose, DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  HOURS_SAVED_WINDOW_HOURS,
-  addHours,
-  getDefaultIncrementFor,
-  nextHour,
-} from "@/lib/hours-saved/constants";
 import { cn } from "@/lib/utils";
+import { useTranslations } from "next-intl";
 
 import { updateHoursSavedScheduleAction } from "../hours-saved-actions";
+import {
+  HOURS_SAVED_WINDOW_HOURS,
+  startOfHour,
+} from "@/lib/hours-saved/constants";
 
 type ScheduleRowState = {
   scheduledFor: Date;
   input: string;
-};
-
-type HoursSavedManagerStrings = {
-  baseLabel: string;
-  baseHelper: string;
-  scheduleHeading: string;
-  scheduleDescription: string;
-  timeColumnLabel: string;
-  resetLabel: string;
-  submitLabel: string;
-  savingLabel: string;
-  cancelLabel: string;
-  successMessage: string;
-  errorMessage: string;
-  validationError: string;
-  amountSuffix: string;
 };
 
 type HoursSavedManagerProps = {
@@ -44,29 +31,73 @@ type HoursSavedManagerProps = {
   timeZone: string;
   baseAmount: number;
   schedule: { scheduledFor: string; amount: number }[];
-  strings: HoursSavedManagerStrings;
+};
+
+type DayEntry = {
+  id: string;
+  hourCode: string;
+  rangeLabel: string;
+  row: ScheduleRowState;
+};
+
+type DayBucket = {
+  key: string;
+  label: string;
+  isToday: boolean;
+  entries: DayEntry[];
 };
 
 function sortSchedule(entries: { scheduledFor: string; amount: number }[]): ScheduleRowState[] {
-  return [...entries]
-    .sort((a, b) => new Date(a.scheduledFor).getTime() - new Date(b.scheduledFor).getTime())
-    .map((entry) => ({
-      scheduledFor: new Date(entry.scheduledFor),
+  const sorted = [...entries].sort(
+    (a, b) => new Date(a.scheduledFor).getTime() - new Date(b.scheduledFor).getTime(),
+  );
+
+  const seenHours = new Set<string>();
+  const sanitized: ScheduleRowState[] = [];
+
+  for (const entry of sorted) {
+    const scheduledFor = new Date(entry.scheduledFor);
+    const hourKey = startOfHour(scheduledFor).toISOString();
+
+    if (seenHours.has(hourKey)) {
+      continue;
+    }
+
+    seenHours.add(hourKey);
+    sanitized.push({
+      scheduledFor,
       input: entry.amount.toString(),
-    }));
+    });
+
+    if (sanitized.length === HOURS_SAVED_WINDOW_HOURS) {
+      break;
+    }
+  }
+
+  return sanitized;
 }
 
-export function HoursSavedManager({ locale, timeZone, baseAmount, schedule, strings }: HoursSavedManagerProps) {
+function getPart(parts: Intl.DateTimeFormatPart[], type: Intl.DateTimeFormatPart["type"]) {
+  return parts.find((part) => part.type === type)?.value ?? "";
+}
+
+export function HoursSavedManager({ locale, timeZone, baseAmount, schedule }: HoursSavedManagerProps) {
+  const t = useTranslations("Dashboard.hoursSaved");
+
   const [baseValue, setBaseValue] = useState(baseAmount.toString());
   const [rows, setRows] = useState<ScheduleRowState[]>(() => sortSchedule(schedule));
   const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [selectedDay, setSelectedDay] = useState<string>("");
+  const [activeHour, setActiveHour] = useState<string>("");
+  const [copyMode, setCopyMode] = useState(false);
+  const [copySource, setCopySource] = useState<string | null>(null);
+  const [copyTargets, setCopyTargets] = useState<string[]>([]);
 
   const timeFormatter = useMemo(
     () =>
       new Intl.DateTimeFormat(locale, {
-        weekday: "short",
         hour: "2-digit",
         minute: "2-digit",
         hour12: false,
@@ -75,35 +106,151 @@ export function HoursSavedManager({ locale, timeZone, baseAmount, schedule, stri
     [locale, timeZone],
   );
 
+  const dayLabelFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        weekday: "short",
+        day: "numeric",
+        month: "short",
+        timeZone,
+      }),
+    [locale, timeZone],
+  );
+
+  const dayKeyFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat("en-CA", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        timeZone,
+      }),
+    [timeZone],
+  );
+
+  const getHourCode = useCallback(
+    (date: Date) => {
+      const parts = timeFormatter.formatToParts(date);
+      const hour = parts.find((part) => part.type === "hour")?.value ?? "00";
+      return hour.padStart(2, "0");
+    },
+    [timeFormatter],
+  );
+
+  const getRangeLabel = useCallback(
+    (date: Date) => {
+      const hourCode = getHourCode(date);
+      const startLabel = `${hourCode}:00`;
+      const endHour = (Number.parseInt(hourCode, 10) + 1) % 24;
+      const endLabel = `${endHour.toString().padStart(2, "0")}:00`;
+      return `${startLabel} – ${endLabel}`;
+    },
+    [getHourCode],
+  );
+
+  const getDayKey = useCallback(
+    (date: Date) => {
+      const parts = dayKeyFormatter.formatToParts(date);
+      const year = getPart(parts, "year");
+      const month = getPart(parts, "month");
+      const day = getPart(parts, "day");
+      return `${year}-${month}-${day}`;
+    },
+    [dayKeyFormatter],
+  );
+
+  const todayKey = useMemo(() => getDayKey(new Date()), [getDayKey]);
+
+  const dayBuckets: DayBucket[] = useMemo(() => {
+    const byDay = new Map<string, DayBucket>();
+
+    for (const row of rows) {
+      const key = getDayKey(row.scheduledFor);
+      const label = dayLabelFormatter.format(row.scheduledFor);
+      const bucket = byDay.get(key);
+
+      if (bucket) {
+        bucket.entries.push({
+          id: row.scheduledFor.toISOString(),
+          hourCode: getHourCode(row.scheduledFor),
+          rangeLabel: getRangeLabel(row.scheduledFor),
+          row,
+        });
+        continue;
+      }
+
+      byDay.set(key, {
+        key,
+        label,
+        isToday: key === todayKey,
+        entries: [
+          {
+            id: row.scheduledFor.toISOString(),
+            hourCode: getHourCode(row.scheduledFor),
+            rangeLabel: getRangeLabel(row.scheduledFor),
+            row,
+          },
+        ],
+      });
+    }
+
+    return Array.from(byDay.values()).map((bucket) => ({
+      ...bucket,
+      entries: bucket.entries.sort(
+        (a, b) => a.row.scheduledFor.getTime() - b.row.scheduledFor.getTime(),
+      ),
+    }));
+  }, [rows, getDayKey, dayLabelFormatter, getHourCode, getRangeLabel, todayKey]);
+
+  useEffect(() => {
+    if (selectedDay && dayBuckets.some((bucket) => bucket.key === selectedDay)) {
+      return;
+    }
+
+    const fallback = dayBuckets[0]?.key ?? "";
+    if (fallback) {
+      setSelectedDay(fallback);
+      setActiveHour(dayBuckets[0]?.entries[0]?.id ?? "");
+    }
+  }, [dayBuckets, selectedDay]);
+
+  const selectedDayBucket = useMemo(
+    () => dayBuckets.find((bucket) => bucket.key === selectedDay),
+    [dayBuckets, selectedDay],
+  );
+
+  useEffect(() => {
+    if (!selectedDayBucket) {
+      return;
+    }
+
+    if (!selectedDayBucket.entries.some((entry) => entry.id === activeHour)) {
+      const fallback = selectedDayBucket.entries[0]?.id ?? "";
+      setActiveHour(fallback);
+    }
+  }, [selectedDayBucket, activeHour]);
+
+  const activeEntry = useMemo(
+    () => selectedDayBucket?.entries.find((entry) => entry.id === activeHour) ?? null,
+    [selectedDayBucket, activeHour],
+  );
+
   const handleBaseChange = (value: string) => {
     setBaseValue(value);
     setStatus("idle");
     setStatusMessage(null);
   };
 
-  const handleRowChange = (index: number, value: string) => {
-    setRows((current) => {
-      const next = [...current];
-      next[index] = { ...next[index], input: value };
-      return next;
-    });
-    setStatus("idle");
-    setStatusMessage(null);
-  };
+  const handleActiveValueChange = (value: string) => {
+    if (!activeEntry) {
+      return;
+    }
 
-  const resetToDefaults = () => {
-    const reference = new Date();
-    const windowStart = nextHour(reference);
-
-    const defaults: ScheduleRowState[] = Array.from({ length: HOURS_SAVED_WINDOW_HOURS }, (_, index) => {
-      const scheduledFor = addHours(windowStart, index);
-      return {
-        scheduledFor,
-        input: getDefaultIncrementFor(scheduledFor).toString(),
-      };
-    });
-
-    setRows(defaults);
+    setRows((current) =>
+      current.map((row) =>
+        row.scheduledFor.toISOString() === activeEntry.id ? { ...row, input: value } : row,
+      ),
+    );
     setStatus("idle");
     setStatusMessage(null);
   };
@@ -113,21 +260,44 @@ export function HoursSavedManager({ locale, timeZone, baseAmount, schedule, stri
     setStatus("idle");
     setStatusMessage(null);
 
-    const parsedBase = Number.parseInt(baseValue, 10);
-
-    if (Number.isNaN(parsedBase) || parsedBase < 0) {
+    const baseTrimmed = baseValue.trim();
+    if (baseTrimmed === "") {
       setStatus("error");
-      setStatusMessage(strings.validationError);
+      setStatusMessage(t("status.validation"));
       return;
     }
 
-    const schedulePayload = rows.map((row) => {
-      const parsed = Number.parseInt(row.input, 10);
-      return {
+    const parsedBase = Number(baseTrimmed);
+
+    if (!Number.isFinite(parsedBase) || parsedBase < 0 || !Number.isInteger(parsedBase)) {
+      setStatus("error");
+      setStatusMessage(t("status.validation"));
+      return;
+    }
+
+    const schedulePayload: { scheduledFor: string; amount: number }[] = [];
+
+    for (const row of rows) {
+      const trimmed = row.input.trim();
+      if (trimmed === "") {
+        setStatus("error");
+        setStatusMessage(t("status.validation"));
+        return;
+      }
+
+      const parsed = Number(trimmed);
+
+      if (!Number.isFinite(parsed) || parsed < 0 || !Number.isInteger(parsed)) {
+        setStatus("error");
+        setStatusMessage(t("status.validation"));
+        return;
+      }
+
+      schedulePayload.push({
         scheduledFor: row.scheduledFor.toISOString(),
-        amount: Number.isNaN(parsed) || parsed < 0 ? 0 : parsed,
-      };
-    });
+        amount: parsed,
+      });
+    }
 
     startTransition(async () => {
       const result = await updateHoursSavedScheduleAction(locale, {
@@ -137,7 +307,9 @@ export function HoursSavedManager({ locale, timeZone, baseAmount, schedule, stri
 
       if (!result.success) {
         setStatus("error");
-        setStatusMessage(result.error === "validation" ? strings.validationError : strings.errorMessage);
+        setStatusMessage(
+          result.error === "validation" ? t("status.validation") : t("status.error"),
+        );
         return;
       }
 
@@ -153,78 +325,286 @@ export function HoursSavedManager({ locale, timeZone, baseAmount, schedule, stri
       }
 
       setStatus("success");
-      setStatusMessage(strings.successMessage);
+      setStatusMessage(t("status.success"));
+      setCopyMode(false);
+      setCopySource(null);
+      setCopyTargets([]);
     });
   };
 
+  const toggleCopyMode = () => {
+    setCopyMode((current) => {
+      const next = !current;
+      if (next) {
+        setCopySource(selectedDayBucket?.key ?? null);
+        setCopyTargets([]);
+      } else {
+        setCopySource(null);
+        setCopyTargets([]);
+      }
+      return next;
+    });
+    setStatus("idle");
+    setStatusMessage(null);
+  };
+
+  const toggleCopyTarget = (dayKey: string) => {
+    setCopyTargets((current) =>
+      current.includes(dayKey)
+        ? current.filter((key) => key !== dayKey)
+        : [...current, dayKey],
+    );
+  };
+
+  const applyCopy = () => {
+    if (!copySource || copyTargets.length === 0) {
+      setStatus("error");
+      setStatusMessage(t("status.copyValidation"));
+      return;
+    }
+
+    const sourceBucket = dayBuckets.find((bucket) => bucket.key === copySource);
+
+    if (!sourceBucket) {
+      setStatus("error");
+      setStatusMessage(t("status.copyValidation"));
+      return;
+    }
+
+    const sourceValues = new Map<string, string>(
+      sourceBucket.entries.map((entry) => [entry.hourCode, entry.row.input]),
+    );
+
+    setRows((current) =>
+      current.map((row) => {
+        const dayKey = getDayKey(row.scheduledFor);
+        if (!copyTargets.includes(dayKey)) {
+          return row;
+        }
+
+        const hourCode = getHourCode(row.scheduledFor);
+        const replacement = sourceValues.get(hourCode);
+        if (replacement === undefined) {
+          return row;
+        }
+
+        return { ...row, input: replacement };
+      }),
+    );
+
+    setStatus("success");
+    setStatusMessage(t("status.copySuccess"));
+    setCopyMode(false);
+    setCopySource(null);
+    setCopyTargets([]);
+  };
+
+  const daySummary = (() => {
+    if (!selectedDayBucket) {
+      return "";
+    }
+
+    if (selectedDayBucket.isToday) {
+      const nextLabel = selectedDayBucket.entries[0]?.rangeLabel ?? "";
+      return t("days.todaySummary", {
+        window: nextLabel,
+        remaining: selectedDayBucket.entries.length,
+      });
+    }
+
+    return t("days.daySummary", { count: selectedDayBucket.entries.length });
+  })();
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
+    <form onSubmit={handleSubmit} className="space-y-8">
       <div className="space-y-2">
-        <Label className="text-sm font-medium text-white/80">{strings.baseLabel}</Label>
+        <Label className="text-sm font-medium text-white/80">{t("base.label")}</Label>
         <Input
           type="number"
           inputMode="numeric"
           pattern="[0-9]*"
+          step={1}
           value={baseValue}
           min={0}
           onChange={(event) => handleBaseChange(event.target.value)}
-          className="border-white/15 bg-white/5 text-white placeholder:text-white/40 focus-visible:ring-white/40"
+          className="h-11 rounded-xl border-white/15 bg-white/5 text-base text-white placeholder:text-white/40 focus-visible:ring-white/40"
         />
-        <p className="text-xs text-white/50">{strings.baseHelper}</p>
+        <p className="text-xs text-white/50">{t("base.helper")}</p>
       </div>
 
-      <div className="space-y-3">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <p className="text-sm font-semibold text-white">{strings.scheduleHeading}</p>
-            <p className="text-xs text-white/50">{strings.scheduleDescription}</p>
-          </div>
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={resetToDefaults}
-            className="h-9 rounded-full border border-white/10 bg-white/5 px-4 text-xs font-semibold uppercase tracking-[0.2em] text-white/70 hover:bg-white/10"
-          >
-            {strings.resetLabel}
-          </Button>
+      <div className="space-y-4">
+        <div className="space-y-1">
+          <p className="text-sm font-semibold text-white">{t("days.heading")}</p>
+          <p className="text-xs text-white/50">{t("days.helper")}</p>
         </div>
+        <div className="flex flex-wrap gap-2">
+          {dayBuckets.map((bucket) => (
+            <button
+              key={bucket.key}
+              type="button"
+              onClick={() => {
+                setSelectedDay(bucket.key);
+                setStatus("idle");
+                setStatusMessage(null);
+              }}
+              className={cn(
+                "flex items-center gap-2 rounded-xl border px-4 py-2 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black",
+                selectedDay === bucket.key
+                  ? "border-white/90 bg-white text-black shadow"
+                  : "border-white/15 bg-white/5 text-white/70 hover:border-white/40",
+              )}
+            >
+              <span>{bucket.label}</span>
+              {bucket.isToday ? (
+                <span className="rounded-full bg-black/40 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.24em] text-white/60">
+                  {t("days.todayBadge")}
+                </span>
+              ) : null}
+            </button>
+          ))}
+        </div>
+        {daySummary ? <p className="text-xs text-white/60">{daySummary}</p> : null}
+      </div>
 
-        <div className="rounded-2xl border border-white/10 bg-white/5">
-          <div className="grid grid-cols-[1fr_auto] gap-4 border-b border-white/10 px-4 py-3 text-xs font-semibold uppercase tracking-[0.2em] text-white/50">
-            <span>{strings.timeColumnLabel}</span>
-            <span className="text-right">{strings.amountSuffix}</span>
+      {selectedDayBucket ? (
+        <div className="space-y-5">
+          <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-6">
+            {selectedDayBucket.entries.map((entry) => (
+              <button
+                key={entry.id}
+                type="button"
+                onClick={() => {
+                  setActiveHour(entry.id);
+                  setStatus("idle");
+                  setStatusMessage(null);
+                }}
+                aria-label={t("days.hourButtonAria", {
+                  time: entry.rangeLabel,
+                  amount: entry.row.input || "0",
+                })}
+                className={cn(
+                  "flex h-14 items-center justify-center rounded-xl border text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black",
+                  activeHour === entry.id
+                    ? "border-white/80 bg-white text-black shadow"
+                    : "border-white/15 bg-white/5 text-white/70 hover:border-white/40",
+                )}
+              >
+                {entry.rangeLabel}
+              </button>
+            ))}
           </div>
-          <ScrollArea className="max-h-72">
-            <div className="divide-y divide-white/5">
-              {rows.map((row, index) => {
-                const label = timeFormatter.format(row.scheduledFor);
-                return (
-                  <div
-                    key={row.scheduledFor.toISOString()}
-                    className="grid grid-cols-[1fr_auto] items-center gap-4 px-4 py-3 text-sm text-white/80"
-                  >
-                    <span className="font-mono text-xs uppercase tracking-[0.25em] text-white/60 sm:text-sm">
-                      {label}
-                    </span>
-                    <div className="flex items-center gap-2">
-                      <Input
-                        type="number"
-                        inputMode="numeric"
-                        pattern="[0-9]*"
-                        min={0}
-                        value={row.input}
-                        onChange={(event) => handleRowChange(index, event.target.value)}
-                        className="h-9 w-24 border-white/15 bg-black/60 text-right text-sm text-white focus-visible:ring-white/40"
-                      />
-                      <span className="text-xs uppercase tracking-[0.3em] text-white/40">{strings.amountSuffix}</span>
-                    </div>
-                  </div>
-                );
-              })}
+
+          {activeEntry ? (
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-white">
+                  {t("editor.title", { time: activeEntry.rangeLabel })}
+                </p>
+                <p className="text-xs text-white/50">{t("editor.helper")}</p>
+              </div>
+              <div className="mt-4 flex items-center gap-3">
+                <Label htmlFor="hour-amount" className="text-xs font-semibold uppercase tracking-[0.28em] text-white/60">
+                  {t("editor.amountLabel")}
+                </Label>
+                <Input
+                  id="hour-amount"
+                  type="number"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  step={1}
+                  min={0}
+                  value={activeEntry.row.input}
+                  onChange={(event) => handleActiveValueChange(event.target.value)}
+                  className="h-10 w-28 rounded-xl border-white/15 bg-black/60 text-right text-sm text-white focus-visible:ring-white/40"
+                />
+                <span className="text-xs font-semibold uppercase tracking-[0.28em] text-white/40">
+                  {t("editor.amountSuffix")}
+                </span>
+              </div>
             </div>
-          </ScrollArea>
+          ) : null}
         </div>
-      </div>
+      ) : null}
+
+      {copyMode ? (
+        <div className="space-y-4 rounded-2xl border border-white/10 bg-black/40 p-5">
+          <div className="space-y-1">
+            <p className="text-sm font-semibold text-white">{t("copy.title")}</p>
+            <p className="text-xs text-white/50">{t("copy.description")}</p>
+          </div>
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+              {t("copy.sourceLabel")}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {dayBuckets.map((bucket) => (
+                <button
+                  key={`source-${bucket.key}`}
+                  type="button"
+                  onClick={() => setCopySource(bucket.key)}
+                  className={cn(
+                    "rounded-full border px-3 py-1 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black",
+                    copySource === bucket.key
+                      ? "border-white/90 bg-white text-black"
+                      : "border-white/15 bg-white/5 text-white/70 hover:border-white/40",
+                  )}
+                >
+                  {bucket.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+              {t("copy.targetLabel")}
+            </p>
+            <p className="text-[11px] text-white/50">{t("copy.helper")}</p>
+            <div className="flex flex-wrap gap-2">
+              {dayBuckets
+                .filter((bucket) => bucket.key !== copySource)
+                .map((bucket) => {
+                  const isSelected = copyTargets.includes(bucket.key);
+                  return (
+                    <button
+                      key={`target-${bucket.key}`}
+                      type="button"
+                      onClick={() => toggleCopyTarget(bucket.key)}
+                      aria-pressed={isSelected}
+                      className={cn(
+                        "rounded-full border px-3 py-1 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black",
+                        isSelected
+                          ? "border-white/90 bg-white text-black"
+                          : "border-white/15 bg-white/5 text-white/70 hover:border-white/40",
+                      )}
+                    >
+                      {bucket.label}
+                    </button>
+                  );
+                })}
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              onClick={() => {
+                setCopyMode(false);
+                setCopySource(null);
+                setCopyTargets([]);
+              }}
+              className="h-9 rounded-full border border-white/20 bg-white/10 px-4 text-xs font-semibold uppercase tracking-[0.24em] text-white/70 hover:bg-white/15"
+            >
+              {t("copy.cancel")}
+            </Button>
+            <Button
+              type="button"
+              onClick={applyCopy}
+              className="h-9 rounded-full bg-white px-4 text-xs font-semibold uppercase tracking-[0.3em] text-black hover:bg-white/90"
+            >
+              {t("copy.apply")}
+            </Button>
+          </div>
+        </div>
+      ) : null}
 
       {statusMessage ? (
         <p
@@ -237,25 +617,22 @@ export function HoursSavedManager({ locale, timeZone, baseAmount, schedule, stri
         </p>
       ) : null}
 
-      <DialogFooter className="gap-2 sm:gap-3">
-        <DialogClose asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-10 rounded-full border border-white/10 bg-white/5 px-6 text-xs font-semibold uppercase tracking-[0.2em] text-white/70 hover:bg-white/10"
-            disabled={isPending}
-          >
-            {strings.cancelLabel}
-          </Button>
-        </DialogClose>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Button
+          type="button"
+          onClick={toggleCopyMode}
+          className="h-10 rounded-full border border-white/20 bg-white/10 px-5 text-xs font-semibold uppercase tracking-[0.24em] text-white/70 hover:bg-white/15"
+        >
+          {copyMode ? t("actions.copyClose") : t("actions.copy")}
+        </Button>
         <Button
           type="submit"
-          className="h-10 rounded-full bg-white px-6 text-xs font-semibold uppercase tracking-[0.3em] text-black hover:bg-white/90"
           disabled={isPending}
+          className="h-10 rounded-full bg-white px-6 text-xs font-semibold uppercase tracking-[0.3em] text-black hover:bg-white/90 disabled:opacity-60"
         >
-          {isPending ? strings.savingLabel : strings.submitLabel}
+          {isPending ? t("actions.saving") : t("actions.submit")}
         </Button>
-      </DialogFooter>
+      </div>
     </form>
   );
 }

--- a/apps/www/app/[locale]/(site)/dashboard/hours-saved-actions.ts
+++ b/apps/www/app/[locale]/(site)/dashboard/hours-saved-actions.ts
@@ -9,6 +9,7 @@ import {
   HOURS_SAVED_WINDOW_HOURS,
   addHours,
   nextHour,
+  randomizeWithinHour,
 } from "@/lib/hours-saved/constants";
 
 const scheduleItemSchema = z.object({
@@ -48,10 +49,15 @@ export async function updateHoursSavedScheduleAction(locale: string, payload: un
     }))
     .sort((a, b) => a.scheduledFor.getTime() - b.scheduledFor.getTime());
 
-  const normalizedSchedule = sortedEntries.map((entry, index) => ({
-    scheduledFor: addHours(windowStart, index),
-    amount: entry.amount,
-  }));
+  const usedTimestamps = new Set<number>();
+  const normalizedSchedule = sortedEntries.map((entry, index) => {
+    const hourStart = addHours(windowStart, index);
+    const scheduledFor = randomizeWithinHour(hourStart, usedTimestamps);
+    return {
+      scheduledFor,
+      amount: entry.amount,
+    };
+  });
 
   try {
     await updateHoursSavedSettings({
@@ -66,6 +72,7 @@ export async function updateHoursSavedScheduleAction(locale: string, payload: un
 
   await revalidatePath(`/${locale}`);
   await revalidatePath(`/${locale}/dashboard`);
+  await revalidatePath(`/${locale}/dashboard/hours-saved`);
 
   return { success: true as const };
 }

--- a/apps/www/app/[locale]/(site)/dashboard/hours-saved-actions.ts
+++ b/apps/www/app/[locale]/(site)/dashboard/hours-saved-actions.ts
@@ -1,0 +1,71 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { getAuthSession } from "@/lib/auth";
+import { updateHoursSavedSettings } from "@/lib/hours-saved";
+import {
+  HOURS_SAVED_WINDOW_HOURS,
+  addHours,
+  nextHour,
+} from "@/lib/hours-saved/constants";
+
+const scheduleItemSchema = z.object({
+  scheduledFor: z.string().datetime(),
+  amount: z.number().int().min(0).max(1_000_000),
+});
+
+const payloadSchema = z.object({
+  baseAmount: z.number().int().min(0).max(1_000_000_000),
+  schedule: z.array(scheduleItemSchema).length(HOURS_SAVED_WINDOW_HOURS),
+});
+
+export async function updateHoursSavedScheduleAction(locale: string, payload: unknown) {
+  const session = await getAuthSession();
+
+  if (session?.user?.role !== "staff") {
+    return { success: false as const, error: "unauthorized" as const };
+  }
+
+  const parsed = payloadSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return {
+      success: false as const,
+      error: "validation" as const,
+      issues: parsed.error.flatten().fieldErrors,
+    };
+  }
+
+  const reference = new Date();
+  const windowStart = nextHour(reference);
+
+  const sortedEntries = parsed.data.schedule
+    .map((entry) => ({
+      scheduledFor: new Date(entry.scheduledFor),
+      amount: entry.amount,
+    }))
+    .sort((a, b) => a.scheduledFor.getTime() - b.scheduledFor.getTime());
+
+  const normalizedSchedule = sortedEntries.map((entry, index) => ({
+    scheduledFor: addHours(windowStart, index),
+    amount: entry.amount,
+  }));
+
+  try {
+    await updateHoursSavedSettings({
+      baseAmount: parsed.data.baseAmount,
+      schedule: normalizedSchedule,
+      now: reference,
+    });
+  } catch (error) {
+    console.error("Failed to update hours saved schedule", error);
+    return { success: false as const, error: "unknown" as const };
+  }
+
+  await revalidatePath(`/${locale}`);
+  await revalidatePath(`/${locale}/dashboard`);
+
+  return { success: true as const };
+}

--- a/apps/www/app/[locale]/(site)/dashboard/hours-saved/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/hours-saved/page.tsx
@@ -1,0 +1,94 @@
+import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
+
+import { HoursSavedManager } from "../components/hours-saved-manager";
+import { getAuthSession } from "@/lib/auth";
+import { formatDateWithZone } from "@/lib/date";
+import { getHoursSavedOverview } from "@/lib/hours-saved";
+import { HOURS_SAVED_TIME_ZONE } from "@/lib/hours-saved/constants";
+
+interface PageProps {
+  params: {
+    locale: string;
+  };
+}
+
+export default async function HoursSavedDashboardPage({ params }: PageProps) {
+  const { locale } = params;
+  const session = await getAuthSession();
+
+  if (session?.user?.role !== "staff") {
+    redirect(`/${locale}/newsupdates`);
+  }
+
+  const t = await getTranslations({ locale, namespace: "Dashboard" });
+  const hoursSavedOverview = await getHoursSavedOverview();
+
+  const hoursSavedSchedule = hoursSavedOverview.schedule.map((entry) => ({
+    scheduledFor: entry.scheduledFor.toISOString(),
+    amount: entry.amount,
+  }));
+
+  const nextUpdateLabel = hoursSavedOverview.nextUpdateAt
+    ? formatDateWithZone(
+        hoursSavedOverview.nextUpdateAt,
+        {
+          weekday: "short",
+          day: "numeric",
+          month: "short",
+          hour: "2-digit",
+          minute: "2-digit",
+        },
+        locale,
+        HOURS_SAVED_TIME_ZONE,
+      )
+    : null;
+
+  const currentAmountLabel = t("summary.currentValue", {
+    amount: hoursSavedOverview.currentAmount.toLocaleString(locale),
+  });
+
+  const nextUpdateValue = nextUpdateLabel
+    ? t("summary.nextValue", { time: nextUpdateLabel })
+    : t("summary.noUpcoming");
+
+  return (
+    <div className="bg-black py-12 sm:py-16">
+      <div className="container max-w-4xl space-y-6">
+        <header className="space-y-3">
+          <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+            {t("title")}
+          </h1>
+          <p className="text-sm text-white/60 sm:text-base">{t("subtitle")}</p>
+          <p className="text-xs font-medium uppercase tracking-[0.3em] text-white/50">
+            {t("currentUser", { email: session.user.email ?? "" })}
+          </p>
+        </header>
+
+        <section className="space-y-6 rounded-2xl border border-white/10 bg-white/[0.04] p-6 shadow-lg backdrop-blur">
+          <div className="grid gap-4 text-sm text-white/70 sm:grid-cols-2">
+            <div className="rounded-xl border border-white/10 bg-black/40 p-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-white/50">
+                {t("summary.currentLabel")}
+              </p>
+              <p className="mt-2 text-xl font-semibold text-white">{currentAmountLabel}</p>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-black/40 p-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-white/50">
+                {t("summary.nextLabel")}
+              </p>
+              <p className="mt-2 text-base font-medium text-white">{nextUpdateValue}</p>
+            </div>
+          </div>
+
+          <HoursSavedManager
+            locale={locale}
+            timeZone={HOURS_SAVED_TIME_ZONE}
+            baseAmount={hoursSavedOverview.baseAmount}
+            schedule={hoursSavedSchedule}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/www/app/[locale]/(site)/dashboard/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/page.tsx
@@ -1,3 +1,7 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Dialog,
@@ -7,14 +11,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { getAuthSession } from "@/lib/auth";
 import { db } from "@/lib/db/client";
 import { users } from "@/lib/db/schema";
@@ -22,13 +19,9 @@ import { formatDateWithZone } from "@/lib/date";
 import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
 import { getUpcomingMeetings } from "@/lib/meetings/queries";
 import { getVisitorOverview, type VisitorOverview } from "@/lib/visitors";
-import { getHoursSavedOverview, type HoursSavedScheduleEntry } from "@/lib/hours-saved";
-import { HOURS_SAVED_TIME_ZONE } from "@/lib/hours-saved/constants";
+import { getHoursSavedOverview } from "@/lib/hours-saved";
 import { VisitorsChartSection, type VisitorsChartBucket } from "./components/visitors-chart";
-import { HoursSavedManager } from "./components/hours-saved-manager";
 import { desc, eq, sql } from "drizzle-orm";
-import { getTranslations } from "next-intl/server";
-import { redirect } from "next/navigation";
 
 interface PageProps {
   params: {
@@ -37,14 +30,14 @@ interface PageProps {
 }
 
 export default async function DashboardPage({ params }: PageProps) {
+  const { locale } = params;
   const session = await getAuthSession();
-  const locale = params.locale;
 
   if (session?.user?.role !== "staff") {
     redirect(`/${locale}/newsupdates`);
   }
 
-  const t = await getTranslations({ locale, namespace: "Dashboard" });
+  const t = await getTranslations({ locale, namespace: "DashboardOverview" });
 
   const [
     roleCounts,
@@ -53,46 +46,87 @@ export default async function DashboardPage({ params }: PageProps) {
     staffAccounts,
     visitorOverview,
     hoursSavedOverview,
-  ] =
-    await Promise.all([
-      db
-        .select({
-          role: users.role,
-          total: sql<number>`count(*)`,
-        })
-        .from(users)
-        .groupBy(users.role),
-      getUpcomingMeetings(8),
-      db
-        .select({
-          id: users.id,
-          name: users.name,
-          email: users.email,
-          createdAt: users.createdAt,
-        })
-        .from(users)
-        .where(eq(users.role, "client"))
-        .orderBy(desc(users.createdAt)),
-      db
-        .select({
-          id: users.id,
-          name: users.name,
-          email: users.email,
-          createdAt: users.createdAt,
-        })
-        .from(users)
-        .where(eq(users.role, "staff"))
-        .orderBy(desc(users.createdAt)),
-      getVisitorOverview(),
-      getHoursSavedOverview(),
-    ]);
-
-  type UpcomingMeeting = (typeof upcomingMeetings)[number];
+  ] = await Promise.all([
+    db
+      .select({
+        role: users.role,
+        total: sql<number>`count(*)`,
+      })
+      .from(users)
+      .groupBy(users.role),
+    getUpcomingMeetings(8),
+    db
+      .select({
+        id: users.id,
+        name: users.name,
+        email: users.email,
+        createdAt: users.createdAt,
+      })
+      .from(users)
+      .where(eq(users.role, "client"))
+      .orderBy(desc(users.createdAt)),
+    db
+      .select({
+        id: users.id,
+        name: users.name,
+        email: users.email,
+        createdAt: users.createdAt,
+      })
+      .from(users)
+      .where(eq(users.role, "staff"))
+      .orderBy(desc(users.createdAt)),
+    getVisitorOverview(),
+    getHoursSavedOverview(),
+  ]);
 
   const totals: Record<string, number> = { client: 0, staff: 0 };
   for (const row of roleCounts) {
     totals[row.role] = Number(row.total);
   }
+
+  const links = [
+    {
+      key: "hoursSaved" as const,
+      href: `/${locale}/dashboard/hours-saved`,
+      eyebrow: t("sections.hoursSaved.eyebrow"),
+      title: t("sections.hoursSaved.title"),
+      description: t("sections.hoursSaved.description"),
+    },
+    {
+      key: "planning" as const,
+      href: `/${locale}/dashboard/planning`,
+      eyebrow: t("sections.planning.eyebrow"),
+      title: t("sections.planning.title"),
+      description: t("sections.planning.description"),
+    },
+  ];
+
+  const highlightMetrics = [
+    {
+      key: "clients" as const,
+      label: t("metrics.clients.title"),
+      value: totals.client.toLocaleString(locale),
+      caption: t("metrics.clients.caption", { count: totals.client }),
+    },
+    {
+      key: "staff" as const,
+      label: t("metrics.staff.title"),
+      value: totals.staff.toLocaleString(locale),
+      caption: t("metrics.staff.caption", { count: totals.staff }),
+    },
+    {
+      key: "visitors" as const,
+      label: t("metrics.visitors.title"),
+      value: visitorOverview.total.toLocaleString(locale),
+      caption: t("metrics.visitors.caption", { count: visitorOverview.total }),
+    },
+    {
+      key: "hoursSaved" as const,
+      label: t("metrics.hoursSaved.title"),
+      value: hoursSavedOverview.currentAmount.toLocaleString(locale),
+      caption: t("metrics.hoursSaved.caption", { count: hoursSavedOverview.currentAmount }),
+    },
+  ];
 
   const visitorTabs = {
     hourly: t("visitors.tabs.hourly"),
@@ -148,56 +182,80 @@ export default async function DashboardPage({ params }: PageProps) {
     createdAt: t("accounts.columns.createdAt"),
   } as const;
 
-  const hoursSavedSchedule = hoursSavedOverview.schedule.map((entry: HoursSavedScheduleEntry) => ({
-    scheduledFor: entry.scheduledFor.toISOString(),
-    amount: entry.amount,
-  }));
-
-  const hoursSavedDialogStrings = {
-    baseLabel: t("hoursSaved.dialog.baseLabel"),
-    baseHelper: t("hoursSaved.dialog.baseHelper"),
-    scheduleHeading: t("hoursSaved.dialog.scheduleHeading"),
-    scheduleDescription: t("hoursSaved.dialog.scheduleDescription", { timeZone: HOURS_SAVED_TIME_ZONE }),
-    timeColumnLabel: t("hoursSaved.dialog.timeColumnLabel"),
-    resetLabel: t("hoursSaved.dialog.reset"),
-    submitLabel: t("hoursSaved.dialog.submit"),
-    savingLabel: t("hoursSaved.dialog.saving"),
-    cancelLabel: t("hoursSaved.dialog.cancel"),
-    successMessage: t("hoursSaved.dialog.success"),
-    errorMessage: t("hoursSaved.dialog.error"),
-    validationError: t("hoursSaved.dialog.validation"),
-    amountSuffix: t("hoursSaved.dialog.amountSuffix"),
-  } as const;
-
   const ratioValue =
     totals.staff === 0 ? "–" : `${(totals.client / Math.max(totals.staff, 1)).toFixed(1)} : 1`;
 
+  type UpcomingMeeting = (typeof upcomingMeetings)[number];
+
   return (
-    <div className="relative isolate min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top,_rgba(37,99,235,0.22),_transparent_55%)] py-28">
+    <div className="relative isolate overflow-hidden bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.18),_transparent_55%)] py-24">
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-x-0 top-[-280px] h-[560px] bg-gradient-to-b from-blue-500/20 via-transparent to-transparent blur-3xl"
+        className="pointer-events-none absolute inset-x-0 top-[-300px] h-[580px] bg-gradient-to-b from-sky-400/25 via-transparent to-transparent blur-3xl"
       />
-      <div className="container relative z-10 max-w-6xl">
-        <div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-white/60">{t("eyebrow")}</p>
-            <h1 className="mt-3 text-4xl font-semibold tracking-tight text-white sm:text-5xl">{t("title")}</h1>
-            <p className="mt-4 text-base text-white/60 sm:text-lg">{t("subtitle")}</p>
-          </div>
-          <div className="rounded-xl border border-white/10 bg-white/10 px-5 py-3 text-xs text-white/70">
+      <div className="container relative z-10 max-w-6xl space-y-14">
+        <header className="max-w-3xl space-y-4">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.08] px-5 py-2 text-xs font-semibold uppercase tracking-[0.32em] text-white/60">
+            {t("eyebrow")}
+          </span>
+          <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+            {t("title")}
+          </h1>
+          <p className="text-base text-white/70 sm:text-lg">{t("subtitle")}</p>
+          <p className="text-xs font-medium uppercase tracking-[0.3em] text-white/50">
             {t("currentUser", { email: session.user.email ?? "" })}
-          </div>
-        </div>
+          </p>
+        </header>
 
-        <div className="mt-16 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {highlightMetrics.map((metric) => (
+            <div
+              key={metric.key}
+              className="rounded-2xl border border-white/10 bg-white/[0.06] px-5 py-4 text-white shadow-lg backdrop-blur-xl"
+            >
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+                {metric.label}
+              </p>
+              <p className="mt-3 text-3xl font-semibold tracking-tight text-white">{metric.value}</p>
+              <p className="mt-2 text-xs text-white/60">{metric.caption}</p>
+            </div>
+          ))}
+        </section>
+
+        <section className="grid gap-6 sm:grid-cols-2">
+          {links.map((item) => (
+            <Link
+              key={item.key}
+              href={item.href}
+              className="group relative flex h-full flex-col justify-between overflow-hidden rounded-3xl border border-white/10 bg-white/[0.04] p-6 text-white shadow-lg transition hover:border-white/40 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+            >
+              <div className="space-y-3">
+                <span className="inline-flex items-center rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.28em] text-white/60">
+                  {item.eyebrow}
+                </span>
+                <h2 className="text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+                  {item.title}
+                </h2>
+                <p className="text-sm text-white/60 sm:text-base">{item.description}</p>
+              </div>
+              <div className="mt-6 inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.3em] text-white/70 group-hover:text-white">
+                {t("cta")}
+                <span aria-hidden className="translate-x-0 transition group-hover:translate-x-1">
+                  →
+                </span>
+              </div>
+            </Link>
+          ))}
+        </section>
+
+        <section className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
           <Dialog>
             <DialogTrigger asChild>
               <button
                 type="button"
                 className="text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
-                <Card className="relative overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition hover:border-white/20">
+                <Card className="relative h-full overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition hover:border-white/20">
                   <CardHeader className="pb-4">
                     <CardTitle className="text-lg font-semibold text-white/70">
                       {t("metrics.clients.title")}
@@ -230,7 +288,7 @@ export default async function DashboardPage({ params }: PageProps) {
                 type="button"
                 className="text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
-                <Card className="relative overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition hover:border-white/20">
+                <Card className="relative h-full overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition hover:border-white/20">
                   <CardHeader className="pb-4">
                     <CardTitle className="text-lg font-semibold text-white/70">
                       {t("metrics.staff.title")}
@@ -263,7 +321,7 @@ export default async function DashboardPage({ params }: PageProps) {
                 type="button"
                 className="text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
-                <Card className="relative overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition hover:border-white/20">
+                <Card className="relative h-full overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition hover:border-white/20">
                   <CardHeader className="pb-4">
                     <CardTitle className="text-lg font-semibold text-white/70">
                       {t("metrics.visitors.title")}
@@ -282,9 +340,7 @@ export default async function DashboardPage({ params }: PageProps) {
             </DialogTrigger>
             <DialogContent className="max-w-3xl bg-neutral-950 text-white">
               <DialogHeader>
-                <DialogTitle className="text-white">
-                  {t("visitors.title")}
-                </DialogTitle>
+                <DialogTitle className="text-white">{t("visitors.title")}</DialogTitle>
                 <DialogDescription className="text-white/60">
                   {t("visitors.description")}
                 </DialogDescription>
@@ -300,49 +356,31 @@ export default async function DashboardPage({ params }: PageProps) {
             </DialogContent>
           </Dialog>
 
-          <Dialog>
-            <DialogTrigger asChild>
-              <button
-                type="button"
-                className="text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
-              >
-                <Card className="relative overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition hover:border-white/20">
-                  <CardHeader className="pb-4">
-                    <CardTitle className="text-lg font-semibold text-white/70">
-                      {t("metrics.hoursSaved.title")}
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="pb-6">
-                    <p className="text-4xl font-semibold tracking-tight text-white">
-                      {hoursSavedOverview.currentAmount.toLocaleString(locale)}
-                    </p>
-                    <p className="mt-2 text-sm text-white/60">
-                      {t("metrics.hoursSaved.caption", { count: hoursSavedOverview.currentAmount })}
-                    </p>
-                  </CardContent>
-                </Card>
-              </button>
-            </DialogTrigger>
-            <DialogContent className="max-w-3xl bg-neutral-950 text-white">
-              <DialogHeader>
-                <DialogTitle className="text-white">{t("hoursSaved.dialog.title")}</DialogTitle>
-                <DialogDescription className="text-white/60">
-                  {t("hoursSaved.dialog.description", { timeZone: HOURS_SAVED_TIME_ZONE })}
-                </DialogDescription>
-              </DialogHeader>
-              <div className="mt-6">
-                <HoursSavedManager
-                  locale={locale}
-                  timeZone={HOURS_SAVED_TIME_ZONE}
-                  baseAmount={hoursSavedOverview.baseAmount}
-                  schedule={hoursSavedSchedule}
-                  strings={hoursSavedDialogStrings}
-                />
-              </div>
-            </DialogContent>
-          </Dialog>
+          <Link
+            href={`/${locale}/dashboard/hours-saved`}
+            className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+          >
+            <Card className="relative h-full overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition hover:border-white/20">
+              <CardHeader className="pb-4">
+                <CardTitle className="text-lg font-semibold text-white/70">
+                  {t("metrics.hoursSaved.title")}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="pb-6">
+                <p className="text-4xl font-semibold tracking-tight text-white">
+                  {hoursSavedOverview.currentAmount.toLocaleString(locale)}
+                </p>
+                <p className="mt-2 text-sm text-white/60">
+                  {t("metrics.hoursSaved.caption", { count: hoursSavedOverview.currentAmount })}
+                </p>
+                <p className="mt-4 text-xs font-semibold uppercase tracking-[0.28em] text-white/60">
+                  {t("metrics.hoursSaved.manage")}
+                </p>
+              </CardContent>
+            </Card>
+          </Link>
 
-          <Card className="relative overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl">
+          <Card className="relative h-full overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl md:col-span-2 xl:col-span-1">
             <CardHeader className="pb-4">
               <CardTitle className="text-lg font-semibold text-white/70">
                 {t("metrics.ratio.title")}
@@ -353,13 +391,11 @@ export default async function DashboardPage({ params }: PageProps) {
               <p className="mt-2 text-sm text-white/60">{t("metrics.ratio.caption")}</p>
             </CardContent>
           </Card>
-        </div>
+        </section>
 
-        <div className="mt-16 space-y-6">
+        <section className="space-y-6">
           <div>
-            <h2 className="text-xl font-semibold text-white">
-              {t("meetings.title")}
-            </h2>
+            <h2 className="text-xl font-semibold text-white">{t("meetings.title")}</h2>
             {upcomingMeetings.length === 0 ? (
               <p className="mt-4 rounded-2xl border border-white/10 bg-white/[0.05] p-4 text-sm text-white/70">
                 {t("meetings.empty")}
@@ -385,11 +421,7 @@ export default async function DashboardPage({ params }: PageProps) {
                     locale,
                     MEETING_TIME_ZONE,
                   );
-                  const contactLines = [
-                    meeting.personName,
-                    meeting.company,
-                    meeting.email,
-                  ].filter(Boolean);
+                  const contactLines = [meeting.personName, meeting.company, meeting.email].filter(Boolean);
 
                   return (
                     <div
@@ -419,9 +451,7 @@ export default async function DashboardPage({ params }: PageProps) {
                           <p className="font-semibold uppercase tracking-[0.3em] text-white/50">
                             {t("meetings.fields.notes")}
                           </p>
-                          <p className="mt-1 leading-relaxed text-white/70">
-                            {meeting.publicDescription}
-                          </p>
+                          <p className="mt-1 leading-relaxed text-white/70">{meeting.publicDescription}</p>
                         </div>
                       ) : null}
                     </div>
@@ -430,16 +460,16 @@ export default async function DashboardPage({ params }: PageProps) {
               </div>
             )}
           </div>
-        </div>
+        </section>
 
-        <div className="rounded-2xl border border-white/10 bg-black/40 p-8 text-sm leading-relaxed text-white/70">
+        <section className="rounded-2xl border border-white/10 bg-black/40 p-8 text-sm leading-relaxed text-white/70">
           <h2 className="text-xl font-semibold text-white">{t("nextSteps.title")}</h2>
           <ul className="mt-4 space-y-3 text-sm text-white/70">
             <li>{t("nextSteps.items.audit")}</li>
             <li>{t("nextSteps.items.outreach")}</li>
             <li>{t("nextSteps.items.briefings")}</li>
           </ul>
-        </div>
+        </section>
       </div>
     </div>
   );
@@ -537,9 +567,7 @@ function AccountListDialog({
 function DashboardMeetingField({ label, value }: DashboardMeetingFieldProps) {
   return (
     <div className="space-y-2">
-      <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
-        {label}
-      </p>
+      <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">{label}</p>
       <p className="text-sm text-white/80">{value}</p>
     </div>
   );

--- a/apps/www/app/[locale]/(site)/dashboard/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/page.tsx
@@ -22,7 +22,10 @@ import { formatDateWithZone } from "@/lib/date";
 import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
 import { getUpcomingMeetings } from "@/lib/meetings/queries";
 import { getVisitorOverview, type VisitorOverview } from "@/lib/visitors";
+import { getHoursSavedOverview, type HoursSavedScheduleEntry } from "@/lib/hours-saved";
+import { HOURS_SAVED_TIME_ZONE } from "@/lib/hours-saved/constants";
 import { VisitorsChartSection, type VisitorsChartBucket } from "./components/visitors-chart";
+import { HoursSavedManager } from "./components/hours-saved-manager";
 import { desc, eq, sql } from "drizzle-orm";
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
@@ -43,7 +46,14 @@ export default async function DashboardPage({ params }: PageProps) {
 
   const t = await getTranslations({ locale, namespace: "Dashboard" });
 
-  const [roleCounts, upcomingMeetings, clientAccounts, staffAccounts, visitorOverview] =
+  const [
+    roleCounts,
+    upcomingMeetings,
+    clientAccounts,
+    staffAccounts,
+    visitorOverview,
+    hoursSavedOverview,
+  ] =
     await Promise.all([
       db
         .select({
@@ -74,6 +84,7 @@ export default async function DashboardPage({ params }: PageProps) {
         .where(eq(users.role, "staff"))
         .orderBy(desc(users.createdAt)),
       getVisitorOverview(),
+      getHoursSavedOverview(),
     ]);
 
   type UpcomingMeeting = (typeof upcomingMeetings)[number];
@@ -135,6 +146,27 @@ export default async function DashboardPage({ params }: PageProps) {
     name: t("accounts.columns.name"),
     email: t("accounts.columns.email"),
     createdAt: t("accounts.columns.createdAt"),
+  } as const;
+
+  const hoursSavedSchedule = hoursSavedOverview.schedule.map((entry: HoursSavedScheduleEntry) => ({
+    scheduledFor: entry.scheduledFor.toISOString(),
+    amount: entry.amount,
+  }));
+
+  const hoursSavedDialogStrings = {
+    baseLabel: t("hoursSaved.dialog.baseLabel"),
+    baseHelper: t("hoursSaved.dialog.baseHelper"),
+    scheduleHeading: t("hoursSaved.dialog.scheduleHeading"),
+    scheduleDescription: t("hoursSaved.dialog.scheduleDescription", { timeZone: HOURS_SAVED_TIME_ZONE }),
+    timeColumnLabel: t("hoursSaved.dialog.timeColumnLabel"),
+    resetLabel: t("hoursSaved.dialog.reset"),
+    submitLabel: t("hoursSaved.dialog.submit"),
+    savingLabel: t("hoursSaved.dialog.saving"),
+    cancelLabel: t("hoursSaved.dialog.cancel"),
+    successMessage: t("hoursSaved.dialog.success"),
+    errorMessage: t("hoursSaved.dialog.error"),
+    validationError: t("hoursSaved.dialog.validation"),
+    amountSuffix: t("hoursSaved.dialog.amountSuffix"),
   } as const;
 
   const ratioValue =
@@ -263,6 +295,48 @@ export default async function DashboardPage({ params }: PageProps) {
                   daily={dailyChartData}
                   tabLabels={visitorTabs}
                   emptyMessages={visitorEmptyMessages}
+                />
+              </div>
+            </DialogContent>
+          </Dialog>
+
+          <Dialog>
+            <DialogTrigger asChild>
+              <button
+                type="button"
+                className="text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              >
+                <Card className="relative overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition hover:border-white/20">
+                  <CardHeader className="pb-4">
+                    <CardTitle className="text-lg font-semibold text-white/70">
+                      {t("metrics.hoursSaved.title")}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="pb-6">
+                    <p className="text-4xl font-semibold tracking-tight text-white">
+                      {hoursSavedOverview.currentAmount.toLocaleString(locale)}
+                    </p>
+                    <p className="mt-2 text-sm text-white/60">
+                      {t("metrics.hoursSaved.caption", { count: hoursSavedOverview.currentAmount })}
+                    </p>
+                  </CardContent>
+                </Card>
+              </button>
+            </DialogTrigger>
+            <DialogContent className="max-w-3xl bg-neutral-950 text-white">
+              <DialogHeader>
+                <DialogTitle className="text-white">{t("hoursSaved.dialog.title")}</DialogTitle>
+                <DialogDescription className="text-white/60">
+                  {t("hoursSaved.dialog.description", { timeZone: HOURS_SAVED_TIME_ZONE })}
+                </DialogDescription>
+              </DialogHeader>
+              <div className="mt-6">
+                <HoursSavedManager
+                  locale={locale}
+                  timeZone={HOURS_SAVED_TIME_ZONE}
+                  baseAmount={hoursSavedOverview.baseAmount}
+                  schedule={hoursSavedSchedule}
+                  strings={hoursSavedDialogStrings}
                 />
               </div>
             </DialogContent>

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -16,6 +16,7 @@ import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/hero
 import { OssLight } from "@/components/svg/oss-light";
 import { UsageBento } from "@/components/usage-bento";
 import { isLocale } from "@/i18n/routing";
+import { getHoursSavedOverview } from "@/lib/hours-saved";
 import {
   BarChart3,
   ChevronRight,
@@ -106,6 +107,8 @@ export default async function Landing({
     getTranslations({ locale, namespace: "FeatureSection" }),
   ]);
 
+  const hoursSavedOverview = await getHoursSavedOverview();
+
   const featureBoxes = [
     { key: "futureProofWorkforce", icon: GraduationCap },
     { key: "revenueStreamAnalysis", icon: BarChart3 },
@@ -139,7 +142,14 @@ export default async function Landing({
         </div>
         <div className="container relative flex flex-col mx-auto space-y-16 md:space-y-32">
           <Section>
-            <Hero />
+            <Hero
+              initialHoursSavedAmount={hoursSavedOverview.currentAmount}
+              initialHoursSavedNextUpdateAt={
+                hoursSavedOverview.nextUpdateAt
+                  ? hoursSavedOverview.nextUpdateAt.toISOString()
+                  : null
+              }
+            />
           </Section>
           <Section className="mt-16 md:mt-32">
             <DesktopLogoCloud />

--- a/apps/www/app/api/hours-saved/route.ts
+++ b/apps/www/app/api/hours-saved/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+import { getHoursSavedOverview } from "@/lib/hours-saved";
+
+export async function GET() {
+  try {
+    const overview = await getHoursSavedOverview();
+
+    return NextResponse.json(
+      {
+        baseAmount: overview.baseAmount,
+        baseSetAt: overview.baseSetAt.toISOString(),
+        currentAmount: overview.currentAmount,
+        nextUpdateAt: overview.nextUpdateAt ? overview.nextUpdateAt.toISOString() : null,
+        schedule: overview.schedule.map((entry) => ({
+          scheduledFor: entry.scheduledFor.toISOString(),
+          amount: entry.amount,
+        })),
+      },
+      {
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  } catch (error) {
+    console.error("Failed to load hours saved overview", error);
+    return NextResponse.json(
+      { error: "internal_error" },
+      {
+        status: 500,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+}

--- a/apps/www/components/hero/hero-main-section.tsx
+++ b/apps/www/components/hero/hero-main-section.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { PrimaryButton, SecondaryButton } from "@/components/button";
 import { BookOpen, ChevronRight, LogIn } from "lucide-react";
 
+import { HoursSavedTicker } from "./hours-saved-ticker";
+
 type HeroMainSectionProps = {
   title: string;
   body: string;
@@ -10,7 +12,9 @@ type HeroMainSectionProps = {
   primaryCtaHref: string;
   secondaryCtaLabel: string;
   hoursSavedLabel: string;
-  hoursSavedAmount: string;
+  hoursSavedInitialAmount: number;
+  hoursSavedNextUpdateAt: string | null;
+  locale: string;
 };
 
 export function HeroMainSection({
@@ -20,7 +24,9 @@ export function HeroMainSection({
   primaryCtaHref,
   secondaryCtaLabel,
   hoursSavedLabel,
-  hoursSavedAmount,
+  hoursSavedInitialAmount,
+  hoursSavedNextUpdateAt,
+  locale,
 }: HeroMainSectionProps) {
   return (
     <div className="relative flex flex-col items-center text-center">
@@ -44,7 +50,12 @@ export function HeroMainSection({
         <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-6 py-2 font-semibold uppercase text-white/70 backdrop-blur-sm sm:gap-3 sm:px-8 sm:py-2.5 whitespace-nowrap">
           <span className="text-[0.75rem] tracking-[0.35em] text-white/60 sm:text-xs">{hoursSavedLabel}</span>
           <span className="text-white/40">:</span>
-          <span className="text-sm tracking-[0.2em] text-white sm:text-base">{hoursSavedAmount}</span>
+          <HoursSavedTicker
+            initialAmount={hoursSavedInitialAmount}
+            initialNextUpdateAt={hoursSavedNextUpdateAt}
+            locale={locale}
+            className="text-sm tracking-[0.2em] text-white sm:text-base"
+          />
         </div>
         <Link href="/docs" className="hidden w-full sm:inline-flex sm:w-auto sm:flex-shrink-0">
           <SecondaryButton

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -6,7 +6,15 @@ import { HeroMainSection } from "./hero-main-section";
 
 import mainboard from "@/images/mainboard.svg";
 import { SubHeroMainboard } from "./hero-sub-mainboard";
-export const Hero: React.FC = () => {
+type HeroProps = {
+  initialHoursSavedAmount: number;
+  initialHoursSavedNextUpdateAt: string | null;
+};
+
+export const Hero: React.FC<HeroProps> = ({
+  initialHoursSavedAmount,
+  initialHoursSavedNextUpdateAt,
+}) => {
   const hero = useTranslations("Hero");
   const cta = useTranslations("CTA");
   const locale = useLocale();
@@ -45,7 +53,9 @@ export const Hero: React.FC = () => {
           primaryCtaHref={meetingHref}
           secondaryCtaLabel={cta("exploreProjects")}
           hoursSavedLabel={cta("hoursSavedLabel")}
-          hoursSavedAmount={cta("hoursSavedAmount")}
+          hoursSavedInitialAmount={initialHoursSavedAmount}
+          hoursSavedNextUpdateAt={initialHoursSavedNextUpdateAt}
+          locale={locale}
         />
       </motion.div>
 

--- a/apps/www/components/hero/hours-saved-ticker.tsx
+++ b/apps/www/components/hero/hours-saved-ticker.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { animate, useAnimate, useMotionValue, useReducedMotion } from "framer-motion";
+
+import { cn } from "@/lib/utils";
+
+type HoursSavedTickerProps = {
+  initialAmount: number;
+  initialNextUpdateAt: string | null;
+  locale: string;
+  className?: string;
+};
+
+type HoursSavedState = {
+  amount: number;
+  nextUpdateAt: string | null;
+};
+
+const FALLBACK_REFRESH_INTERVAL_MS = 60_000;
+
+export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, className }: HoursSavedTickerProps) {
+  const [state, setState] = useState<HoursSavedState>({
+    amount: initialAmount,
+    nextUpdateAt: initialNextUpdateAt,
+  });
+  const motionValue = useMotionValue(initialAmount);
+  const [displayValue, setDisplayValue] = useState(initialAmount);
+  const reducedMotion = useReducedMotion();
+  const [scope, animateScope] = useAnimate<HTMLSpanElement>();
+
+  useEffect(() => {
+    setState({ amount: initialAmount, nextUpdateAt: initialNextUpdateAt });
+    setDisplayValue(initialAmount);
+    motionValue.set(initialAmount);
+  }, [initialAmount, initialNextUpdateAt, motionValue]);
+
+  useEffect(() => {
+    const unsubscribe = motionValue.on("change", (latest) => {
+      setDisplayValue(Math.round(latest));
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [motionValue]);
+
+  useEffect(() => {
+    if (reducedMotion) {
+      motionValue.set(state.amount);
+      setDisplayValue(state.amount);
+      return;
+    }
+
+    const controls = animate(motionValue, state.amount, {
+      duration: 0.8,
+      ease: "easeOut",
+    });
+
+    if (scope.current) {
+      void animateScope(scope.current, { scale: [1, 1.05, 1] }, { duration: 0.6, ease: "easeOut" });
+    }
+
+    return () => {
+      controls.stop();
+    };
+  }, [state.amount, animateScope, motionValue, reducedMotion, scope]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    const fetchLatest = async () => {
+      try {
+        const response = await fetch("/api/hours-saved", { cache: "no-store" });
+        if (!response.ok) {
+          return;
+        }
+
+        const data = (await response.json()) as {
+          currentAmount: number;
+          nextUpdateAt: string | null;
+        };
+
+        if (!cancelled) {
+          setState({ amount: data.currentAmount, nextUpdateAt: data.nextUpdateAt });
+        }
+      } catch (error) {
+        console.error("Failed to refresh hours saved ticker", error);
+      }
+    };
+
+    const scheduleNextFetch = () => {
+      if (!state.nextUpdateAt) {
+        return;
+      }
+
+      const targetTime = new Date(state.nextUpdateAt).getTime() - Date.now();
+      const delay = Math.max(targetTime, 0) + 1200;
+      timeoutId = setTimeout(fetchLatest, delay);
+    };
+
+    scheduleNextFetch();
+    intervalId = setInterval(fetchLatest, FALLBACK_REFRESH_INTERVAL_MS);
+
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        void fetchLatest();
+      }
+    };
+
+    const handleFocus = () => {
+      void fetchLatest();
+    };
+
+    window.addEventListener("focus", handleFocus);
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      cancelled = true;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+      window.removeEventListener("focus", handleFocus);
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [state.nextUpdateAt]);
+
+  const formatter = useMemo(() => new Intl.NumberFormat(locale), [locale]);
+  const formatted = formatter.format(displayValue);
+
+  return (
+    <span ref={scope} className={cn("inline-flex items-center font-medium text-white", className)} aria-live="polite">
+      {formatted}
+    </span>
+  );
+}

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -82,8 +82,9 @@ export function Navigation() {
     normalizedPathname === "/newsupdates" || normalizedPathname.startsWith("/newsupdates/");
   const isStaffOverviewView = normalizedPathname === "/dashboard";
   const isStaffPlanningView = normalizedPathname.startsWith("/dashboard/planning");
+  const isStaffHoursSavedView = normalizedPathname.startsWith("/dashboard/hours-saved");
   const isStaffView =
-    isStaffOverviewView || isStaffPlanningView || normalizedPathname.startsWith("/dashboard/");
+    isStaffOverviewView || isStaffPlanningView || isStaffHoursSavedView || normalizedPathname.startsWith("/dashboard/");
   const isLoggedInView = isClientView || isStaffView;
   const settledLogoScale = 0.68;
   const initialLogoScale = isHome ? 1 : 0.74;
@@ -106,6 +107,12 @@ export function Navigation() {
             href: "/dashboard",
             label: t("loggedIn.overview"),
             current: isStaffOverviewView,
+          },
+          {
+            key: "hoursSaved",
+            href: "/dashboard/hours-saved",
+            label: t("loggedIn.hoursSaved"),
+            current: isStaffHoursSavedView,
           },
           {
             key: "planning",

--- a/apps/www/lib/db/schema.ts
+++ b/apps/www/lib/db/schema.ts
@@ -159,6 +159,49 @@ export const visitorSessions = pgTable(
   }),
 );
 
+export const hoursSavedStates = pgTable("hours_saved_states", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  baseAmount: integer("base_amount").notNull().default(0),
+  baseSetAt: timestamp("base_set_at", { mode: "date", withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export const hoursSavedIncrements = pgTable(
+  "hours_saved_increments",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    stateId: text("state_id")
+      .notNull()
+      .references(() => hoursSavedStates.id, { onDelete: "cascade" }),
+    scheduledFor: timestamp("scheduled_for", { mode: "date", withTimezone: true }).notNull(),
+    amount: integer("amount").notNull(),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => ({
+    scheduleTimeIdx: uniqueIndex("hours_saved_increments_state_time_idx").on(
+      table.stateId,
+      table.scheduledFor,
+    ),
+    scheduledForIdx: index("hours_saved_increments_scheduled_for_idx").on(table.scheduledFor),
+  }),
+);
+
 export const usersRelations = relations(users, ({ many }) => ({
   accounts: many(accounts),
   sessions: many(sessions),
@@ -195,6 +238,17 @@ export const meetingBookingsRelations = relations(meetingBookings, ({ one }) => 
   slot: one(meetingSlots, {
     fields: [meetingBookings.slotId],
     references: [meetingSlots.id],
+  }),
+}));
+
+export const hoursSavedStatesRelations = relations(hoursSavedStates, ({ many }) => ({
+  increments: many(hoursSavedIncrements),
+}));
+
+export const hoursSavedIncrementsRelations = relations(hoursSavedIncrements, ({ one }) => ({
+  state: one(hoursSavedStates, {
+    fields: [hoursSavedIncrements.stateId],
+    references: [hoursSavedStates.id],
   }),
 }));
 

--- a/apps/www/lib/hours-saved/constants.ts
+++ b/apps/www/lib/hours-saved/constants.ts
@@ -1,6 +1,6 @@
 import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
 
-export const HOURS_SAVED_WINDOW_HOURS = 24;
+export const HOURS_SAVED_WINDOW_HOURS = 24 * 7;
 export const HOURS_SAVED_DEFAULT_DAY_INCREMENT = 104;
 export const HOURS_SAVED_DEFAULT_NIGHT_INCREMENT = 65;
 export const HOURS_SAVED_DAY_START_HOUR = 8;
@@ -27,6 +27,26 @@ export function addHours(date: Date, hours: number): Date {
 
 export function nextHour(date: Date): Date {
   return addHours(startOfHour(date), 1);
+}
+
+export function randomizeWithinHour(base: Date, used: Set<number>): Date {
+  const hourStart = startOfHour(base);
+
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    const candidate = new Date(hourStart);
+    candidate.setMinutes(Math.floor(Math.random() * 60));
+    candidate.setSeconds(Math.floor(Math.random() * 60), 0);
+    const time = candidate.getTime();
+    if (!used.has(time)) {
+      used.add(time);
+      return candidate;
+    }
+  }
+
+  const fallback = new Date(hourStart);
+  fallback.setSeconds(0, 0);
+  used.add(fallback.getTime());
+  return fallback;
 }
 
 export function getZoneHour(date: Date): number {

--- a/apps/www/lib/hours-saved/constants.ts
+++ b/apps/www/lib/hours-saved/constants.ts
@@ -1,0 +1,45 @@
+import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
+
+export const HOURS_SAVED_WINDOW_HOURS = 24;
+export const HOURS_SAVED_DEFAULT_DAY_INCREMENT = 104;
+export const HOURS_SAVED_DEFAULT_NIGHT_INCREMENT = 65;
+export const HOURS_SAVED_DAY_START_HOUR = 8;
+export const HOURS_SAVED_DAY_END_HOUR = 20;
+export const HOURS_SAVED_TIME_ZONE = MEETING_TIME_ZONE;
+
+const hourFormatter = new Intl.DateTimeFormat("en-US", {
+  hour: "numeric",
+  hour12: false,
+  timeZone: HOURS_SAVED_TIME_ZONE,
+});
+
+export function startOfHour(date: Date): Date {
+  const copy = new Date(date);
+  copy.setMinutes(0, 0, 0);
+  return copy;
+}
+
+export function addHours(date: Date, hours: number): Date {
+  const copy = new Date(date);
+  copy.setHours(copy.getHours() + hours);
+  return copy;
+}
+
+export function nextHour(date: Date): Date {
+  return addHours(startOfHour(date), 1);
+}
+
+export function getZoneHour(date: Date): number {
+  const parts = hourFormatter.formatToParts(date);
+  const hourPart = parts.find((part) => part.type === "hour");
+  return hourPart ? Number.parseInt(hourPart.value, 10) : Number.parseInt(hourFormatter.format(date), 10);
+}
+
+export function isDaytimeInZone(date: Date): boolean {
+  const hour = getZoneHour(date);
+  return hour >= HOURS_SAVED_DAY_START_HOUR && hour < HOURS_SAVED_DAY_END_HOUR;
+}
+
+export function getDefaultIncrementFor(date: Date): number {
+  return isDaytimeInZone(date) ? HOURS_SAVED_DEFAULT_DAY_INCREMENT : HOURS_SAVED_DEFAULT_NIGHT_INCREMENT;
+}

--- a/apps/www/lib/hours-saved/index.ts
+++ b/apps/www/lib/hours-saved/index.ts
@@ -1,0 +1,209 @@
+import { and, asc, eq, gte, lt, lte } from "drizzle-orm";
+
+import { db, type DrizzleDB } from "@/lib/db/client";
+import { hoursSavedIncrements, hoursSavedStates } from "@/lib/db/schema";
+
+import {
+  HOURS_SAVED_WINDOW_HOURS,
+  addHours,
+  getDefaultIncrementFor,
+  nextHour,
+} from "./constants";
+
+export type HoursSavedScheduleEntry = {
+  scheduledFor: Date;
+  amount: number;
+};
+
+export type HoursSavedOverview = {
+  baseAmount: number;
+  baseSetAt: Date;
+  currentAmount: number;
+  nextUpdateAt: Date | null;
+  schedule: HoursSavedScheduleEntry[];
+};
+
+type DbExecutor = DrizzleDB;
+
+async function ensureState(executor: DbExecutor = db) {
+  const existing = await executor.query.hoursSavedStates.findFirst();
+
+  if (existing) {
+    return existing;
+  }
+
+  const [created] = await executor
+    .insert(hoursSavedStates)
+    .values({
+      baseAmount: 0,
+      baseSetAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .returning();
+
+  if (!created) {
+    throw new Error("Failed to initialize hours saved state");
+  }
+
+  return created;
+}
+
+async function ensureUpcomingSchedule(
+  executor: DbExecutor,
+  stateId: string,
+  now: Date,
+) {
+  const windowStart = nextHour(now);
+  const windowEnd = addHours(windowStart, HOURS_SAVED_WINDOW_HOURS);
+
+  const existing = await executor
+    .select({ scheduledFor: hoursSavedIncrements.scheduledFor })
+    .from(hoursSavedIncrements)
+    .where(
+      and(
+        eq(hoursSavedIncrements.stateId, stateId),
+        gte(hoursSavedIncrements.scheduledFor, windowStart),
+        lt(hoursSavedIncrements.scheduledFor, windowEnd),
+      ),
+    );
+
+  const existingSet = new Set(existing.map((entry) => entry.scheduledFor.toISOString()));
+  const inserts: { stateId: string; scheduledFor: Date; amount: number }[] = [];
+
+  for (let offset = 0; offset < HOURS_SAVED_WINDOW_HOURS; offset += 1) {
+    const scheduledFor = addHours(windowStart, offset);
+
+    if (existingSet.has(scheduledFor.toISOString())) {
+      continue;
+    }
+
+    inserts.push({
+      stateId,
+      scheduledFor,
+      amount: getDefaultIncrementFor(scheduledFor),
+    });
+  }
+
+  if (inserts.length > 0) {
+    await executor.insert(hoursSavedIncrements).values(inserts);
+  }
+}
+
+async function sumAppliedIncrements(
+  executor: DbExecutor,
+  stateId: string,
+  baseSetAt: Date,
+  now: Date,
+) {
+  const rows = await executor
+    .select({ amount: hoursSavedIncrements.amount })
+    .from(hoursSavedIncrements)
+    .where(
+      and(
+        eq(hoursSavedIncrements.stateId, stateId),
+        gte(hoursSavedIncrements.scheduledFor, baseSetAt),
+        lte(hoursSavedIncrements.scheduledFor, now),
+      ),
+    );
+
+  return rows.reduce((total, row) => total + row.amount, 0);
+}
+
+export async function getHoursSavedOverview(now: Date = new Date()): Promise<HoursSavedOverview> {
+  const state = await ensureState();
+
+  await ensureUpcomingSchedule(db, state.id, now);
+
+  const applied = await sumAppliedIncrements(db, state.id, state.baseSetAt, now);
+
+  const windowStart = nextHour(now);
+  const windowEnd = addHours(windowStart, HOURS_SAVED_WINDOW_HOURS);
+
+  const scheduleRows = await db
+    .select({
+      scheduledFor: hoursSavedIncrements.scheduledFor,
+      amount: hoursSavedIncrements.amount,
+    })
+    .from(hoursSavedIncrements)
+    .where(
+      and(
+        eq(hoursSavedIncrements.stateId, state.id),
+        gte(hoursSavedIncrements.scheduledFor, windowStart),
+        lt(hoursSavedIncrements.scheduledFor, windowEnd),
+      ),
+    )
+    .orderBy(asc(hoursSavedIncrements.scheduledFor));
+
+  return {
+    baseAmount: state.baseAmount,
+    baseSetAt: state.baseSetAt,
+    currentAmount: state.baseAmount + applied,
+    nextUpdateAt: scheduleRows[0]?.scheduledFor ?? null,
+    schedule: scheduleRows.map((row) => ({
+      scheduledFor: row.scheduledFor,
+      amount: row.amount,
+    })),
+  };
+}
+
+export async function updateHoursSavedSettings(input: {
+  baseAmount: number;
+  schedule: HoursSavedScheduleEntry[];
+  now?: Date;
+}): Promise<HoursSavedOverview> {
+  const reference = input.now ?? new Date();
+
+  await db.transaction(async (tx) => {
+    const executor = tx as unknown as DbExecutor;
+    const state = await ensureState(executor);
+
+    const baseSetAt = reference;
+
+    await executor
+      .update(hoursSavedStates)
+      .set({
+        baseAmount: input.baseAmount,
+        baseSetAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(hoursSavedStates.id, state.id));
+
+    await executor
+      .delete(hoursSavedIncrements)
+      .where(
+        and(
+          eq(hoursSavedIncrements.stateId, state.id),
+          lt(hoursSavedIncrements.scheduledFor, baseSetAt),
+        ),
+      );
+
+    const windowStart = nextHour(reference);
+    const windowEnd = addHours(windowStart, HOURS_SAVED_WINDOW_HOURS);
+
+    await executor
+      .delete(hoursSavedIncrements)
+      .where(
+        and(
+          eq(hoursSavedIncrements.stateId, state.id),
+          gte(hoursSavedIncrements.scheduledFor, windowStart),
+          lt(hoursSavedIncrements.scheduledFor, windowEnd),
+        ),
+      );
+
+    if (input.schedule.length > 0) {
+      const values = input.schedule.map((entry) => ({
+        stateId: state.id,
+        scheduledFor: entry.scheduledFor,
+        amount: entry.amount,
+        updatedAt: new Date(),
+      }));
+
+      await executor.insert(hoursSavedIncrements).values(values);
+    }
+
+    await ensureUpcomingSchedule(executor, state.id, reference);
+  });
+
+  return getHoursSavedOverview(reference);
+}

--- a/apps/www/lib/hours-saved/index.ts
+++ b/apps/www/lib/hours-saved/index.ts
@@ -8,6 +8,8 @@ import {
   addHours,
   getDefaultIncrementFor,
   nextHour,
+  randomizeWithinHour,
+  startOfHour,
 } from "./constants";
 
 export type HoursSavedScheduleEntry = {
@@ -68,15 +70,20 @@ async function ensureUpcomingSchedule(
       ),
     );
 
-  const existingSet = new Set(existing.map((entry) => entry.scheduledFor.toISOString()));
+  const existingHourKeys = new Set(
+    existing.map((entry) => startOfHour(entry.scheduledFor).toISOString()),
+  );
+  const usedTimestamps = new Set(existing.map((entry) => entry.scheduledFor.getTime()));
   const inserts: { stateId: string; scheduledFor: Date; amount: number }[] = [];
 
   for (let offset = 0; offset < HOURS_SAVED_WINDOW_HOURS; offset += 1) {
-    const scheduledFor = addHours(windowStart, offset);
-
-    if (existingSet.has(scheduledFor.toISOString())) {
+    const hourStart = addHours(windowStart, offset);
+    if (existingHourKeys.has(hourStart.toISOString())) {
       continue;
     }
+
+    const scheduledFor = randomizeWithinHour(hourStart, usedTimestamps);
+    existingHourKeys.add(hourStart.toISOString());
 
     inserts.push({
       stateId,
@@ -135,15 +142,33 @@ export async function getHoursSavedOverview(now: Date = new Date()): Promise<Hou
     )
     .orderBy(asc(hoursSavedIncrements.scheduledFor));
 
+  const seenHours = new Set<string>();
+  const scheduleEntries: HoursSavedScheduleEntry[] = [];
+
+  for (const row of scheduleRows) {
+    const hourKey = startOfHour(row.scheduledFor).toISOString();
+
+    if (seenHours.has(hourKey)) {
+      continue;
+    }
+
+    seenHours.add(hourKey);
+    scheduleEntries.push({
+      scheduledFor: row.scheduledFor,
+      amount: row.amount,
+    });
+
+    if (scheduleEntries.length === HOURS_SAVED_WINDOW_HOURS) {
+      break;
+    }
+  }
+
   return {
     baseAmount: state.baseAmount,
     baseSetAt: state.baseSetAt,
     currentAmount: state.baseAmount + applied,
-    nextUpdateAt: scheduleRows[0]?.scheduledFor ?? null,
-    schedule: scheduleRows.map((row) => ({
-      scheduledFor: row.scheduledFor,
-      amount: row.amount,
-    })),
+    nextUpdateAt: scheduleEntries[0]?.scheduledFor ?? null,
+    schedule: scheduleEntries,
   };
 }
 

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -28,6 +28,7 @@
       "messages": "Messages",
       "overview": "Overview",
       "planning": "Planning",
+      "hoursSaved": "Hours saved",
       "resources": "Resources"
     },
     "membersMenu": {
@@ -1214,32 +1215,100 @@
     "ctaNote": "Share confidential updates responsibly. Forward this space to leadership teams that need visibility."
   },
   "Dashboard": {
-    "eyebrow": "Staff dashboard",
-    "title": "TransformAI account health",
-    "subtitle": "Monitor how many client and staff seats are active across the platform.",
+    "title": "Hours saved planner",
+    "subtitle": "Set the starting total and adjust hourly increments for the next seven days.",
     "currentUser": "Signed in as {email}",
-  "metrics": {
-    "clients": {
-      "title": "Client accounts",
-      "caption": "{count, plural, one {# client live} other {# clients live}}"
+    "summary": {
+      "currentLabel": "Current ticker",
+      "currentValue": "{amount} hrs total",
+      "nextLabel": "Next update",
+      "nextValue": "{time}",
+      "noUpcoming": "No scheduled updates in the next 7 days."
     },
-    "staff": {
-      "title": "Staff accounts",
-      "caption": "{count, plural, one {# internal teammate online} other {# internal teammates online}}"
-    },
-    "visitors": {
-      "title": "Unique visitors",
-      "caption": "{count, plural, one {# visitor session recorded} other {# visitor sessions recorded}}"
-  },
-  "hoursSaved": {
-      "title": "Hours saved with AI",
-      "caption": "{count, plural, one {# hour automated} other {# hours automated}}"
-    },
-    "ratio": {
-      "title": "Client-to-staff ratio",
-      "caption": "Healthy coverage is between 4:1 and 8:1 so every project has a partner lead."
+    "hoursSaved": {
+      "base": {
+        "label": "Starting amount",
+        "helper": "Resets the ticker to this total immediately."
+      },
+      "days": {
+        "heading": "Plan the next 7 days",
+        "helper": "Select a day to edit the hourly increments.",
+        "todayBadge": "Today",
+        "todaySummary": "Current window {window}. {remaining, plural, one {# hour left today.} other {# hours left today.}}",
+        "daySummary": "{count, plural, one {# hour scheduled.} other {# hours scheduled.}}",
+        "hourButtonAria": "Edit {time}. Currently {amount} hours."
+      },
+      "editor": {
+        "title": "Update {time}",
+        "helper": "Set how many hours will be added automatically at this time.",
+        "amountLabel": "Hours",
+        "amountSuffix": "hrs"
+      },
+      "actions": {
+        "submit": "Push changes",
+        "saving": "Saving…",
+        "copy": "Copy day",
+        "copyClose": "Close copy"
+      },
+      "copy": {
+        "title": "Copy schedule to other days",
+        "description": "Reuse the hourly plan from one day and apply it elsewhere.",
+        "sourceLabel": "Copy from",
+        "targetLabel": "Apply to",
+        "helper": "Selecting a day overwrites its hourly values.",
+        "apply": "Apply copy",
+        "cancel": "Cancel"
+      },
+      "status": {
+        "success": "Hours saved schedule updated.",
+        "error": "We couldn't update the schedule. Try again.",
+        "validation": "Enter a non-negative value for the starting amount and each hour.",
+        "copyValidation": "Select a source day and at least one day to copy to.",
+        "copySuccess": "Day copied successfully."
+      }
     }
   },
+  "DashboardOverview": {
+    "eyebrow": "Staff workspace",
+    "title": "Choose the area you want to manage",
+    "subtitle": "Jump straight into the tools you need today. Each module keeps its data within the TransformAI staff workspace.",
+    "currentUser": "Signed in as {email}",
+    "cta": "Open",
+    "sections": {
+      "hoursSaved": {
+        "eyebrow": "Hours saved",
+        "title": "Tune the AI hours ticker",
+        "description": "Reset the starting total and plan the automatic increments for the next seven days."
+      },
+      "planning": {
+        "eyebrow": "Planning",
+        "title": "Coordinate the meeting agenda",
+        "description": "Review availability, assign colleagues, and publish upcoming TransformAI strategy sessions."
+      }
+    },
+    "metrics": {
+      "clients": {
+        "title": "Client accounts",
+        "caption": "{count, plural, one {# client live} other {# clients live}}"
+      },
+      "staff": {
+        "title": "Staff accounts",
+        "caption": "{count, plural, one {# internal teammate online} other {# internal teammates online}}"
+      },
+      "visitors": {
+        "title": "Unique visitors",
+        "caption": "{count, plural, one {# visitor session recorded} other {# visitor sessions recorded}}"
+      },
+      "hoursSaved": {
+        "title": "Hours saved with AI",
+        "caption": "{count, plural, one {# hour automated} other {# hours automated}}",
+        "manage": "Open planner"
+      },
+      "ratio": {
+        "title": "Client-to-staff ratio",
+        "caption": "Healthy coverage is between 4:1 and 8:1 so every project has a partner lead."
+      }
+    },
     "accounts": {
       "clients": {
         "title": "Client account roster",

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -1218,24 +1218,28 @@
     "title": "TransformAI account health",
     "subtitle": "Monitor how many client and staff seats are active across the platform.",
     "currentUser": "Signed in as {email}",
-    "metrics": {
-      "clients": {
-        "title": "Client accounts",
-        "caption": "{count, plural, one {# client live} other {# clients live}}"
-      },
-      "staff": {
-        "title": "Staff accounts",
-        "caption": "{count, plural, one {# internal teammate online} other {# internal teammates online}}"
-      },
-      "visitors": {
-        "title": "Unique visitors",
-        "caption": "{count, plural, one {# visitor session recorded} other {# visitor sessions recorded}}"
-      },
-      "ratio": {
-        "title": "Client-to-staff ratio",
-        "caption": "Healthy coverage is between 4:1 and 8:1 so every project has a partner lead."
-      }
+  "metrics": {
+    "clients": {
+      "title": "Client accounts",
+      "caption": "{count, plural, one {# client live} other {# clients live}}"
     },
+    "staff": {
+      "title": "Staff accounts",
+      "caption": "{count, plural, one {# internal teammate online} other {# internal teammates online}}"
+    },
+    "visitors": {
+      "title": "Unique visitors",
+      "caption": "{count, plural, one {# visitor session recorded} other {# visitor sessions recorded}}"
+  },
+  "hoursSaved": {
+      "title": "Hours saved with AI",
+      "caption": "{count, plural, one {# hour automated} other {# hours automated}}"
+    },
+    "ratio": {
+      "title": "Client-to-staff ratio",
+      "caption": "Healthy coverage is between 4:1 and 8:1 so every project has a partner lead."
+    }
+  },
     "accounts": {
       "clients": {
         "title": "Client account roster",
@@ -1287,6 +1291,25 @@
         "outreach": "Coordinate with delivery leads to share the new AI maturity playbook with their accounts.",
         "briefings": "Prepare January leadership briefings showcasing ROI metrics from automation pilots."
       }
+    }
+  },
+  "hoursSaved": {
+    "dialog": {
+      "title": "Automate the hours saved ticker",
+      "description": "Plan the next 24 hours of automatic additions. Times use {timeZone}.",
+      "baseLabel": "Starting amount",
+      "baseHelper": "Resets the ticker to this total immediately.",
+      "scheduleHeading": "Next 24 hours",
+      "scheduleDescription": "Each entry is added at the top of the hour ({timeZone}).",
+      "timeColumnLabel": "Hour",
+      "reset": "Reset defaults",
+      "submit": "Save schedule",
+      "saving": "Saving…",
+      "cancel": "Cancel",
+      "success": "Hours saved schedule updated.",
+      "error": "We couldn’t update the schedule. Try again.",
+      "validation": "Enter a non-negative value for each field.",
+      "amountSuffix": "hrs"
     }
   }
 }

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -1175,24 +1175,28 @@
     "title": "Gezondheid van TransformAI-accounts",
     "subtitle": "Volg hoeveel klant- en staff-accounts actief zijn op het platform.",
     "currentUser": "Ingelogd als {email}",
-    "metrics": {
-      "clients": {
-        "title": "Klantaccounts",
-        "caption": "{count, plural, one {# klant actief} other {# klanten actief}}"
-      },
-      "staff": {
-        "title": "Staff-accounts",
-        "caption": "{count, plural, one {# collega online} other {# collega's online}}"
-      },
-      "visitors": {
-        "title": "Unieke bezoekers",
-        "caption": "{count, plural, one {# bezoekersessie geregistreerd} other {# bezoekersessies geregistreerd}}"
-      },
-      "ratio": {
-        "title": "Verhouding klant/staff",
-        "caption": "Een gezonde dekking ligt tussen 4:1 en 8:1 zodat elk project een partnerlead heeft."
-      }
+  "metrics": {
+    "clients": {
+      "title": "Klantaccounts",
+      "caption": "{count, plural, one {# klant actief} other {# klanten actief}}"
     },
+    "staff": {
+      "title": "Staff-accounts",
+      "caption": "{count, plural, one {# collega online} other {# collega's online}}"
+    },
+    "visitors": {
+      "title": "Unieke bezoekers",
+      "caption": "{count, plural, one {# bezoekersessie geregistreerd} other {# bezoekersessies geregistreerd}}"
+    },
+    "hoursSaved": {
+      "title": "Bespaarde uren met AI",
+      "caption": "{count, plural, one {# uur geautomatiseerd} other {# uren geautomatiseerd}}"
+    },
+    "ratio": {
+      "title": "Verhouding klant/staff",
+      "caption": "Een gezonde dekking ligt tussen 4:1 en 8:1 zodat elk project een partnerlead heeft."
+    }
+  },
     "accounts": {
       "clients": {
         "title": "Overzicht klantaccounts",
@@ -1244,6 +1248,25 @@
         "outreach": "Stem met delivery leads af om het nieuwe AI-maturiteitsplaybook bij hun accounts te delen.",
         "briefings": "Bereid leiderschapsbriefings voor januari voor met ROI-cijfers uit de automatiseringspilots."
       }
+    }
+  },
+  "hoursSaved": {
+    "dialog": {
+      "title": "Automatiseer de teller voor bespaarde uren",
+      "description": "Plan de automatische toevoegingen voor de komende 24 uur. Tijden gebruiken {timeZone}.",
+      "baseLabel": "Startwaarde",
+      "baseHelper": "Zet de teller direct op dit totaal.",
+      "scheduleHeading": "Komende 24 uur",
+      "scheduleDescription": "Elke waarde wordt op het hele uur toegevoegd ({timeZone}).",
+      "timeColumnLabel": "Uur",
+      "reset": "Herstel standaard",
+      "submit": "Schema opslaan",
+      "saving": "Bezig…",
+      "cancel": "Annuleren",
+      "success": "Schema voor bespaarde uren bijgewerkt.",
+      "error": "Bijwerken is mislukt. Probeer het opnieuw.",
+      "validation": "Voer voor elk veld een niet-negatieve waarde in.",
+      "amountSuffix": "uur"
     }
   }
 }

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -28,6 +28,7 @@
       "messages": "Berichten",
       "overview": "Overzicht",
       "planning": "Planning",
+      "hoursSaved": "Uren bespaard",
       "resources": "Bronnen"
     },
     "membersMenu": {
@@ -1171,32 +1172,100 @@
     "ctaNote": "Deel vertrouwelijke updates zorgvuldig. Stuur dit door naar bestuurders die inzicht nodig hebben."
   },
   "Dashboard": {
-    "eyebrow": "Staff-dashboard",
-    "title": "Gezondheid van TransformAI-accounts",
-    "subtitle": "Volg hoeveel klant- en staff-accounts actief zijn op het platform.",
+    "title": "Planner voor bespaarde uren",
+    "subtitle": "Stel de startwaarde in en beheer de uurlijkse toevoegingen voor de komende zeven dagen.",
     "currentUser": "Ingelogd als {email}",
-  "metrics": {
-    "clients": {
-      "title": "Klantaccounts",
-      "caption": "{count, plural, one {# klant actief} other {# klanten actief}}"
-    },
-    "staff": {
-      "title": "Staff-accounts",
-      "caption": "{count, plural, one {# collega online} other {# collega's online}}"
-    },
-    "visitors": {
-      "title": "Unieke bezoekers",
-      "caption": "{count, plural, one {# bezoekersessie geregistreerd} other {# bezoekersessies geregistreerd}}"
+    "summary": {
+      "currentLabel": "Huidige teller",
+      "currentValue": "{amount} uur totaal",
+      "nextLabel": "Volgende update",
+      "nextValue": "{time}",
+      "noUpcoming": "Geen ingeplande updates in de komende 7 dagen."
     },
     "hoursSaved": {
-      "title": "Bespaarde uren met AI",
-      "caption": "{count, plural, one {# uur geautomatiseerd} other {# uren geautomatiseerd}}"
-    },
-    "ratio": {
-      "title": "Verhouding klant/staff",
-      "caption": "Een gezonde dekking ligt tussen 4:1 en 8:1 zodat elk project een partnerlead heeft."
+      "base": {
+        "label": "Startwaarde",
+        "helper": "Zet de teller direct op dit totaal."
+      },
+      "days": {
+        "heading": "Plan de komende 7 dagen",
+        "helper": "Kies een dag om de uurlijkse toevoegingen aan te passen.",
+        "todayBadge": "Vandaag",
+        "todaySummary": "Huidig venster {window}. {remaining, plural, one {# uur resterend vandaag.} other {# uren resterend vandaag.}}",
+        "daySummary": "{count, plural, one {# uur gepland.} other {# uren gepland.}}",
+        "hourButtonAria": "Bewerk {time}. Momenteel {amount} uur."
+      },
+      "editor": {
+        "title": "Werk {time} bij",
+        "helper": "Bepaal hoeveel uur er op dit tijdstip automatisch wordt toegevoegd.",
+        "amountLabel": "Uren",
+        "amountSuffix": "uur"
+      },
+      "actions": {
+        "submit": "Wijzigingen doorvoeren",
+        "saving": "Bezig…",
+        "copy": "Dag kopiëren",
+        "copyClose": "Kopiëren sluiten"
+      },
+      "copy": {
+        "title": "Kopieer schema naar andere dagen",
+        "description": "Herbruik het uurschema van één dag en pas het elders toe.",
+        "sourceLabel": "Kopieer van",
+        "targetLabel": "Toepassen op",
+        "helper": "Geselecteerde dagen worden overschreven met deze waarden.",
+        "apply": "Kopie toepassen",
+        "cancel": "Annuleren"
+      },
+      "status": {
+        "success": "Schema voor bespaarde uren bijgewerkt.",
+        "error": "Bijwerken is mislukt. Probeer het opnieuw.",
+        "validation": "Voer voor de startwaarde en elk uur een niet-negatieve waarde in.",
+        "copyValidation": "Selecteer een bron-dag en minstens één dag om naar te kopiëren.",
+        "copySuccess": "Dag succesvol gekopieerd."
+      }
     }
   },
+  "DashboardOverview": {
+    "eyebrow": "Teamomgeving",
+    "title": "Kies welke module je wilt openen",
+    "subtitle": "Start direct in de tools die je vandaag nodig hebt. Elke module blijft binnen de beveiligde TransformAI-teamomgeving.",
+    "currentUser": "Ingelogd als {email}",
+    "cta": "Openen",
+    "sections": {
+      "hoursSaved": {
+        "eyebrow": "Uren bespaard",
+        "title": "Stel de AI-urenteller af",
+        "description": "Reset de startwaarde en plan de automatische toevoegingen voor de komende zeven dagen."
+      },
+      "planning": {
+        "eyebrow": "Planning",
+        "title": "Stem de agenda af",
+        "description": "Bekijk de beschikbaarheid, wijs collega’s toe en publiceer aankomende TransformAI-strategiesessies."
+      }
+    },
+    "metrics": {
+      "clients": {
+        "title": "Klantaccounts",
+        "caption": "{count, plural, one {# klant actief} other {# klanten actief}}"
+      },
+      "staff": {
+        "title": "Staff-accounts",
+        "caption": "{count, plural, one {# collega online} other {# collega's online}}"
+      },
+      "visitors": {
+        "title": "Unieke bezoekers",
+        "caption": "{count, plural, one {# bezoekersessie geregistreerd} other {# bezoekersessies geregistreerd}}"
+      },
+      "hoursSaved": {
+        "title": "Bespaarde uren met AI",
+        "caption": "{count, plural, one {# uur geautomatiseerd} other {# uren geautomatiseerd}}",
+        "manage": "Planner openen"
+      },
+      "ratio": {
+        "title": "Verhouding klant/staff",
+        "caption": "Een gezonde dekking ligt tussen 4:1 en 8:1 zodat elk project een partnerlead heeft."
+      }
+    },
     "accounts": {
       "clients": {
         "title": "Overzicht klantaccounts",


### PR DESCRIPTION
## Plan
- Introduce a stats highlight row on the staff dashboard hero using existing metrics data.
- Ensure the existing metric cards and dialogs continue to work without regressions.
- Record the change for the team in the FIXES log.

## Summary
- Added a four-card highlight grid to the staff dashboard hero so client, staff, visitor, and hours-saved totals are visible immediately while keeping the detailed cards below.
- Logged the visibility update in WRITE_HERE/FIXES for team awareness.

## Testing
- `pnpm --filter www run lint` *(fails: Next.js config requires the unavailable `next-intl` package in this environment).* 
- `pnpm --filter www exec tsc -p tsconfig.json --noEmit` *(fails: repository lacks `next-intl`, `drizzle-orm`, and related type declarations in this environment).*

------
https://chatgpt.com/codex/tasks/task_e_68df719350a4832a9ba9b749a4df9e93