### PR TITLE
Keep landing hero hours-saved ticker aligned with staff schedule

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-30T1230--homepage-hours-saved-refresh.md
+++ b/WRITE_HERE/FIXES/2025-11-30T1230--homepage-hours-saved-refresh.md
@@ -1,0 +1,6 @@
+# Ensure homepage hours-saved ticker uses live data
+
+- **What:** Forced the landing page route to render dynamically so the hero ticker receives the latest hours-saved amount on each load.
+- **Why:** The page was statically cached, so visitors saw stale totals even after the staff dashboard updated the counter; reloading did not show the new number.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-30T1305--hero-hours-saved-sync.md
+++ b/WRITE_HERE/FIXES/2025-11-30T1305--hero-hours-saved-sync.md
@@ -1,0 +1,6 @@
+# Keep hero hours-saved ticker in sync with staff updates
+
+- **What:** Disabled Next.js caching on the landing route and forced the hero ticker to fetch the latest hours-saved totals as soon as it becomes visible, ensuring it immediately reflects staff dashboard adjustments.
+- **Why:** The homepage number lagged behind the staff-managed schedule because the initial render reused cached data and the ticker waited for its first scheduled refresh before polling for new totals.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `apps/www/components/hero/hours-saved-ticker.tsx`.
+- **Follow-ups:** Consider surfacing the next scheduled update time on the homepage badge if stakeholders request more context.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { AnalyticsBento } from "@/components/analytics/analytics-bento";
 import { AuditLogsBento } from "@/components/audit-logs-bento";
 import { PrimaryButton, SecondaryButton } from "@/components/button";
@@ -32,6 +34,7 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { unstable_noStore as noStore } from "next/cache";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
@@ -97,6 +100,8 @@ export default async function Landing({
   if (!isLocale(locale)) {
     notFound();
   }
+
+  noStore();
 
   const meetingHref = `/${locale}/meeting` as const;
 

--- a/apps/www/components/hero/hours-saved-ticker.tsx
+++ b/apps/www/components/hero/hours-saved-ticker.tsx
@@ -31,6 +31,8 @@ export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, c
   const targetAmountRef = useRef(initialAmount);
   const displayAmountRef = useRef(initialAmount);
   const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fetchLatestRef = useRef<(() => Promise<void>) | null>(null);
+  const didRunInitialFetchRef = useRef(false);
 
   const updateDisplayValue = useCallback((value: number) => {
     displayAmountRef.current = value;
@@ -160,6 +162,19 @@ export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, c
       }
     };
 
+    fetchLatestRef.current = async () => {
+      if (cancelled) {
+        return;
+      }
+
+      await fetchLatest();
+    };
+
+    if (!didRunInitialFetchRef.current) {
+      didRunInitialFetchRef.current = true;
+      void fetchLatest();
+    }
+
     const scheduleNextFetch = () => {
       if (!state.nextUpdateAt) {
         return;
@@ -196,8 +211,17 @@ export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, c
       }
       window.removeEventListener("focus", handleFocus);
       document.removeEventListener("visibilitychange", handleVisibility);
+      fetchLatestRef.current = null;
     };
   }, [state.nextUpdateAt]);
+
+  useEffect(() => {
+    if (!isInView) {
+      return;
+    }
+
+    void fetchLatestRef.current?.();
+  }, [isInView]);
 
   const formatter = useMemo(() => new Intl.NumberFormat(locale), [locale]);
   const formatted = formatter.format(displayValue);


### PR DESCRIPTION
## Summary
- opt the landing route out of Next.js caching so the hero ticker renders with fresh hours-saved totals on each load
- trigger an immediate client-side refresh of the ticker when it mounts or comes into view so staff updates appear without delay
- log the fix for the hours-saved ticker lag in WRITE_HERE/FIXES

## Plan
- review the staff dashboard hours-saved utilities to confirm the expected data flow
- update the landing page data loader to bypass caching and reuse the existing overview helper
- tighten the ticker client logic to fetch the latest total right away when viewed
- document the regression fix for future reference

## Testing
- `pnpm --filter www run lint` *(fails: missing dependency `next-intl` referenced by Next lint)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa3c6cdd0832aabfe53f9be650a69