### PR TITLE
Ensure landing page hours-saved ticker reflects live data

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-30T1230--homepage-hours-saved-refresh.md
+++ b/WRITE_HERE/FIXES/2025-11-30T1230--homepage-hours-saved-refresh.md
@@ -1,0 +1,6 @@
+# Ensure homepage hours-saved ticker uses live data
+
+- **What:** Forced the landing page route to render dynamically so the hero ticker receives the latest hours-saved amount on each load.
+- **Why:** The page was statically cached, so visitors saw stale totals even after the staff dashboard updated the counter; reloading did not show the new number.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { AnalyticsBento } from "@/components/analytics/analytics-bento";
 import { AuditLogsBento } from "@/components/audit-logs-bento";
 import { PrimaryButton, SecondaryButton } from "@/components/button";


### PR DESCRIPTION
## Summary
- force the landing page route to render dynamically so the hero ticker always pulls the latest hours-saved total
- document the bug fix in WRITE_HERE/FIXES for future traceability

## Plan
- inspect the landing page data loading to find the caching source
- update the route configuration to opt out of static generation
- verify no additional code changes are required for the ticker client logic

## Testing
- `pnpm --filter www run lint` *(fails: missing dependency next-intl in lint environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa3c6cdd0832aabfe53f9be650a69