### PR TITLE
Revamp client dashboard with overview and premium teaser

### DIFF
--- a/WRITE_HERE/UPDATES/2025-10-03T0847--client-dashboard-refresh.md
+++ b/WRITE_HERE/UPDATES/2025-10-03T0847--client-dashboard-refresh.md
@@ -1,0 +1,6 @@
+# Client dashboard experience refreshed
+
+- **What:** Replaced the news updates feed with a dashboard overview, premium teaser, and CTA flow, refreshed styling to light blue, and added a Premium tab in the member navigation.
+- **Why:** Aligns the members area with the requested dashboard concept while preparing space for future premium resources.
+- **Files:** `apps/www/app/[locale]/(site)/newsupdates/page.tsx`, `apps/www/components/navbar/navigation.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Populate metrics dynamically and wire the premium section once resources are ready.

--- a/apps/www/app/[locale]/(site)/newsupdates/page.tsx
+++ b/apps/www/app/[locale]/(site)/newsupdates/page.tsx
@@ -1,6 +1,8 @@
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getAuthSession } from "@/lib/auth";
-import { cn } from "@/lib/utils";
+import { Link } from "@/i18n/navigation";
+import { Lock, MoveRight } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
 
@@ -19,21 +21,16 @@ export default async function NewsUpdatesPage({ params }: PageProps) {
   }
 
   const t = await getTranslations({ locale, namespace: "NewsUpdates" });
-
-  const updateKeys = ["aiMaturity", "events", "playbooks"] as const;
-  const updates = updateKeys.map((key) => ({
-    key,
-    title: t(`items.${key}.title`),
-    date: t(`items.${key}.date`),
-    summary: t(`items.${key}.summary`),
-    badge: t(`items.${key}.badge`),
-  }));
+  const meetingHref = `/${locale}/meeting` as const;
+  const premiumResourceItems = ["item1", "item2", "item3"].map((key) =>
+    t(`premium.resources.items.${key}`),
+  );
 
   return (
-    <div className="relative isolate min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top,_rgba(34,197,94,0.18),_transparent_55%)] py-28">
+    <div className="relative isolate min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.18),_transparent_55%)] py-28">
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-x-0 top-[-280px] h-[560px] bg-gradient-to-b from-emerald-400/20 via-transparent to-transparent blur-3xl"
+        className="pointer-events-none absolute inset-x-0 top-[-280px] h-[560px] bg-gradient-to-b from-sky-400/20 via-transparent to-transparent blur-3xl"
       />
       <div className="container relative z-10 max-w-5xl">
         <div className="mx-auto max-w-3xl text-center">
@@ -42,33 +39,160 @@ export default async function NewsUpdatesPage({ params }: PageProps) {
           <p className="mt-4 text-base text-white/60 sm:text-lg">{t("subtitle")}</p>
         </div>
 
-        <div className="mt-16 grid gap-6 md:grid-cols-2">
-          {updates.map((update, index) => (
-            <Card
-              key={update.key}
-              className={cn(
-                "group relative overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl transition",
-                index === 0 ? "md:col-span-2" : "",
-              )}
+        <nav className="mt-14 flex justify-center">
+          <div className="flex items-center gap-1 rounded-full border border-white/10 bg-white/5 p-1 text-sm text-white/60 backdrop-blur">
+            <Link
+              href="/newsupdates"
+              aria-current="page"
+              className="rounded-full bg-sky-500/20 px-5 py-2 font-medium tracking-wide text-white shadow-[0_0_20px_rgba(56,189,248,0.25)] transition"
             >
-              <CardHeader className="space-y-3 pb-4">
-                <div className="flex items-center justify-between text-xs uppercase tracking-[0.32em] text-emerald-300/60">
-                  <span>{update.badge}</span>
-                  <span className="text-white/40">{update.date}</span>
-                </div>
-                <CardTitle className="text-2xl font-semibold text-white sm:text-3xl">
-                  {update.title}
+              {t("tabs.dashboard")}
+            </Link>
+            <Link
+              href="/newsupdates#premium"
+              className="rounded-full px-5 py-2 font-medium tracking-wide text-white/60 transition hover:text-white"
+            >
+              {t("tabs.premium")}
+            </Link>
+          </div>
+        </nav>
+
+        <section aria-labelledby="dashboard-overview" className="mt-16 space-y-10">
+          <h2 id="dashboard-overview" className="sr-only">
+            {t("overview.heading")}
+          </h2>
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card className="border-white/10 bg-white/5 text-white backdrop-blur-xl">
+              <CardHeader className="space-y-2 pb-3">
+                <p className="text-xs uppercase tracking-[0.32em] text-sky-300/60">
+                  {t("overview.progress.eyebrow")}
+                </p>
+                <CardTitle className="text-2xl font-semibold text-white">
+                  {t("overview.progress.title")}
                 </CardTitle>
               </CardHeader>
-              <CardContent className="space-y-4 pb-8 text-sm leading-relaxed text-white/70 sm:text-base">
-                <p>{update.summary}</p>
-                <div className="rounded-lg border border-white/10 bg-black/40 p-4 text-xs text-white/60">
-                  {t("ctaNote")}
-                </div>
+              <CardContent className="pb-6">
+                <p className="text-5xl font-semibold text-white">{t("overview.progress.value")}</p>
+                <p className="mt-3 text-sm leading-relaxed text-white/60">
+                  {t("overview.progress.caption")}
+                </p>
               </CardContent>
             </Card>
-          ))}
-        </div>
+
+            <Card className="border-white/10 bg-white/5 text-white backdrop-blur-xl">
+              <CardHeader className="space-y-2 pb-3">
+                <p className="text-xs uppercase tracking-[0.32em] text-sky-300/60">
+                  {t("overview.phase.eyebrow")}
+                </p>
+                <CardTitle className="text-2xl font-semibold text-white">
+                  {t("overview.phase.title")}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="pb-6">
+                <p className="text-5xl font-semibold text-white">{t("overview.phase.value")}</p>
+                <p className="mt-3 text-sm leading-relaxed text-white/60">
+                  {t("overview.phase.caption")}
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card className="md:col-span-2 overflow-hidden border-white/10 bg-gradient-to-br from-sky-500/25 via-sky-400/10 to-blue-500/10 text-white shadow-[0_0_60px_rgba(56,189,248,0.18)]">
+              <CardContent className="flex flex-col gap-6 p-8 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.32em] text-white/70">
+                    {t("overview.cta.eyebrow")}
+                  </p>
+                  <h3 className="mt-3 text-2xl font-semibold sm:text-3xl">{t("overview.cta.title")}</h3>
+                  <p className="mt-4 max-w-xl text-base text-white/70">{t("overview.cta.subtitle")}</p>
+                </div>
+                <Button asChild className="group inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-[0_0_25px_rgba(56,189,248,0.35)] transition hover:shadow-[0_0_35px_rgba(56,189,248,0.45)]">
+                  <Link href={meetingHref}>
+                    {t("overview.cta.button")}
+                    <MoveRight className="h-4 w-4 transition-transform group-hover:translate-x-1" aria-hidden />
+                  </Link>
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        <section id="premium" aria-labelledby="premium-access" className="mt-20 space-y-10">
+          <div className="text-center">
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-white/60">
+              {t("premium.eyebrow")}
+            </p>
+            <h2 id="premium-access" className="mt-3 text-3xl font-semibold text-white sm:text-4xl">
+              {t("premium.title")}
+            </h2>
+            <p className="mt-4 text-base text-white/60 sm:text-lg">{t("premium.subtitle")}</p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card className="relative overflow-hidden border-white/10 bg-white/5 text-white backdrop-blur-xl">
+              <div aria-hidden className="pointer-events-none absolute inset-0 bg-gradient-to-br from-sky-500/20 via-transparent to-transparent" />
+              <CardHeader className="relative space-y-3 pb-4">
+                <p className="text-xs uppercase tracking-[0.32em] text-sky-300/60">
+                  {t("premium.weekly.eyebrow")}
+                </p>
+                <CardTitle className="text-2xl font-semibold text-white">
+                  {t("premium.weekly.title")}
+                </CardTitle>
+                <p className="text-sm leading-relaxed text-white/70">
+                  {t("premium.weekly.caption")}
+                </p>
+              </CardHeader>
+              <CardContent className="relative space-y-3 pb-8">
+                <div className="h-3 w-3/4 rounded-full bg-white/10" aria-hidden />
+                <div className="h-3 w-full rounded-full bg-white/10" aria-hidden />
+                <div className="h-3 w-2/3 rounded-full bg-white/10" aria-hidden />
+                <div className="h-3 w-4/5 rounded-full bg-white/10" aria-hidden />
+                <div className="h-3 w-1/2 rounded-full bg-white/10" aria-hidden />
+              </CardContent>
+              <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 bg-slate-950/75 backdrop-blur-md">
+                <Lock className="h-8 w-8 text-white/70" aria-hidden />
+                <div className="space-y-2 text-center">
+                  <p className="text-sm font-medium text-white/80">{t("premium.weekly.locked")}</p>
+                  <p className="text-xs uppercase tracking-[0.32em] text-white/40">
+                    {t("premium.weekly.ctaLabel")}
+                  </p>
+                </div>
+                <Button asChild className="rounded-full border border-white/20 bg-white/10 px-6 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/20">
+                  <Link href={meetingHref}>{t("premium.weekly.button")}</Link>
+                </Button>
+              </div>
+            </Card>
+
+            <Card className="border-white/10 bg-white/5 text-white backdrop-blur-xl">
+              <CardHeader className="space-y-3 pb-4">
+                <p className="text-xs uppercase tracking-[0.32em] text-sky-300/60">
+                  {t("premium.resources.eyebrow")}
+                </p>
+                <CardTitle className="text-2xl font-semibold text-white">
+                  {t("premium.resources.title")}
+                </CardTitle>
+                <p className="text-sm leading-relaxed text-white/70">
+                  {t("premium.resources.caption")}
+                </p>
+              </CardHeader>
+              <CardContent className="space-y-5 pb-8 text-sm leading-relaxed text-white/70">
+                <ul className="space-y-3 text-left">
+                  {premiumResourceItems.map((item) => (
+                    <li key={item} className="flex items-start gap-3 text-white/70">
+                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-sky-300/80" aria-hidden />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+                <Button asChild className="group inline-flex items-center gap-2 rounded-full border border-white/20 bg-transparent px-5 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/10">
+                  <Link href={meetingHref}>
+                    {t("premium.resources.button")}
+                    <MoveRight className="h-4 w-4 transition-transform group-hover:translate-x-1" aria-hidden />
+                  </Link>
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -128,10 +128,15 @@ export function Navigation() {
             label: t("loggedIn.exit"),
           },
           {
-            key: "resources",
+            key: "dashboard",
             href: "/newsupdates",
-            label: t("loggedIn.resources"),
+            label: t("loggedIn.dashboard"),
             current: isClientView,
+          },
+          {
+            key: "premium",
+            href: "/newsupdates#premium",
+            label: t("loggedIn.premium"),
           },
           {
             key: "messages",

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -29,7 +29,8 @@
       "overview": "Overview",
       "planning": "Planning",
       "hoursSaved": "Hours saved",
-      "resources": "Resources"
+      "dashboard": "Dashboard",
+      "premium": "Premium"
     },
     "membersMenu": {
       "createAccountDescription": "Join TransformAI to unlock member resources.",
@@ -1188,30 +1189,58 @@
     }
   },
   "NewsUpdates": {
-    "eyebrow": "News updates",
-    "title": "Intelligence for TransformAI members",
-    "subtitle": "Fresh briefings on AI transformations we're guiding across Dutch industry.",
-    "items": {
-      "aiMaturity": {
-        "badge": "Strategy",
-        "title": "AI maturity playbook released",
-        "date": "27 Nov 2025",
-        "summary": "A new guide on measuring AI readiness across finance, logistics, and retail clients. Includes KPIs, capability ladders, and quick wins for leadership teams."
+    "eyebrow": "Client dashboard",
+    "title": "Dashboard",
+    "subtitle": "Track progress, plan the next phase, and unlock premium AI resources when you need them.",
+    "tabs": {
+      "dashboard": "Dashboard",
+      "premium": "Premium"
+    },
+    "overview": {
+      "heading": "Dashboard overview",
+      "progress": {
+        "eyebrow": "Progress made",
+        "title": "Progress made",
+        "value": "0%",
+        "caption": "We'll publish your metrics here as soon as the first initiatives land."
       },
-      "events": {
-        "badge": "Events",
-        "title": "Amsterdam executive roundtable confirmed",
-        "date": "10 Dec 2025",
-        "summary": "We're hosting 12 CIOs to map the first 100 days of AI reinvention. Members will receive the full deck and recordings."
+      "phase": {
+        "eyebrow": "Development phase",
+        "title": "Phase of development",
+        "value": "Phase 0",
+        "caption": "You're at the starting line—kickoff unlocks phase 1 milestones and measurable outputs."
       },
-      "playbooks": {
-        "badge": "Insights",
-        "title": "Automation pilots expanding",
-        "date": "Early January 2026",
-        "summary": "Three client pilots now cover customer support, compliance checks, and finance reconciliation with measurable ROI snapshots inside."
+      "cta": {
+        "eyebrow": "Need momentum?",
+        "title": "Want to make progress with your company in AI?",
+        "subtitle": "Book a strategy call with our consultants to identify quick wins and architect the roadmap.",
+        "button": "Book a call"
       }
     },
-    "ctaNote": "Share confidential updates responsibly. Forward this space to leadership teams that need visibility."
+    "premium": {
+      "eyebrow": "Premium access",
+      "title": "Premium intelligence on standby",
+      "subtitle": "Upgrade for weekly debriefs, quantified outcomes, and executive-ready toolkits.",
+      "weekly": {
+        "eyebrow": "Weekly update",
+        "title": "Deep-dive report on active initiatives",
+        "caption": "Impact metrics, implementation notes, and stakeholder-ready talking points—refreshed every Friday.",
+        "locked": "Locked for premium members",
+        "ctaLabel": "Want to get access?",
+        "button": "Contact us"
+      },
+      "resources": {
+        "eyebrow": "Premium resources",
+        "title": "Resource vault",
+        "caption": "Blueprints, templates, and benchmark data curated for Dutch leadership teams.",
+        "items": {
+          "item1": "Executive-ready AI opportunity assessments tailored to your operations.",
+          "item2": "Process automation templates with ROI models and risk controls.",
+          "item3": "Change enablement playbooks to guide teams through adoption."
+        },
+        "button": "Get access"
+      }
+    }
   },
   "Dashboard": {
     "title": "Hours saved planner",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -29,7 +29,8 @@
       "overview": "Overzicht",
       "planning": "Planning",
       "hoursSaved": "Uren bespaard",
-      "resources": "Bronnen"
+      "dashboard": "Dashboard",
+      "premium": "Premium"
     },
     "membersMenu": {
       "createAccountDescription": "Meld je aan om toegang te krijgen tot onze ledenomgeving.",
@@ -1145,30 +1146,58 @@
     }
   },
   "NewsUpdates": {
-    "eyebrow": "News updates",
-    "title": "Intelligence voor TransformAI-leden",
-    "subtitle": "Kersverse briefings over AI-transformaties die we in Nederlandse sectoren begeleiden.",
-    "items": {
-      "aiMaturity": {
-        "badge": "Strategie",
-        "title": "AI-maturiteitsplaybook gelanceerd",
-        "date": "27 nov 2025",
-        "summary": "Een nieuwe gids om AI-gereedheid te meten in finance, logistiek en retail. Inclusief KPI's, maturiteitsladders en quick wins voor directies."
+    "eyebrow": "Klantdashboard",
+    "title": "Dashboard",
+    "subtitle": "Volg de voortgang, plan de volgende fase en ontgrendel premium AI-resources wanneer het nodig is.",
+    "tabs": {
+      "dashboard": "Dashboard",
+      "premium": "Premium"
+    },
+    "overview": {
+      "heading": "Dashboard-overzicht",
+      "progress": {
+        "eyebrow": "Voortgang",
+        "title": "Voortgang",
+        "value": "0%",
+        "caption": "We delen je statistieken hier zodra de eerste initiatieven live staan."
       },
-      "events": {
-        "badge": "Events",
-        "title": "Executive roundtable in Amsterdam bevestigd",
-        "date": "10 dec 2025",
-        "summary": "We ontvangen 12 CIO's om de eerste 100 dagen van AI-transformatie te schetsen. Leden krijgen het volledige deck en de opname."
+      "phase": {
+        "eyebrow": "Ontwikkelfase",
+        "title": "Fase van ontwikkeling",
+        "value": "Fase 0",
+        "caption": "Je staat aan de start—na de kick-off ontgrendelen we fase 1 mijlpalen en meetbare resultaten."
       },
-      "playbooks": {
-        "badge": "Insights",
-        "title": "Automatiseringspilots opgeschaald",
-        "date": "Begin januari 2026",
-        "summary": "Drie klantpilots bestrijken nu customer support, compliance checks en financiële reconciliatie met meetbare ROI-snapshots."
+      "cta": {
+        "eyebrow": "Meer momentum?",
+        "title": "Wil je vooruitgang boeken met je bedrijf in AI?",
+        "subtitle": "Plan een strategiesessie met onze consultants om quick wins te identificeren en de roadmap op te zetten.",
+        "button": "Plan een call"
       }
     },
-    "ctaNote": "Deel vertrouwelijke updates zorgvuldig. Stuur dit door naar bestuurders die inzicht nodig hebben."
+    "premium": {
+      "eyebrow": "Premium toegang",
+      "title": "Premium intelligence staat klaar",
+      "subtitle": "Upgrade voor wekelijkse debriefs, gekwantificeerde resultaten en executive-ready toolkits.",
+      "weekly": {
+        "eyebrow": "Wekelijkse update",
+        "title": "Diepgaand rapport over lopende initiatieven",
+        "caption": "Impactmetrics, implementatie-notes en boardroom-ready talking points—iedere vrijdag vernieuwd.",
+        "locked": "Vergrendeld voor premiumleden",
+        "ctaLabel": "Toegang krijgen?",
+        "button": "Neem contact op"
+      },
+      "resources": {
+        "eyebrow": "Premium resources",
+        "title": "Resourcekluis",
+        "caption": "Blueprints, templates en benchmarkdata samengesteld voor Nederlandse leiderschapsteams.",
+        "items": {
+          "item1": "Executive-ready AI-kansenanalyses op maat voor jouw operatie.",
+          "item2": "Procesautomatiserings-templates met ROI-modellen en risicobeheersing.",
+          "item3": "Change-management playbooks om teams door adoptie te begeleiden."
+        },
+        "button": "Krijg toegang"
+      }
+    }
   },
   "Dashboard": {
     "title": "Planner voor bespaarde uren",


### PR DESCRIPTION
## Summary
- replace the former news updates feed with a dashboard-themed overview, static progress metrics, and a premium teaser section
- refresh member navigation to expose Dashboard and Premium tabs for clients and update translations in English and Dutch
- add a booking-focused CTA and log the update for future dynamic data work

## Plan
- redesign the /newsupdates page to present overview cards, a CTA, and a premium teaser state
- update copy and translations to align with the new dashboard narrative in both supported locales
- expose navigation affordances for Dashboard and Premium destinations for signed-in clients
- document the change in WRITE_HERE/UPDATES for continuity

## Testing
- pnpm --filter www run lint *(fails: missing `next-intl` dependency in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df8c77608c832aaf16d6314936008e