### PR TITLE
Smooth hours-saved ticker with random daily targets

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-30T1230--homepage-hours-saved-refresh.md
+++ b/WRITE_HERE/FIXES/2025-11-30T1230--homepage-hours-saved-refresh.md
@@ -1,0 +1,6 @@
+# Ensure homepage hours-saved ticker uses live data
+
+- **What:** Forced the landing page route to render dynamically so the hero ticker receives the latest hours-saved amount on each load.
+- **Why:** The page was statically cached, so visitors saw stale totals even after the staff dashboard updated the counter; reloading did not show the new number.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`
+- **Follow-ups:** None.

--- a/WRITE_HERE/FIXES/2025-11-30T1305--hero-hours-saved-sync.md
+++ b/WRITE_HERE/FIXES/2025-11-30T1305--hero-hours-saved-sync.md
@@ -1,0 +1,6 @@
+# Keep hero hours-saved ticker in sync with staff updates
+
+- **What:** Disabled Next.js caching on the landing route and forced the hero ticker to fetch the latest hours-saved totals as soon as it becomes visible, ensuring it immediately reflects staff dashboard adjustments.
+- **Why:** The homepage number lagged behind the staff-managed schedule because the initial render reused cached data and the ticker waited for its first scheduled refresh before polling for new totals.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `apps/www/components/hero/hours-saved-ticker.tsx`.
+- **Follow-ups:** Consider surfacing the next scheduled update time on the homepage badge if stakeholders request more context.

--- a/WRITE_HERE/FIXES/2025-11-30T1500--hours-saved-random-drip.md
+++ b/WRITE_HERE/FIXES/2025-11-30T1500--hours-saved-random-drip.md
@@ -1,0 +1,6 @@
+# Smooth hours-saved ticker with daily random targets
+
+- **What:** Reworked the hours-saved scheduler to break each hour into multiple micro-increments driven by a configurable daily total, added staff controls for the daily target with an auto-regenerate button, and exposed the new target to the dashboard and hero API so the homepage number now drips in throughout each hour.
+- **Why:** The previous implementation dropped the full hourly amount near the start of the hour and lacked a single control for the daily total; stakeholders needed a smoother cadence and an easy way to retune the automated additions.
+- **Files:** `apps/www/lib/hours-saved/**`, `apps/www/app/[locale]/(site)/dashboard/**`, `apps/www/app/api/hours-saved/route.ts`, `apps/www/messages/*.json`, `apps/www/lib/db/schema.ts`.
+- **Follow-ups:** Consider persisting a seed per day to make the random schedule deterministic for auditing, and explore visualizing the regenerated plan so staff can preview the distribution before saving.

--- a/apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/components/hours-saved-manager.tsx
@@ -31,6 +31,7 @@ type HoursSavedManagerProps = {
   locale: string;
   timeZone: string;
   baseAmount: number;
+  dailyTarget: number;
   schedule: ScheduleDisplayEntry[];
   referenceDayKey: string;
 };
@@ -53,12 +54,14 @@ export function HoursSavedManager({
   locale,
   timeZone,
   baseAmount,
+  dailyTarget,
   schedule,
   referenceDayKey,
 }: HoursSavedManagerProps) {
   const t = useTranslations("Dashboard.hoursSaved");
 
   const [baseValue, setBaseValue] = useState(baseAmount.toString());
+  const [dailyTargetValue, setDailyTargetValue] = useState(dailyTarget.toString());
   const [rows, setRows] = useState<ScheduleRowState[]>(() =>
     schedule.slice(0, HOURS_SAVED_WINDOW_HOURS).map((entry) => ({
       scheduledFor: new Date(entry.scheduledFor),
@@ -73,6 +76,7 @@ export function HoursSavedManager({
   const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [pendingAction, setPendingAction] = useState<"manual" | "auto" | null>(null);
   const [selectedDay, setSelectedDay] = useState<string>(referenceDayKey);
   const [activeHour, setActiveHour] = useState<string>(schedule[0]?.scheduledFor ?? "");
   const [copyMode, setCopyMode] = useState(false);
@@ -85,6 +89,10 @@ export function HoursSavedManager({
   );
 
   const todayKey = referenceDayKey;
+
+  useEffect(() => {
+    setDailyTargetValue(dailyTarget.toString());
+  }, [dailyTarget]);
 
   const buildRowsFromSchedule = useCallback(
     (entries: { scheduledFor: string; amount: number }[]) =>
@@ -178,6 +186,12 @@ export function HoursSavedManager({
     setStatusMessage(null);
   };
 
+  const handleDailyTargetChange = (value: string) => {
+    setDailyTargetValue(value);
+    setStatus("idle");
+    setStatusMessage(null);
+  };
+
   const handleActiveValueChange = (value: string) => {
     if (!activeEntry) {
       return;
@@ -198,15 +212,25 @@ export function HoursSavedManager({
     setStatusMessage(null);
 
     const baseTrimmed = baseValue.trim();
-    if (baseTrimmed === "") {
+    const targetTrimmed = dailyTargetValue.trim();
+
+    if (baseTrimmed === "" || targetTrimmed === "") {
       setStatus("error");
       setStatusMessage(t("status.validation"));
       return;
     }
 
     const parsedBase = Number(baseTrimmed);
+    const parsedTarget = Number(targetTrimmed);
 
-    if (!Number.isFinite(parsedBase) || parsedBase < 0 || !Number.isInteger(parsedBase)) {
+    if (
+      !Number.isFinite(parsedBase) ||
+      parsedBase < 0 ||
+      !Number.isInteger(parsedBase) ||
+      !Number.isFinite(parsedTarget) ||
+      parsedTarget < 0 ||
+      !Number.isInteger(parsedTarget)
+    ) {
       setStatus("error");
       setStatusMessage(t("status.validation"));
       return;
@@ -236,36 +260,117 @@ export function HoursSavedManager({
       });
     }
 
+    setPendingAction("manual");
     startTransition(async () => {
-      const result = await updateHoursSavedScheduleAction(locale, {
-        baseAmount: parsedBase,
-        schedule: schedulePayload,
-      });
-
-      if (!result.success) {
-        setStatus("error");
-        setStatusMessage(
-          result.error === "validation" ? t("status.validation") : t("status.error"),
-        );
-        return;
-      }
-
       try {
-        const response = await fetch("/api/hours-saved", { cache: "no-store" });
-        if (response.ok) {
-          const data = await response.json();
-          setRows(buildRowsFromSchedule(data.schedule));
-          setBaseValue(data.baseAmount.toString());
-        }
-      } catch (error) {
-        console.error("Failed to refresh hours saved overview", error);
-      }
+        const result = await updateHoursSavedScheduleAction(locale, {
+          mode: "manual",
+          baseAmount: parsedBase,
+          dailyTarget: parsedTarget,
+          schedule: schedulePayload,
+        });
 
-      setStatus("success");
-      setStatusMessage(t("status.success"));
-      setCopyMode(false);
-      setCopySource(null);
-      setCopyTargets([]);
+        if (!result.success) {
+          setStatus("error");
+          setStatusMessage(
+            result.error === "validation" ? t("status.validation") : t("status.error"),
+          );
+          return;
+        }
+
+        try {
+          const response = await fetch("/api/hours-saved", { cache: "no-store" });
+          if (response.ok) {
+            const data = await response.json();
+            setRows(buildRowsFromSchedule(data.schedule));
+            setBaseValue(data.baseAmount.toString());
+            if (typeof data.dailyTarget === "number") {
+              setDailyTargetValue(data.dailyTarget.toString());
+            }
+          }
+        } catch (error) {
+          console.error("Failed to refresh hours saved overview", error);
+        }
+
+        setStatus("success");
+        setStatusMessage(t("status.success"));
+        setCopyMode(false);
+        setCopySource(null);
+        setCopyTargets([]);
+      } finally {
+        setPendingAction(null);
+      }
+    });
+  };
+
+  const handleRegenerate = () => {
+    setStatus("idle");
+    setStatusMessage(null);
+
+    const baseTrimmed = baseValue.trim();
+    const targetTrimmed = dailyTargetValue.trim();
+
+    if (baseTrimmed === "" || targetTrimmed === "") {
+      setStatus("error");
+      setStatusMessage(t("status.validation"));
+      return;
+    }
+
+    const parsedBase = Number(baseTrimmed);
+    const parsedTarget = Number(targetTrimmed);
+
+    if (
+      !Number.isFinite(parsedBase) ||
+      parsedBase < 0 ||
+      !Number.isInteger(parsedBase) ||
+      !Number.isFinite(parsedTarget) ||
+      parsedTarget < 0 ||
+      !Number.isInteger(parsedTarget)
+    ) {
+      setStatus("error");
+      setStatusMessage(t("status.validation"));
+      return;
+    }
+
+    setPendingAction("auto");
+    startTransition(async () => {
+      try {
+        const result = await updateHoursSavedScheduleAction(locale, {
+          mode: "auto",
+          baseAmount: parsedBase,
+          dailyTarget: parsedTarget,
+        });
+
+        if (!result.success) {
+          setStatus("error");
+          setStatusMessage(
+            result.error === "validation" ? t("status.validation") : t("status.error"),
+          );
+          return;
+        }
+
+        try {
+          const response = await fetch("/api/hours-saved", { cache: "no-store" });
+          if (response.ok) {
+            const data = await response.json();
+            setRows(buildRowsFromSchedule(data.schedule));
+            setBaseValue(data.baseAmount.toString());
+            if (typeof data.dailyTarget === "number") {
+              setDailyTargetValue(data.dailyTarget.toString());
+            }
+          }
+        } catch (error) {
+          console.error("Failed to refresh hours saved overview", error);
+        }
+
+        setStatus("success");
+        setStatusMessage(t("status.success"));
+        setCopyMode(false);
+        setCopySource(null);
+        setCopyTargets([]);
+      } finally {
+        setPendingAction(null);
+      }
     });
   };
 
@@ -365,6 +470,21 @@ export function HoursSavedManager({
           className="h-11 rounded-xl border-white/15 bg-white/5 text-base text-white placeholder:text-white/40 focus-visible:ring-white/40"
         />
         <p className="text-xs text-white/50">{t("base.helper")}</p>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-sm font-medium text-white/80">{t("dailyTarget.label")}</Label>
+        <Input
+          type="number"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          step={1}
+          min={0}
+          value={dailyTargetValue}
+          onChange={(event) => handleDailyTargetChange(event.target.value)}
+          className="h-11 rounded-xl border-white/15 bg-white/5 text-base text-white placeholder:text-white/40 focus-visible:ring-white/40"
+        />
+        <p className="text-xs text-white/50">{t("dailyTarget.helper")}</p>
       </div>
 
       <div className="space-y-4">
@@ -552,20 +672,32 @@ export function HoursSavedManager({
         </p>
       ) : null}
 
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <Button
-          type="button"
-          onClick={toggleCopyMode}
-          className="h-10 rounded-full border border-white/20 bg-white/10 px-5 text-xs font-semibold uppercase tracking-[0.24em] text-white/70 hover:bg-white/15"
-        >
-          {copyMode ? t("actions.copyClose") : t("actions.copy")}
-        </Button>
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-2">
+          <Button
+            type="button"
+            onClick={toggleCopyMode}
+            className="h-10 rounded-full border border-white/20 bg-white/10 px-5 text-xs font-semibold uppercase tracking-[0.24em] text-white/70 hover:bg-white/15"
+          >
+            {copyMode ? t("actions.copyClose") : t("actions.copy")}
+          </Button>
+          <Button
+            type="button"
+            onClick={handleRegenerate}
+            disabled={isPending}
+            className="h-10 rounded-full border border-white/20 bg-white/15 px-5 text-xs font-semibold uppercase tracking-[0.24em] text-white hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isPending && pendingAction === "auto"
+              ? t("actions.regenerating")
+              : t("actions.regenerate")}
+          </Button>
+        </div>
         <Button
           type="submit"
           disabled={isPending}
-          className="h-10 rounded-full bg-white px-6 text-xs font-semibold uppercase tracking-[0.3em] text-black hover:bg-white/90 disabled:opacity-60"
+          className="h-10 rounded-full bg-white px-6 text-xs font-semibold uppercase tracking-[0.3em] text-black hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-60"
         >
-          {isPending ? t("actions.saving") : t("actions.submit")}
+          {isPending && pendingAction === "manual" ? t("actions.saving") : t("actions.submit")}
         </Button>
       </div>
     </form>

--- a/apps/www/app/[locale]/(site)/dashboard/hours-saved-actions.ts
+++ b/apps/www/app/[locale]/(site)/dashboard/hours-saved-actions.ts
@@ -5,22 +5,27 @@ import { z } from "zod";
 
 import { getAuthSession } from "@/lib/auth";
 import { updateHoursSavedSettings } from "@/lib/hours-saved";
-import {
-  HOURS_SAVED_WINDOW_HOURS,
-  addHours,
-  nextHour,
-  randomizeWithinHour,
-} from "@/lib/hours-saved/constants";
+import { HOURS_SAVED_WINDOW_HOURS } from "@/lib/hours-saved/constants";
 
 const scheduleItemSchema = z.object({
   scheduledFor: z.string().datetime(),
   amount: z.number().int().min(0).max(1_000_000),
 });
 
-const payloadSchema = z.object({
+const manualPayloadSchema = z.object({
+  mode: z.literal("manual"),
   baseAmount: z.number().int().min(0).max(1_000_000_000),
   schedule: z.array(scheduleItemSchema).length(HOURS_SAVED_WINDOW_HOURS),
+  dailyTarget: z.number().int().min(0).max(1_000_000_000).optional(),
 });
+
+const autoPayloadSchema = z.object({
+  mode: z.literal("auto"),
+  baseAmount: z.number().int().min(0).max(1_000_000_000),
+  dailyTarget: z.number().int().min(0).max(1_000_000_000),
+});
+
+const payloadSchema = z.discriminatedUnion("mode", [manualPayloadSchema, autoPayloadSchema]);
 
 export async function updateHoursSavedScheduleAction(locale: string, payload: unknown) {
   const session = await getAuthSession();
@@ -40,31 +45,31 @@ export async function updateHoursSavedScheduleAction(locale: string, payload: un
   }
 
   const reference = new Date();
-  const windowStart = nextHour(reference);
-
-  const sortedEntries = parsed.data.schedule
-    .map((entry) => ({
-      scheduledFor: new Date(entry.scheduledFor),
-      amount: entry.amount,
-    }))
-    .sort((a, b) => a.scheduledFor.getTime() - b.scheduledFor.getTime());
-
-  const usedTimestamps = new Set<number>();
-  const normalizedSchedule = sortedEntries.map((entry, index) => {
-    const hourStart = addHours(windowStart, index);
-    const scheduledFor = randomizeWithinHour(hourStart, usedTimestamps);
-    return {
-      scheduledFor,
-      amount: entry.amount,
-    };
-  });
 
   try {
-    await updateHoursSavedSettings({
-      baseAmount: parsed.data.baseAmount,
-      schedule: normalizedSchedule,
-      now: reference,
-    });
+    if (parsed.data.mode === "manual") {
+      const scheduleEntries = parsed.data.schedule
+        .map((entry) => ({
+          scheduledFor: new Date(entry.scheduledFor),
+          amount: entry.amount,
+        }))
+        .sort((a, b) => a.scheduledFor.getTime() - b.scheduledFor.getTime());
+
+      await updateHoursSavedSettings({
+        mode: "manual",
+        baseAmount: parsed.data.baseAmount,
+        schedule: scheduleEntries,
+        dailyTarget: parsed.data.dailyTarget,
+        now: reference,
+      });
+    } else {
+      await updateHoursSavedSettings({
+        mode: "auto",
+        baseAmount: parsed.data.baseAmount,
+        dailyTarget: parsed.data.dailyTarget,
+        now: reference,
+      });
+    }
   } catch (error) {
     console.error("Failed to update hours saved schedule", error);
     return { success: false as const, error: "unknown" as const };

--- a/apps/www/app/[locale]/(site)/dashboard/hours-saved/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/hours-saved/page.tsx
@@ -93,6 +93,7 @@ export default async function HoursSavedDashboardPage({ params }: PageProps) {
             locale={locale}
             timeZone={HOURS_SAVED_TIME_ZONE}
             baseAmount={hoursSavedOverview.baseAmount}
+            dailyTarget={hoursSavedOverview.dailyTarget}
             schedule={hoursSavedSchedule}
             referenceDayKey={referenceDayKey}
           />

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { AnalyticsBento } from "@/components/analytics/analytics-bento";
 import { AuditLogsBento } from "@/components/audit-logs-bento";
 import { PrimaryButton, SecondaryButton } from "@/components/button";
@@ -32,6 +34,7 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { unstable_noStore as noStore } from "next/cache";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
@@ -97,6 +100,8 @@ export default async function Landing({
   if (!isLocale(locale)) {
     notFound();
   }
+
+  noStore();
 
   const meetingHref = `/${locale}/meeting` as const;
 

--- a/apps/www/app/api/hours-saved/route.ts
+++ b/apps/www/app/api/hours-saved/route.ts
@@ -12,6 +12,7 @@ export async function GET() {
         baseSetAt: overview.baseSetAt.toISOString(),
         currentAmount: overview.currentAmount,
         nextUpdateAt: overview.nextUpdateAt ? overview.nextUpdateAt.toISOString() : null,
+        dailyTarget: overview.dailyTarget,
         schedule: overview.schedule.map((entry) => ({
           scheduledFor: entry.scheduledFor.toISOString(),
           amount: entry.amount,

--- a/apps/www/components/hero/hours-saved-ticker.tsx
+++ b/apps/www/components/hero/hours-saved-ticker.tsx
@@ -31,6 +31,8 @@ export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, c
   const targetAmountRef = useRef(initialAmount);
   const displayAmountRef = useRef(initialAmount);
   const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fetchLatestRef = useRef<(() => Promise<void>) | null>(null);
+  const didRunInitialFetchRef = useRef(false);
 
   const updateDisplayValue = useCallback((value: number) => {
     displayAmountRef.current = value;
@@ -160,6 +162,19 @@ export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, c
       }
     };
 
+    fetchLatestRef.current = async () => {
+      if (cancelled) {
+        return;
+      }
+
+      await fetchLatest();
+    };
+
+    if (!didRunInitialFetchRef.current) {
+      didRunInitialFetchRef.current = true;
+      void fetchLatest();
+    }
+
     const scheduleNextFetch = () => {
       if (!state.nextUpdateAt) {
         return;
@@ -196,8 +211,17 @@ export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, c
       }
       window.removeEventListener("focus", handleFocus);
       document.removeEventListener("visibilitychange", handleVisibility);
+      fetchLatestRef.current = null;
     };
   }, [state.nextUpdateAt]);
+
+  useEffect(() => {
+    if (!isInView) {
+      return;
+    }
+
+    void fetchLatestRef.current?.();
+  }, [isInView]);
 
   const formatter = useMemo(() => new Intl.NumberFormat(locale), [locale]);
   const formatted = formatter.format(displayValue);

--- a/apps/www/lib/db/schema.ts
+++ b/apps/www/lib/db/schema.ts
@@ -167,6 +167,7 @@ export const hoursSavedStates = pgTable("hours_saved_states", {
   baseSetAt: timestamp("base_set_at", { mode: "date", withTimezone: true })
     .notNull()
     .defaultNow(),
+  autoDailyTarget: integer("auto_daily_target").notNull().default(10_000),
   createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/apps/www/lib/hours-saved/constants.ts
+++ b/apps/www/lib/hours-saved/constants.ts
@@ -1,10 +1,8 @@
 import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
 
 export const HOURS_SAVED_WINDOW_HOURS = 24 * 7;
-export const HOURS_SAVED_DEFAULT_DAY_INCREMENT = 104;
-export const HOURS_SAVED_DEFAULT_NIGHT_INCREMENT = 65;
-export const HOURS_SAVED_DAY_START_HOUR = 8;
-export const HOURS_SAVED_DAY_END_HOUR = 20;
+export const HOURS_SAVED_ENTRIES_PER_HOUR = 12;
+export const HOURS_SAVED_DEFAULT_DAILY_TARGET = 10_000;
 export const HOURS_SAVED_TIME_ZONE = MEETING_TIME_ZONE;
 
 const hourFormatter = new Intl.DateTimeFormat("en-US", {
@@ -53,13 +51,4 @@ export function getZoneHour(date: Date): number {
   const parts = hourFormatter.formatToParts(date);
   const hourPart = parts.find((part) => part.type === "hour");
   return hourPart ? Number.parseInt(hourPart.value, 10) : Number.parseInt(hourFormatter.format(date), 10);
-}
-
-export function isDaytimeInZone(date: Date): boolean {
-  const hour = getZoneHour(date);
-  return hour >= HOURS_SAVED_DAY_START_HOUR && hour < HOURS_SAVED_DAY_END_HOUR;
-}
-
-export function getDefaultIncrementFor(date: Date): number {
-  return isDaytimeInZone(date) ? HOURS_SAVED_DEFAULT_DAY_INCREMENT : HOURS_SAVED_DEFAULT_NIGHT_INCREMENT;
 }

--- a/apps/www/lib/hours-saved/index.ts
+++ b/apps/www/lib/hours-saved/index.ts
@@ -5,8 +5,9 @@ import { hoursSavedIncrements, hoursSavedStates } from "@/lib/db/schema";
 
 import {
   HOURS_SAVED_WINDOW_HOURS,
+  HOURS_SAVED_ENTRIES_PER_HOUR,
+  HOURS_SAVED_DEFAULT_DAILY_TARGET,
   addHours,
-  getDefaultIncrementFor,
   nextHour,
   randomizeWithinHour,
   startOfHour,
@@ -22,15 +23,181 @@ export type HoursSavedOverview = {
   baseSetAt: Date;
   currentAmount: number;
   nextUpdateAt: Date | null;
+  dailyTarget: number;
   schedule: HoursSavedScheduleEntry[];
 };
 
 type DbExecutor = DrizzleDB;
+type HoursSavedState = typeof hoursSavedStates.$inferSelect;
+
+const HOURS_PER_DAY = 24;
+
+function allocateIntegerTotal(total: number, buckets: number, minPerBucket = 0): number[] {
+  if (buckets <= 0) {
+    return [];
+  }
+
+  if (total <= 0) {
+    return Array.from({ length: buckets }, () => 0);
+  }
+
+  const safeMin = Math.max(0, Math.floor(minPerBucket));
+  const baseValues = Array.from({ length: buckets }, () => safeMin);
+  let remainder = total - safeMin * buckets;
+
+  if (remainder <= 0) {
+    return baseValues;
+  }
+
+  const weights = Array.from({ length: buckets }, () => Math.random() + 0.001);
+  const weightSum = weights.reduce((sum, value) => sum + value, 0);
+  const raw = weights.map((weight) => (weight / weightSum) * remainder);
+
+  const result = baseValues.map((value, index) => value + Math.floor(raw[index]));
+  let leftover = remainder - raw.reduce((sum, value) => sum + Math.floor(value), 0);
+
+  const fractional = raw
+    .map((value, index) => ({ index, fraction: value - Math.floor(value) }))
+    .sort((a, b) => b.fraction - a.fraction);
+
+  let pointer = 0;
+  while (leftover > 0 && fractional.length > 0) {
+    result[fractional[pointer].index] += 1;
+    leftover -= 1;
+    pointer = (pointer + 1) % fractional.length;
+  }
+
+  return result;
+}
+
+function splitAmountIntoIncrements(amount: number): number[] {
+  const total = Math.max(0, Math.floor(amount));
+
+  if (total === 0) {
+    return [];
+  }
+
+  const incrementsCount = Math.min(total, HOURS_SAVED_ENTRIES_PER_HOUR);
+  const increments = Array.from({ length: incrementsCount }, () => 1);
+  let remainder = total - incrementsCount;
+
+  while (remainder > 0 && increments.length > 0) {
+    const index = Math.floor(Math.random() * increments.length);
+    increments[index] += 1;
+    remainder -= 1;
+  }
+
+  return increments;
+}
+
+function generateAutomaticSchedule({
+  stateId,
+  windowStart,
+  windowHours,
+  dailyTarget,
+}: {
+  stateId: string;
+  windowStart: Date;
+  windowHours: number;
+  dailyTarget: number;
+}): { stateId: string; scheduledFor: Date; amount: number }[] {
+  if (windowHours <= 0) {
+    return [];
+  }
+
+  const schedule: { stateId: string; scheduledFor: Date; amount: number }[] = [];
+  const usedTimestamps = new Set<number>();
+  const days = Math.ceil(windowHours / HOURS_PER_DAY);
+  const safeTarget = Math.max(0, Math.floor(dailyTarget));
+
+  for (let dayIndex = 0; dayIndex < days; dayIndex += 1) {
+    const dayStart = addHours(windowStart, dayIndex * HOURS_PER_DAY);
+    const hoursRemaining = Math.min(HOURS_PER_DAY, windowHours - dayIndex * HOURS_PER_DAY);
+    const hourAllocations = allocateIntegerTotal(
+      safeTarget,
+      HOURS_PER_DAY,
+      safeTarget >= HOURS_PER_DAY ? 1 : 0,
+    );
+
+    for (let hourOffset = 0; hourOffset < hoursRemaining; hourOffset += 1) {
+      const hourAmount = hourAllocations[hourOffset] ?? 0;
+
+      if (hourAmount <= 0) {
+        continue;
+      }
+
+      const increments = splitAmountIntoIncrements(hourAmount);
+      const hourStart = addHours(dayStart, hourOffset);
+
+      for (const increment of increments) {
+        if (increment <= 0) {
+          continue;
+        }
+
+        const scheduledFor = randomizeWithinHour(hourStart, usedTimestamps);
+        schedule.push({ stateId, scheduledFor, amount: increment });
+      }
+    }
+  }
+
+  return schedule;
+}
+
+function expandHourlySchedule(
+  stateId: string,
+  schedule: HoursSavedScheduleEntry[],
+): { stateId: string; scheduledFor: Date; amount: number }[] {
+  const usedTimestamps = new Set<number>();
+  const values: { stateId: string; scheduledFor: Date; amount: number }[] = [];
+
+  for (const entry of schedule) {
+    const amount = Math.max(0, Math.floor(entry.amount));
+
+    if (amount <= 0) {
+      continue;
+    }
+
+    const hourStart = startOfHour(entry.scheduledFor);
+    const increments = splitAmountIntoIncrements(amount);
+
+    for (const increment of increments) {
+      if (increment <= 0) {
+        continue;
+      }
+
+      const scheduledFor = randomizeWithinHour(hourStart, usedTimestamps);
+      values.push({ stateId, scheduledFor, amount: increment });
+    }
+  }
+
+  return values;
+}
 
 async function ensureState(executor: DbExecutor = db) {
   const existing = await executor.query.hoursSavedStates.findFirst();
 
   if (existing) {
+    if (existing.autoDailyTarget == null) {
+      const updated = await executor
+        .update(hoursSavedStates)
+        .set({
+          autoDailyTarget: HOURS_SAVED_DEFAULT_DAILY_TARGET,
+          updatedAt: new Date(),
+        })
+        .where(eq(hoursSavedStates.id, existing.id))
+        .returning()
+        .then((rows) => rows[0]);
+
+      if (updated) {
+        return updated;
+      }
+
+      return {
+        ...existing,
+        autoDailyTarget: HOURS_SAVED_DEFAULT_DAILY_TARGET,
+      } satisfies HoursSavedState;
+    }
+
     return existing;
   }
 
@@ -39,6 +206,7 @@ async function ensureState(executor: DbExecutor = db) {
     .values({
       baseAmount: 0,
       baseSetAt: new Date(),
+      autoDailyTarget: HOURS_SAVED_DEFAULT_DAILY_TARGET,
       createdAt: new Date(),
       updatedAt: new Date(),
     })
@@ -53,47 +221,87 @@ async function ensureState(executor: DbExecutor = db) {
 
 async function ensureUpcomingSchedule(
   executor: DbExecutor,
-  stateId: string,
+  state: HoursSavedState,
   now: Date,
 ) {
   const windowStart = nextHour(now);
   const windowEnd = addHours(windowStart, HOURS_SAVED_WINDOW_HOURS);
 
   const existing = await executor
-    .select({ scheduledFor: hoursSavedIncrements.scheduledFor })
+    .select({
+      scheduledFor: hoursSavedIncrements.scheduledFor,
+      amount: hoursSavedIncrements.amount,
+    })
     .from(hoursSavedIncrements)
     .where(
       and(
-        eq(hoursSavedIncrements.stateId, stateId),
+        eq(hoursSavedIncrements.stateId, state.id),
         gte(hoursSavedIncrements.scheduledFor, windowStart),
         lt(hoursSavedIncrements.scheduledFor, windowEnd),
       ),
     );
 
-  const existingHourKeys = new Set(
-    existing.map((entry) => startOfHour(entry.scheduledFor).toISOString()),
-  );
-  const usedTimestamps = new Set(existing.map((entry) => entry.scheduledFor.getTime()));
-  const inserts: { stateId: string; scheduledFor: Date; amount: number }[] = [];
+  const coverage = new Map<string, { count: number; total: number }>();
+  for (const entry of existing) {
+    const hourKey = startOfHour(entry.scheduledFor).toISOString();
+    const current = coverage.get(hourKey);
 
-  for (let offset = 0; offset < HOURS_SAVED_WINDOW_HOURS; offset += 1) {
-    const hourStart = addHours(windowStart, offset);
-    if (existingHourKeys.has(hourStart.toISOString())) {
-      continue;
+    if (current) {
+      current.count += 1;
+      current.total += entry.amount;
+    } else {
+      coverage.set(hourKey, { count: 1, total: entry.amount });
     }
-
-    const scheduledFor = randomizeWithinHour(hourStart, usedTimestamps);
-    existingHourKeys.add(hourStart.toISOString());
-
-    inserts.push({
-      stateId,
-      scheduledFor,
-      amount: getDefaultIncrementFor(scheduledFor),
-    });
   }
 
-  if (inserts.length > 0) {
-    await executor.insert(hoursSavedIncrements).values(inserts);
+  let needsRegeneration = existing.length === 0;
+
+  if (!needsRegeneration) {
+    for (let offset = 0; offset < HOURS_SAVED_WINDOW_HOURS; offset += 1) {
+      const hourStart = addHours(windowStart, offset);
+      const hourKey = hourStart.toISOString();
+      const data = coverage.get(hourKey);
+
+      if (!data || data.total <= 0) {
+        continue;
+      }
+
+      const expected = Math.min(
+        HOURS_SAVED_ENTRIES_PER_HOUR,
+        Math.max(1, Math.min(data.total, HOURS_SAVED_ENTRIES_PER_HOUR)),
+      );
+
+      if (data.count < expected) {
+        needsRegeneration = true;
+        break;
+      }
+    }
+  }
+
+  if (!needsRegeneration) {
+    return;
+  }
+
+  await executor
+    .delete(hoursSavedIncrements)
+    .where(
+      and(
+        eq(hoursSavedIncrements.stateId, state.id),
+        gte(hoursSavedIncrements.scheduledFor, windowStart),
+        lt(hoursSavedIncrements.scheduledFor, windowEnd),
+      ),
+    );
+
+  const autoTarget = state.autoDailyTarget ?? HOURS_SAVED_DEFAULT_DAILY_TARGET;
+  const values = generateAutomaticSchedule({
+    stateId: state.id,
+    windowStart,
+    windowHours: HOURS_SAVED_WINDOW_HOURS,
+    dailyTarget: autoTarget,
+  });
+
+  if (values.length > 0) {
+    await executor.insert(hoursSavedIncrements).values(values);
   }
 }
 
@@ -120,7 +328,7 @@ async function sumAppliedIncrements(
 export async function getHoursSavedOverview(now: Date = new Date()): Promise<HoursSavedOverview> {
   const state = await ensureState();
 
-  await ensureUpcomingSchedule(db, state.id, now);
+  await ensureUpcomingSchedule(db, state, now);
 
   const applied = await sumAppliedIncrements(db, state.id, state.baseSetAt, now);
 
@@ -142,56 +350,82 @@ export async function getHoursSavedOverview(now: Date = new Date()): Promise<Hou
     )
     .orderBy(asc(hoursSavedIncrements.scheduledFor));
 
-  const seenHours = new Set<string>();
-  const scheduleEntries: HoursSavedScheduleEntry[] = [];
+  const aggregatedByHour = new Map<string, HoursSavedScheduleEntry>();
 
   for (const row of scheduleRows) {
-    const hourKey = startOfHour(row.scheduledFor).toISOString();
+    const hourStart = startOfHour(row.scheduledFor);
+    const hourKey = hourStart.toISOString();
+    const existingEntry = aggregatedByHour.get(hourKey);
 
-    if (seenHours.has(hourKey)) {
+    if (existingEntry) {
+      existingEntry.amount += row.amount;
       continue;
     }
 
-    seenHours.add(hourKey);
-    scheduleEntries.push({
-      scheduledFor: row.scheduledFor,
+    aggregatedByHour.set(hourKey, {
+      scheduledFor: hourStart,
       amount: row.amount,
     });
-
-    if (scheduleEntries.length === HOURS_SAVED_WINDOW_HOURS) {
-      break;
-    }
   }
+
+  const scheduleEntries = Array.from(aggregatedByHour.values())
+    .sort((a, b) => a.scheduledFor.getTime() - b.scheduledFor.getTime())
+    .slice(0, HOURS_SAVED_WINDOW_HOURS);
+
+  const nextUpdateAt = scheduleRows[0]?.scheduledFor ?? null;
 
   return {
     baseAmount: state.baseAmount,
     baseSetAt: state.baseSetAt,
     currentAmount: state.baseAmount + applied,
-    nextUpdateAt: scheduleEntries[0]?.scheduledFor ?? null,
+    nextUpdateAt,
+    dailyTarget: state.autoDailyTarget ?? HOURS_SAVED_DEFAULT_DAILY_TARGET,
     schedule: scheduleEntries,
   };
 }
 
-export async function updateHoursSavedSettings(input: {
+type ManualHoursSavedInput = {
+  mode: "manual";
   baseAmount: number;
   schedule: HoursSavedScheduleEntry[];
   now?: Date;
-}): Promise<HoursSavedOverview> {
+  dailyTarget?: number;
+};
+
+type AutoHoursSavedInput = {
+  mode: "auto";
+  baseAmount: number;
+  dailyTarget: number;
+  now?: Date;
+};
+
+export async function updateHoursSavedSettings(
+  input: ManualHoursSavedInput | AutoHoursSavedInput,
+): Promise<HoursSavedOverview> {
   const reference = input.now ?? new Date();
 
   await db.transaction(async (tx) => {
     const executor = tx as unknown as DbExecutor;
-    const state = await ensureState(executor);
+    let state = await ensureState(executor);
 
     const baseSetAt = reference;
+    const stateUpdate: Partial<typeof hoursSavedStates.$inferInsert> = {
+      baseAmount: input.baseAmount,
+      baseSetAt,
+      updatedAt: new Date(),
+    };
+
+    if (input.mode === "auto") {
+      stateUpdate.autoDailyTarget = input.dailyTarget;
+      state = { ...state, autoDailyTarget: input.dailyTarget } as HoursSavedState;
+    } else if (input.dailyTarget !== undefined) {
+      stateUpdate.autoDailyTarget = input.dailyTarget;
+      state = { ...state, autoDailyTarget: input.dailyTarget } as HoursSavedState;
+    }
 
     await executor
       .update(hoursSavedStates)
-      .set({
-        baseAmount: input.baseAmount,
-        baseSetAt,
-        updatedAt: new Date(),
-      })
+      .set(stateUpdate)
       .where(eq(hoursSavedStates.id, state.id));
 
     await executor
@@ -216,18 +450,43 @@ export async function updateHoursSavedSettings(input: {
         ),
       );
 
-    if (input.schedule.length > 0) {
-      const values = input.schedule.map((entry) => ({
-        stateId: state.id,
-        scheduledFor: entry.scheduledFor,
-        amount: entry.amount,
-        updatedAt: new Date(),
-      }));
+    let values: { stateId: string; scheduledFor: Date; amount: number }[] = [];
 
-      await executor.insert(hoursSavedIncrements).values(values);
+    if (input.mode === "manual") {
+      const sortedSchedule = [...input.schedule]
+        .map((entry) => ({
+          scheduledFor: new Date(entry.scheduledFor),
+          amount: entry.amount,
+        }))
+        .sort((a, b) => a.scheduledFor.getTime() - b.scheduledFor.getTime())
+        .filter(
+          (entry) =>
+            entry.scheduledFor.getTime() >= windowStart.getTime() &&
+            entry.scheduledFor.getTime() < windowEnd.getTime(),
+        );
+
+      values = expandHourlySchedule(state.id, sortedSchedule);
+    } else {
+      const target = state.autoDailyTarget ?? input.dailyTarget;
+      values = generateAutomaticSchedule({
+        stateId: state.id,
+        windowStart,
+        windowHours: HOURS_SAVED_WINDOW_HOURS,
+        dailyTarget: target,
+      });
     }
 
-    await ensureUpcomingSchedule(executor, state.id, reference);
+    if (values.length > 0) {
+      const timestamp = new Date();
+      await executor.insert(hoursSavedIncrements).values(
+        values.map((value) => ({
+          ...value,
+          updatedAt: timestamp,
+        })),
+      );
+    }
+
+    await ensureUpcomingSchedule(executor, state, reference);
   });
 
   return getHoursSavedOverview(reference);

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -1258,6 +1258,10 @@
         "label": "Starting amount",
         "helper": "Resets the ticker to this total immediately."
       },
+      "dailyTarget": {
+        "label": "Daily auto-add total",
+        "helper": "Randomly distribute this many hours across each day in the window."
+      },
       "days": {
         "heading": "Plan the next 7 days",
         "helper": "Select a day to edit the hourly increments.",
@@ -1276,7 +1280,9 @@
         "submit": "Push changes",
         "saving": "Saving…",
         "copy": "Copy day",
-        "copyClose": "Close copy"
+        "copyClose": "Close copy",
+        "regenerate": "Regenerate schedule",
+        "regenerating": "Regenerating…"
       },
       "copy": {
         "title": "Copy schedule to other days",
@@ -1290,7 +1296,7 @@
       "status": {
         "success": "Hours saved schedule updated.",
         "error": "We couldn't update the schedule. Try again.",
-        "validation": "Enter a non-negative value for the starting amount and each hour.",
+        "validation": "Enter a non-negative value for the starting amount, daily target, and each hour.",
         "copyValidation": "Select a source day and at least one day to copy to.",
         "copySuccess": "Day copied successfully."
       }

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -1215,6 +1215,10 @@
         "label": "Startwaarde",
         "helper": "Zet de teller direct op dit totaal."
       },
+      "dailyTarget": {
+        "label": "Dagelijkse automatische toevoeging",
+        "helper": "Verdeel dit aantal uren willekeurig over elke dag binnen het venster."
+      },
       "days": {
         "heading": "Plan de komende 7 dagen",
         "helper": "Kies een dag om de uurlijkse toevoegingen aan te passen.",
@@ -1233,7 +1237,9 @@
         "submit": "Wijzigingen doorvoeren",
         "saving": "Bezig…",
         "copy": "Dag kopiëren",
-        "copyClose": "Kopiëren sluiten"
+        "copyClose": "Kopiëren sluiten",
+        "regenerate": "Schema vernieuwen",
+        "regenerating": "Schema wordt vernieuwd…"
       },
       "copy": {
         "title": "Kopieer schema naar andere dagen",
@@ -1247,7 +1253,7 @@
       "status": {
         "success": "Schema voor bespaarde uren bijgewerkt.",
         "error": "Bijwerken is mislukt. Probeer het opnieuw.",
-        "validation": "Voer voor de startwaarde en elk uur een niet-negatieve waarde in.",
+        "validation": "Voer voor startwaarde, dagdoel en elk uur een niet-negatieve waarde in.",
         "copyValidation": "Selecteer een bron-dag en minstens één dag om naar te kopiëren.",
         "copySuccess": "Dag succesvol gekopieerd."
       }


### PR DESCRIPTION
## Summary
- regenerate upcoming hours-saved increments as minute-level drips driven by a stored daily target while keeping historical totals intact
- add a staff dashboard control for the daily auto-add total with an auto-regenerate action that rewrites the upcoming schedule and updates translations
- expose the new target through the API/overview so the homepage ticker and dashboard stay in sync and log the fix for future reference

## Plan
- redesign the hours-saved scheduling helpers to support configurable daily totals and granular increments
- extend the staff dashboard action/UI to accept either manual schedules or an auto-regenerate request with validation and translations
- update the API response/overview consumers and document the resolved issue in WRITE_HERE/FIXES

## Testing
- `pnpm --filter www run lint` *(fails: missing dependency `next-intl` in lint environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa3c6cdd0832aabfe53f9be650a69