### PR TITLE
Keep disabled footer link color consistent

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-30T1000--footer-navigation-refresh.md
+++ b/WRITE_HERE/UPDATES/2025-11-30T1000--footer-navigation-refresh.md
@@ -1,0 +1,6 @@
+# Footer navigation refresh
+
+- **What:** Disabled placeholder resource and legal links in the footer, removed unused source/status items, added Facebook and LinkedIn under Connect, updated the book-a-call target, and refreshed the footer tagline and copyright copy.
+- **Why:** Align the underheader/footer navigation with the latest content requirements and company messaging.
+- **Files:** `apps/www/components/footer/footer.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Provide localized Facebook/LinkedIn destinations once final social URLs are confirmed.

--- a/WRITE_HERE/UPDATES/2025-11-30T1030--footer-disabled-links-visual-tweak.md
+++ b/WRITE_HERE/UPDATES/2025-11-30T1030--footer-disabled-links-visual-tweak.md
@@ -1,0 +1,6 @@
+# Match disabled footer links to active color
+
+- **What**: Updated the footer column component so disabled navigation items render with the standard link color instead of the muted gray.
+- **Why**: Stakeholder asked that deactivated links remain visually indistinguishable to avoid drawing attention to unavailable destinations.
+- **Files**: `apps/www/components/footer/footer.tsx`
+- **Follow-ups**: None.

--- a/apps/www/components/footer/footer.tsx
+++ b/apps/www/components/footer/footer.tsx
@@ -9,41 +9,34 @@ type NavLink = {
   titleKey: string;
   href: string;
   external?: boolean;
+  disabled?: boolean;
 };
 const navigation = [
   {
     titleKey: "sections.company",
     links: [
       { titleKey: "links.about", href: "/about" },
-      { titleKey: "links.roadmap", href: "/roadmap" },
+      { titleKey: "links.roadmap", href: "/roadmap", disabled: true },
       { titleKey: "links.careers", href: "/careers" },
       { titleKey: "links.contact", href: "/contact" },
-      {
-        titleKey: "links.sourceCode",
-        href: "https://go.unkey.com/github",
-        external: true,
-      },
-      {
-        titleKey: "links.status",
-        href: "https://status.unkey.com",
-        external: true,
-      },
     ],
   },
   {
     titleKey: "sections.resources",
     links: [
       { titleKey: "links.blog", href: "/blog" },
-      { titleKey: "links.changelog", href: "/changelog" },
-      { titleKey: "links.templates", href: "/templates" },
+      { titleKey: "links.changelog", href: "/changelog", disabled: true },
+      { titleKey: "links.templates", href: "/templates", disabled: true },
       {
         titleKey: "links.docs",
         href: "/docs",
         external: true,
+        disabled: true,
       },
       {
         titleKey: "links.glossary",
         href: "/glossary",
+        disabled: true,
       },
     ],
   },
@@ -54,16 +47,27 @@ const navigation = [
         titleKey: "links.twitter",
         href: "https://go.unkey.com/twitter",
         external: true,
+        disabled: true,
       },
       {
         titleKey: "links.discord",
         href: "https://go.unkey.com/discord",
         external: true,
+        disabled: true,
       },
-      { titleKey: "links.ossFriends", href: "/oss-friends" },
       {
         titleKey: "links.bookCall",
-        href: "https://cal.com/team/unkey/user-interview?utm_source=banner&utm_campaign=oss",
+        href: "http://localhost:3002/en/meeting",
+        external: true,
+      },
+      {
+        titleKey: "links.facebook",
+        href: "https://www.facebook.com/TransformAI",
+        external: true,
+      },
+      {
+        titleKey: "links.linkedin",
+        href: "https://www.linkedin.com/company/transformai",
         external: true,
       },
     ],
@@ -71,8 +75,8 @@ const navigation = [
   {
     titleKey: "sections.legal",
     links: [
-      { titleKey: "links.terms", href: "/policies/terms" },
-      { titleKey: "links.privacy", href: "/policies/privacy" },
+      { titleKey: "links.terms", href: "/policies/terms", disabled: true },
+      { titleKey: "links.privacy", href: "/policies/privacy", disabled: true },
     ],
   },
 ] satisfies Array<{ titleKey: string; links: Array<NavLink> }>;
@@ -90,15 +94,24 @@ const Column: React.FC<{
       </span>
       <ul className="flex flex-col gap-4 md:gap-6">
         {links.map((link) => (
-          <li key={link.href}>
-            <Link
-              href={link.href}
-              target={link.external ? "_blank" : undefined}
-              rel={link.external ? "noopener noreferrer" : undefined}
-              className="text-sm font-normal transition hover:text-white/40 text-white/70"
-            >
-              {t(link.titleKey)}
-            </Link>
+          <li key={link.titleKey}>
+            {link.disabled ? (
+              <span
+                className="text-sm font-normal text-white/70"
+                aria-disabled="true"
+              >
+                {t(link.titleKey)}
+              </span>
+            ) : (
+              <Link
+                href={link.href}
+                target={link.external ? "_blank" : undefined}
+                rel={link.external ? "noopener noreferrer" : undefined}
+                className="text-sm font-normal transition hover:text-white/40 text-white/70"
+              >
+                {t(link.titleKey)}
+              </Link>
+            )}
           </li>
         ))}
       </ul>

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -1052,8 +1052,8 @@
     }
   },
   "Footer": {
-    "tagline": "Build better APIs faster.",
-    "copyright": "Unkeyed, Inc. {year}",
+    "tagline": "We Build The Future",
+    "copyright": "TransformAI, inc. 2025",
     "sections": {
       "company": "Company",
       "resources": "Resources",
@@ -1065,8 +1065,6 @@
       "roadmap": "Roadmap",
       "careers": "Careers",
       "contact": "Contact",
-      "sourceCode": "Source Code",
-      "status": "Status Page",
       "blog": "Blog",
       "changelog": "Changelog",
       "templates": "Templates",
@@ -1074,8 +1072,9 @@
       "glossary": "Glossary",
       "twitter": "X (Twitter)",
       "discord": "Discord",
-      "ossFriends": "OSS Friends",
       "bookCall": "Book a Call",
+      "facebook": "Facebook",
+      "linkedin": "LinkedIn",
       "terms": "Terms of Service",
       "privacy": "Privacy Policy"
     }

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -1009,8 +1009,8 @@
     }
   },
   "Footer": {
-    "tagline": "Bouw betere API's sneller.",
-    "copyright": "Unkeyed, Inc. {year}",
+    "tagline": "Wij bouwen de toekomst.",
+    "copyright": "TransformAI, inc. 2025",
     "sections": {
       "company": "Bedrijf",
       "resources": "Resources",
@@ -1022,8 +1022,6 @@
       "roadmap": "Roadmap",
       "careers": "Carrières",
       "contact": "Contact",
-      "sourceCode": "Broncode",
-      "status": "Statuspagina",
       "blog": "Blog",
       "changelog": "Wijzigingen",
       "templates": "Templates",
@@ -1031,8 +1029,9 @@
       "glossary": "Woordenlijst",
       "twitter": "X (Twitter)",
       "discord": "Discord",
-      "ossFriends": "OSS-vrienden",
       "bookCall": "Plan een gesprek",
+      "facebook": "Facebook",
+      "linkedin": "LinkedIn",
       "terms": "Servicevoorwaarden",
       "privacy": "Privacybeleid"
     }


### PR DESCRIPTION
## Summary
- render disabled footer navigation items with the standard link color so they blend with active entries
- record the visual tweak in WRITE_HERE/UPDATES for project history

## Plan
- adjust the footer column component styling for disabled links
- document the change in a new update log entry

## Testing
- pnpm --filter www run lint *(fails: missing next-intl dependency in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68df86a3c404832aa353bcd5c524b50f