### PR TITLE
Update homepage CTA to promote Solutions page

### DIFF
--- a/WRITE_HERE/UPDATES/2025-10-03T1035--homepage-solutions-cta.md
+++ b/WRITE_HERE/UPDATES/2025-10-03T1035--homepage-solutions-cta.md
@@ -1,0 +1,6 @@
+# Homepage solutions CTA update
+
+- **What:** Retitled the homepage secondary CTA to “Explore Solutions,” updated the Dutch translation, and pointed every instance of the button to the localized Solutions page instead of the docs.
+- **Why:** Align the hero and secondary promotions with the dedicated Solutions content per the latest request.
+- **Files:** `apps/www/components/hero/hero-main-section.tsx`, `apps/www/components/hero/hero.tsx`, `apps/www/app/[locale]/(site)/page.tsx`, `apps/www/app/code-examples.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -99,6 +99,7 @@ export default async function Landing({
   }
 
   const meetingHref = `/${locale}/meeting` as const;
+  const solutionsHref = `/${locale}/pricing` as const;
 
   const [cta, platform, hero, featureSection] = await Promise.all([
     getTranslations({ locale, namespace: "CTA" }),
@@ -197,7 +198,7 @@ export default async function Landing({
                     className="h-10"
                   />
                 </Link>
-                <Link href="/docs">
+                <Link href={solutionsHref}>
                   <SecondaryButton
                     label={cta("exploreProjects")}
                     IconRight={ChevronRight}

--- a/apps/www/app/code-examples.tsx
+++ b/apps/www/app/code-examples.tsx
@@ -519,6 +519,7 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
   const projectCopy = useTranslations("CodeExamples.projects");
   const locale = useLocale();
   const meetingHref = `/${locale}/meeting`;
+  const solutionsHref = `/${locale}/pricing`;
   const [language, setLanguage] = useState<Language>("AI integration pt1");
   const [framework, setFramework] = useState<FrameworkName>("AI transformation");
   const [languageHover, setLanguageHover] = useState("AI integration pt1");
@@ -639,7 +640,7 @@ export const CodeExamples: React.FC<Props> = ({ className }) => {
             IconRight={ChevronRight}
           />
         </Link>
-        <Link key="explore-projects" href="/docs">
+        <Link key="explore-projects" href={solutionsHref}>
           <SecondaryButton
             label={cta("exploreProjects")}
             IconRight={ChevronRight}

--- a/apps/www/components/hero/hero-main-section.tsx
+++ b/apps/www/components/hero/hero-main-section.tsx
@@ -11,6 +11,7 @@ type HeroMainSectionProps = {
   primaryCtaLabel: string;
   primaryCtaHref: string;
   secondaryCtaLabel: string;
+  secondaryCtaHref: string;
   hoursSavedLabel: string;
   hoursSavedInitialAmount: number;
   hoursSavedNextUpdateAt: string | null;
@@ -23,6 +24,7 @@ export function HeroMainSection({
   primaryCtaLabel,
   primaryCtaHref,
   secondaryCtaLabel,
+  secondaryCtaHref,
   hoursSavedLabel,
   hoursSavedInitialAmount,
   hoursSavedNextUpdateAt,
@@ -57,7 +59,10 @@ export function HeroMainSection({
             className="text-sm tracking-[0.2em] text-white sm:text-base"
           />
         </div>
-        <Link href="/docs" className="hidden w-full sm:inline-flex sm:w-auto sm:flex-shrink-0">
+        <Link
+          href={secondaryCtaHref}
+          className="hidden w-full sm:inline-flex sm:w-auto sm:flex-shrink-0"
+        >
           <SecondaryButton
             IconLeft={BookOpen}
             label={secondaryCtaLabel}

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -19,6 +19,7 @@ export const Hero: React.FC<HeroProps> = ({
   const cta = useTranslations("CTA");
   const locale = useLocale();
   const meetingHref = `/${locale}/meeting`;
+  const solutionsHref = `/${locale}/pricing`;
 
   const containerVariants = {
     hidden: {},
@@ -52,6 +53,7 @@ export const Hero: React.FC<HeroProps> = ({
           primaryCtaLabel={cta("getStarted")}
           primaryCtaHref={meetingHref}
           secondaryCtaLabel={cta("exploreProjects")}
+          secondaryCtaHref={solutionsHref}
           hoursSavedLabel={cta("hoursSavedLabel")}
           hoursSavedInitialAmount={initialHoursSavedAmount}
           hoursSavedNextUpdateAt={initialHoursSavedNextUpdateAt}

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -830,7 +830,7 @@
   },
   "CTA": {
     "getStarted": "Get Started",
-    "exploreProjects": "Explore All projects",
+    "exploreProjects": "Explore Solutions",
     "hoursSavedLabel": "Hours saved using AI",
     "hoursSavedAmount": "100000+"
   },

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -787,7 +787,7 @@
   },
   "CTA": {
     "getStarted": "Begin Nu",
-    "exploreProjects": "Ontdek alle projecten",
+    "exploreProjects": "Ontdek onze Oplossingen",
     "hoursSavedLabel": "Uren bespaard met AI",
     "hoursSavedAmount": "100.000+"
   },


### PR DESCRIPTION
## Summary
- retitle the "Explore All projects" CTA copy to "Explore Solutions" in English and Dutch
- point every homepage secondary CTA instance to the locale-aware Solutions (pricing) route
- document the change in WRITE_HERE updates for visibility

## Plan
- trace existing `exploreProjects` usage across hero and supporting sections
- add locale-aware Solutions hrefs to the hero and code examples components
- adjust translations and update logs to reflect the new CTA focus

## Testing
- `pnpm --filter www run lint` *(fails: missing `next-intl` package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa6791224832aaab6a89958f2d1f3