### PR TITLE
Fix hours-saved dashboard hydration mismatch

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-30T1700--hours-saved-manager-hydration.md
+++ b/WRITE_HERE/FIXES/2025-11-30T1700--hours-saved-manager-hydration.md
@@ -1,0 +1,6 @@
+# Stabilized hours-saved manager today bucket
+
+- **What:** Pass the server-side reference timestamp into the hours-saved manager and derive the "today" bucket key from it so the highlighted day is computed deterministically.
+- **Why:** The client component previously called `new Date()` during render, so users in timezones ahead of the server saw a different day highlighted than the server-rendered HTML, triggering hydration failures on load.
+- **Files:** `apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx`, `apps/www/app/[locale]/(site)/dashboard/hours-saved/page.tsx`.
+- **Follow-ups:** Consider centralizing reusable helpers for time-zone aware comparisons if more scheduling UI appears.

--- a/apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx
@@ -31,6 +31,7 @@ type HoursSavedManagerProps = {
   timeZone: string;
   baseAmount: number;
   schedule: { scheduledFor: string; amount: number }[];
+  referenceTimestamp: string;
 };
 
 type DayEntry = {
@@ -81,7 +82,13 @@ function getPart(parts: Intl.DateTimeFormatPart[], type: Intl.DateTimeFormatPart
   return parts.find((part) => part.type === type)?.value ?? "";
 }
 
-export function HoursSavedManager({ locale, timeZone, baseAmount, schedule }: HoursSavedManagerProps) {
+export function HoursSavedManager({
+  locale,
+  timeZone,
+  baseAmount,
+  schedule,
+  referenceTimestamp,
+}: HoursSavedManagerProps) {
   const t = useTranslations("Dashboard.hoursSaved");
 
   const [baseValue, setBaseValue] = useState(baseAmount.toString());
@@ -159,7 +166,8 @@ export function HoursSavedManager({ locale, timeZone, baseAmount, schedule }: Ho
     [dayKeyFormatter],
   );
 
-  const todayKey = useMemo(() => getDayKey(new Date()), [getDayKey]);
+  const referenceDate = useMemo(() => new Date(referenceTimestamp), [referenceTimestamp]);
+  const todayKey = useMemo(() => getDayKey(referenceDate), [getDayKey, referenceDate]);
 
   const dayBuckets: DayBucket[] = useMemo(() => {
     const byDay = new Map<string, DayBucket>();

--- a/apps/www/app/[locale]/(site)/dashboard/hours-saved/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/hours-saved/page.tsx
@@ -22,7 +22,8 @@ export default async function HoursSavedDashboardPage({ params }: PageProps) {
   }
 
   const t = await getTranslations({ locale, namespace: "Dashboard" });
-  const hoursSavedOverview = await getHoursSavedOverview();
+  const referenceDate = new Date();
+  const hoursSavedOverview = await getHoursSavedOverview(referenceDate);
 
   const hoursSavedSchedule = hoursSavedOverview.schedule.map((entry) => ({
     scheduledFor: entry.scheduledFor.toISOString(),
@@ -86,6 +87,7 @@ export default async function HoursSavedDashboardPage({ params }: PageProps) {
             timeZone={HOURS_SAVED_TIME_ZONE}
             baseAmount={hoursSavedOverview.baseAmount}
             schedule={hoursSavedSchedule}
+            referenceTimestamp={referenceDate.toISOString()}
           />
         </section>
       </div>


### PR DESCRIPTION
## Summary
- derive the hours-saved manager "today" bucket from a server-provided timestamp so hydration stays stable across timezones
- pass the reference time from the dashboard page into the client manager component and document the fix

## Plan
- reproduce and inspect the hydration mismatch around the hours-saved manager UI
- update the server/client data flow so both sides share a deterministic reference timestamp
- document the resolved issue and run the workspace checks

## Testing
- `pnpm --filter www run typecheck` *(fails: existing locale/account-history typing errors)*
- `pnpm --filter www run lint` *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df8d817124832a91dfd5d8f0d3ff90