### PR TITLE
Ensure saved account links trigger fresh navigation

### DIFF
--- a/WRITE_HERE/FIXES/2025-10-03T0855--members-menu-account-redirects.md
+++ b/WRITE_HERE/FIXES/2025-10-03T0855--members-menu-account-redirects.md
@@ -1,0 +1,5 @@
+# Ensure members menu respects account destinations
+- **What:** Added per-account destination tracking to the account history cookie and updated the members menu to use those stored paths when navigating, refreshing the cookie when a saved account is selected.
+- **Why:** Previously every saved account entry pointed to the same default route, so selecting different profiles from the menu always opened the same page instead of the correct member or staff workspace.
+- **Files:** `apps/www/lib/account-history.ts`, `apps/www/components/navbar/navigation.tsx`, `apps/www/app/[locale]/(site)/auth/post-signin/redirect-gate.tsx`.
+- **Follow-ups:** Consider surfacing account-specific metadata (e.g., avatars) now that destinations are tracked.

--- a/WRITE_HERE/FIXES/2025-11-30T1200--members-redirect-refresh.md
+++ b/WRITE_HERE/FIXES/2025-11-30T1200--members-redirect-refresh.md
@@ -1,0 +1,5 @@
+# Stabilize members redirect after account switch
+- **What:** Disabled prefetching on recent-account links and forced a router refresh after post-sign-in redirects so cached client-side responses cannot override the intended destination.
+- **Why:** Selecting a saved staff profile or finishing sign-in briefly navigated to the correct dashboard before a cached redirect sent the browser back to `/en/newsupdates`.
+- **Files:** `apps/www/components/navbar/navigation.tsx`, `apps/www/app/[locale]/(site)/auth/post-signin/redirect-gate.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-30T1705--members-account-navigation-bypass.md
+++ b/WRITE_HERE/FIXES/2025-11-30T1705--members-account-navigation-bypass.md
@@ -1,0 +1,5 @@
+# Ensure saved members accounts open their own destinations
+- **What:** Updated the members menu account links to intercept clicks, close the menu, remember the account, and then hand the browser a full-page navigation to the localized destination. This bypasses Next.js's cached client redirect that previously replayed the members news feed after a staff selection. Both desktop and mobile menus now share the behavior.
+- **Why:** Selecting a stored staff profile still jumped back to `/en/newsupdates` because the cached redirect response from a prior client visit kept firing. Forcing a fresh navigation ensures each account reaches its intended dashboard or members area.
+- **Files:** `apps/www/components/navbar/navigation.tsx`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/auth/post-signin/redirect-gate.tsx
+++ b/apps/www/app/[locale]/(site)/auth/post-signin/redirect-gate.tsx
@@ -25,8 +25,15 @@ export function RedirectGate({ targetPath, account, locale }: RedirectGateProps)
     }
 
     hasRedirected.current = true;
-    rememberAccount(account);
+    rememberAccount({ ...account, destination: targetPath });
     router.replace(targetPath, { locale });
+    const refreshTimeout = window.setTimeout(() => {
+      router.refresh();
+    }, 100);
+
+    return () => {
+      window.clearTimeout(refreshTimeout);
+    };
   }, [account, locale, router, targetPath]);
 
   const displayName = account.name?.trim() || account.email;

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -11,6 +11,7 @@ import {
 import { Link, usePathname } from "@/i18n/navigation";
 import { locales } from "@/i18n/routing";
 import { useAccountHistory } from "@/hooks/use-account-history";
+import { rememberAccount, resolveAccountDestination } from "@/lib/account-history";
 import { cn } from "@/lib/utils";
 import { useConsentManager } from "@c15t/nextjs";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
@@ -269,6 +270,14 @@ function MembersMenu({ className }: { className?: string }) {
   const contentId = "members-menu";
   const accounts = useAccountHistory();
 
+  const handleAccountNavigate = (href: string) => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.location.assign(href);
+  };
+
   return (
     <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
       <PopoverPrimitive.Trigger asChild>
@@ -299,24 +308,36 @@ function MembersMenu({ className }: { className?: string }) {
                 {t("membersMenu.continueHeading")}
               </p>
               <div className="flex flex-col gap-2">
-                {accounts.map((account) => (
-                  <MembersAccountLink
-                    key={account.id}
-                    href={account.role === "staff" ? "/dashboard" : "/newsupdates"}
-                    name={account.name?.trim() || account.email}
-                    subtitle={
-                      account.role === "staff"
-                        ? t("membersMenu.continueRole.staff")
-                        : t("membersMenu.continueRole.client")
-                    }
-                    onClick={() => {
-                      setOpen(false);
-                      if (hasConsentFor("measurement")) {
-                        track("members-continue", { role: account.role, surface: "navigation" });
+                {accounts.map((account) => {
+                  const destination = resolveAccountDestination(account);
+
+                  return (
+                    <MembersAccountLink
+                      key={account.id}
+                      href={destination}
+                      name={account.name?.trim() || account.email}
+                      subtitle={
+                        account.role === "staff"
+                          ? t("membersMenu.continueRole.staff")
+                          : t("membersMenu.continueRole.client")
                       }
-                    }}
-                  />
-                ))}
+                      onNavigate={handleAccountNavigate}
+                      onClick={() => {
+                        setOpen(false);
+                        rememberAccount({
+                          id: account.id,
+                          email: account.email,
+                          name: account.name ?? null,
+                          role: account.role,
+                          destination,
+                        });
+                        if (hasConsentFor("measurement")) {
+                          track("members-continue", { role: account.role, surface: "navigation" });
+                        }
+                      }}
+                    />
+                  );
+                })}
               </div>
             </div>
           ) : null}
@@ -361,6 +382,14 @@ const MembersDrawerMenu = ({ onNavigate }: MembersDrawerMenuProps) => {
   const menuId = "drawer-members-menu";
   const accounts = useAccountHistory();
 
+  const handleAccountNavigate = (href: string) => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.location.assign(href);
+  };
+
   return (
     <div className="w-full">
       <MembersButton
@@ -381,26 +410,38 @@ const MembersDrawerMenu = ({ onNavigate }: MembersDrawerMenuProps) => {
                 {t("membersMenu.continueHeading")}
               </p>
               <div className="flex flex-col gap-2">
-                {accounts.map((account) => (
-                  <MembersAccountLink
-                    key={account.id}
-                    href={account.role === "staff" ? "/dashboard" : "/newsupdates"}
-                    name={account.name?.trim() || account.email}
-                    subtitle={
-                      account.role === "staff"
-                        ? t("membersMenu.continueRole.staff")
-                        : t("membersMenu.continueRole.client")
-                    }
-                    className="border-white/10 bg-white/5"
-                    onClick={() => {
-                      setOpen(false);
-                      onNavigate();
-                      if (hasConsentFor("measurement")) {
-                        track("members-continue", { role: account.role, surface: "navigation-mobile" });
+                {accounts.map((account) => {
+                  const destination = resolveAccountDestination(account);
+
+                  return (
+                    <MembersAccountLink
+                      key={account.id}
+                      href={destination}
+                      name={account.name?.trim() || account.email}
+                      subtitle={
+                        account.role === "staff"
+                          ? t("membersMenu.continueRole.staff")
+                          : t("membersMenu.continueRole.client")
                       }
-                    }}
-                  />
-                ))}
+                      className="border-white/10 bg-white/5"
+                      onNavigate={handleAccountNavigate}
+                      onClick={() => {
+                        setOpen(false);
+                        rememberAccount({
+                          id: account.id,
+                          email: account.email,
+                          name: account.name ?? null,
+                          role: account.role,
+                          destination,
+                        });
+                        onNavigate();
+                        if (hasConsentFor("measurement")) {
+                          track("members-continue", { role: account.role, surface: "navigation-mobile" });
+                        }
+                      }}
+                    />
+                  );
+                })}
               </div>
             </div>
           ) : null}
@@ -474,13 +515,19 @@ type MembersAccountLinkProps = {
   subtitle: string;
   className?: string;
   onClick?: () => void;
+  onNavigate?: (href: string) => void;
 };
 
-function MembersAccountLink({ href, name, subtitle, className, onClick }: MembersAccountLinkProps) {
+function MembersAccountLink({ href, name, subtitle, className, onClick, onNavigate }: MembersAccountLinkProps) {
   return (
     <Link
       href={href}
-      onClick={onClick}
+      prefetch={false}
+      onClick={(event) => {
+        event.preventDefault();
+        onClick?.();
+        onNavigate?.(event.currentTarget.href);
+      }}
       role="menuitem"
       className={cn(
         "group flex w-full items-center justify-between gap-3 rounded-xl border border-white/15 bg-white/8 px-4 py-3 text-left text-sm text-white transition hover:border-white/25 hover:bg-white/12 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70 focus-visible:ring-offset-2 focus-visible:ring-offset-black",

--- a/apps/www/lib/account-history.ts
+++ b/apps/www/lib/account-history.ts
@@ -1,6 +1,13 @@
+import { locales } from "@/i18n/routing";
+
 export const ACCOUNT_HISTORY_COOKIE = "transformai_recent_accounts";
 export const ACCOUNT_HISTORY_EVENT = "transformai:account-history-updated";
 export const ACCOUNT_HISTORY_MAX_ENTRIES = 3;
+
+const DEFAULT_DESTINATIONS: Record<"client" | "staff", string> = {
+  client: "/newsupdates",
+  staff: "/dashboard",
+};
 
 export type AccountHistoryEntry = {
   id: string;
@@ -8,11 +15,72 @@ export type AccountHistoryEntry = {
   name?: string | null;
   role: "client" | "staff";
   lastActiveAt: string;
+  destination: string;
 };
 
-export type AccountHistoryInput = Omit<AccountHistoryEntry, "lastActiveAt"> & {
+export type AccountHistoryInput = Omit<AccountHistoryEntry, "lastActiveAt" | "destination"> & {
   lastActiveAt?: string;
+  destination?: string;
 };
+
+type RawAccountHistoryEntry = Partial<AccountHistoryInput> & {
+  id?: string | null;
+  email?: string | null;
+  name?: string | null;
+  role?: string | null;
+  lastActiveAt?: string | null;
+  destination?: string | null;
+};
+
+function getDefaultDestination(role: "client" | "staff") {
+  return DEFAULT_DESTINATIONS[role] ?? DEFAULT_DESTINATIONS.client;
+}
+
+function stripLocalePrefix(path: string) {
+  for (const locale of locales) {
+    const prefix = `/${locale}`;
+    if (path === prefix) {
+      return "/";
+    }
+    if (path.startsWith(`${prefix}/`)) {
+      return path.slice(prefix.length) || "/";
+    }
+  }
+  return path;
+}
+
+function normalizeDestination(destination: unknown, role: "client" | "staff") {
+  const fallback = getDefaultDestination(role);
+
+  if (typeof destination !== "string") {
+    return fallback;
+  }
+
+  const trimmed = destination.trim();
+
+  if (!trimmed) {
+    return fallback;
+  }
+
+  try {
+    const parsed = new URL(trimmed, "https://transform.ai");
+    const basePath = parsed.pathname.startsWith("/")
+      ? parsed.pathname
+      : `/${parsed.pathname}`;
+    const strippedPath = stripLocalePrefix(basePath);
+    const normalizedPath = strippedPath.startsWith("/") ? strippedPath : `/${strippedPath}`;
+    const finalPath = normalizedPath === "/" ? fallback : normalizedPath;
+    const href = `${finalPath}${parsed.search}${parsed.hash}`;
+    return href || fallback;
+  } catch {
+    const normalizedPath = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+    const strippedPath = stripLocalePrefix(normalizedPath);
+    if (!strippedPath || strippedPath === "/") {
+      return fallback;
+    }
+    return strippedPath.startsWith("/") ? strippedPath : `/${strippedPath}`;
+  }
+}
 
 function readCookieValue(name: string): string | undefined {
   if (typeof document === "undefined") {
@@ -39,15 +107,28 @@ function writeCookieValue(name: string, value: string, maxAgeSeconds: number) {
   document.cookie = `${name}=${encodeURIComponent(value)}; ${path}; Max-Age=${maxAgeSeconds}; ${sameSite}`;
 }
 
-function sanitizeEntries(entries: AccountHistoryEntry[]): AccountHistoryEntry[] {
+function sanitizeEntries(entries: RawAccountHistoryEntry[]): AccountHistoryEntry[] {
   return entries
-    .filter((entry) => Boolean(entry?.id) && Boolean(entry?.email))
-    .map((entry) => ({
-      ...entry,
-      name: entry.name ?? null,
-      role: entry.role === "staff" ? "staff" : "client",
-      lastActiveAt: entry.lastActiveAt ?? new Date(0).toISOString(),
-    }))
+    .filter((entry) => {
+      const email = entry?.email?.trim();
+      const id = entry?.id?.trim() || email;
+      return Boolean(id) && Boolean(email);
+    })
+    .map((entry) => {
+      const email = (entry.email ?? "").trim();
+      const id = (entry.id ?? email).trim();
+      const role: "client" | "staff" = entry.role === "staff" ? "staff" : "client";
+      const destination = normalizeDestination(entry.destination, role);
+
+      return {
+        id,
+        email,
+        name: entry.name ?? null,
+        role,
+        lastActiveAt: entry.lastActiveAt ?? new Date(0).toISOString(),
+        destination,
+      };
+    })
     .sort((a, b) => new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime())
     .slice(0, ACCOUNT_HISTORY_MAX_ENTRIES);
 }
@@ -63,7 +144,7 @@ export function parseAccountHistory(raw?: string): AccountHistoryEntry[] {
       return [];
     }
 
-    return sanitizeEntries(parsed as AccountHistoryEntry[]);
+    return sanitizeEntries(parsed as RawAccountHistoryEntry[]);
   } catch {
     return [];
   }
@@ -102,4 +183,10 @@ export function rememberAccount(entry: AccountHistoryInput) {
   if (typeof window !== "undefined") {
     window.dispatchEvent(new Event(ACCOUNT_HISTORY_EVENT));
   }
+}
+
+export function resolveAccountDestination(
+  entry: Pick<AccountHistoryEntry, "role" | "destination"> & { destination?: string | null },
+) {
+  return normalizeDestination(entry.destination, entry.role);
 }


### PR DESCRIPTION
## Summary
- intercept saved members-account links so selecting an entry dispatches a full-page navigation and bypasses cached redirects
- reuse the manual navigation handler in both desktop and mobile members menus while still closing the menu, updating history, and tracking analytics
- log the follow-up in WRITE_HERE/FIXES

## Plan
- hook a manual navigation handler into members account links to bypass cached redirects
- reuse the handler across desktop and mobile members menus
- document the follow-up in WRITE_HERE/FIXES

## Testing
- pnpm --filter www run typecheck *(fails: repository missing third-party type definitions such as next-intl, drizzle-orm, resend, etc.)*
- pnpm --filter www run lint *(fails: next-intl package is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df8d43c9dc832a814e4199e8956878