### PR TITLE
fix: clear session before new sign-in

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-30T1430--clear-session-before-new-login.md
+++ b/WRITE_HERE/FIXES/2025-11-30T1430--clear-session-before-new-login.md
@@ -1,0 +1,6 @@
+# Clear existing session before new sign-in attempts
+
+- **What:** Updated the sign-in form to call `signOut` before attempting either credentials or Google authentication so the new login replaces any active session.
+- **Why:** Without clearing the previous session, trying to switch between staff and member accounts in the same browser session kept redirecting back to the most recently active account, preventing users from returning to their earlier role.
+- **Files:** `apps/www/components/auth/sign-in-form.tsx`
+- **Follow-ups:** Consider adding explicit “Sign out” affordances near account switchers so users can intentionally end a session before selecting another saved account.

--- a/apps/www/components/auth/sign-in-form.tsx
+++ b/apps/www/components/auth/sign-in-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { signIn } from "next-auth/react";
+import { signIn, signOut } from "next-auth/react";
 import { Loader2, LogIn } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -22,9 +22,19 @@ export function SignInForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isGoogleSubmitting, setIsGoogleSubmitting] = useState(false);
 
+  const clearActiveSession = async () => {
+    try {
+      await signOut({ redirect: false });
+    } catch {
+      // Ignore sign out failures so users can still attempt a new login.
+    }
+  };
+
   const handleGoogleSignIn = async () => {
     setError(null);
     setIsGoogleSubmitting(true);
+
+    await clearActiveSession();
 
     await signIn("google", {
       callbackUrl: "/auth/post-signin",
@@ -35,6 +45,8 @@ export function SignInForm() {
     event.preventDefault();
     setError(null);
     setIsSubmitting(true);
+
+    await clearActiveSession();
 
     const result = await signIn("credentials", {
       email: email.trim(),


### PR DESCRIPTION
## Summary
- clear any active NextAuth session before starting a new sign-in flow so role-specific redirects respect the selected account
- document the session clearing change in the fixes log for future release notes

## Plan
- inspect the sign-in flow to locate where account switching should happen
- add logic to clear the existing session before invoking either credentials or Google sign-in
- update repository FIXES documentation to capture the behavioral change
- run lint/typecheck to confirm the updated flow passes existing quality checks (noting environment limitations if they fail)

## Testing
- `pnpm --filter www run lint` *(fails: missing next-intl dependency in environment)*
- `pnpm --filter www run typecheck` *(fails: missing next-intl/drizzle/resend types in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df9bae5934832a85c3f6866ec63cf1