### PR TITLE
Refresh header navigation styling

### DIFF
--- a/WRITE_HERE/FIXES/2025-12-01T1130--restore-contact-link-and-active-glow.md
+++ b/WRITE_HERE/FIXES/2025-12-01T1130--restore-contact-link-and-active-glow.md
@@ -1,0 +1,6 @@
+# Restore contact nav link visibility and active glow
+
+- **What:** Ensured the top navigation renders the Contact destination across desktop and mobile link stacks and intensified the active-state glow logic using locale-aware path detection.
+- **Why:** The previous header refresh regressed the visible Contact entry and the requested blue highlight was barely noticeable when selecting a page.
+- **Files:** `apps/www/components/navbar/link.tsx`, `apps/www/components/navbar/navigation.tsx`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/UPDATES/2025-12-01T0900--header-navigation-refresh.md
+++ b/WRITE_HERE/UPDATES/2025-12-01T0900--header-navigation-refresh.md
@@ -1,0 +1,18 @@
+# Header navigation refresh
+
+## What
+- Added a Home entry to the desktop navigation and refreshed link styling for a brighter consultancy look.
+- Introduced a quick settings popover anchored to a grey menu button that houses the language selector.
+- Applied a blue glow to the active navigation item to emphasize the current page.
+
+## Why
+- Align the header layout and treatments with the requested SaaS-style navigation updates while relocating the language control into a dedicated settings affordance.
+
+## Files
+- apps/www/components/navbar/navigation.tsx
+- apps/www/components/navbar/link.tsx
+- apps/www/messages/en.json
+- apps/www/messages/nl.json
+
+## Follow-ups
+- Populate the quick settings menu with additional options once they are defined.

--- a/apps/www/components/navbar/link.tsx
+++ b/apps/www/components/navbar/link.tsx
@@ -1,15 +1,14 @@
 "use client";
-import { Link, useRouter } from "@/i18n/navigation";
+import { Link, usePathname, useRouter } from "@/i18n/navigation";
+import { locales } from "@/i18n/routing";
 import { cn } from "@/lib/utils";
-import { useSelectedLayoutSegment } from "next/navigation";
 
 type Props = { href: string; label: string; external?: boolean };
 
 export const DesktopNavLink: React.FC<Props> = ({ href, label, external }) => {
-  const segment = useSelectedLayoutSegment();
-  const isActive = segment
-    ? href.startsWith(`/${segment}`)
-    : href === "/";
+  const pathname = usePathname();
+  const normalizedPathname = getNormalizedPathname(pathname);
+  const isActive = isPathActive(normalizedPathname, href);
 
   return (
     <Link
@@ -17,13 +16,21 @@ export const DesktopNavLink: React.FC<Props> = ({ href, label, external }) => {
       target={external ? "_blank" : undefined}
       rel={external ? "noopener noreferrer" : undefined}
       className={cn(
-        "text-white/50 hover:text-white/90 duration-200 text-sm tracking-[0.07px]",
-        {
-          "text-white": isActive,
-        },
+        "group relative inline-flex items-center rounded-full border border-white/10 px-5 py-2 text-[15px] font-medium tracking-[0.04em] text-white/70 transition-all duration-300 ease-out backdrop-blur-sm",
+        "hover:border-sky-400/30 hover:text-white",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black",
+        isActive ? "border-sky-400/50 bg-sky-500/10 text-white" : undefined,
       )}
+      aria-current={isActive ? "page" : undefined}
     >
-      {label}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute -inset-2 rounded-full bg-sky-500/35 opacity-0 blur-2xl transition duration-300 ease-out",
+          isActive ? "opacity-100" : "group-hover:opacity-40",
+        )}
+      />
+      <span className="relative z-10 tracking-[0.04em]">{label}</span>
     </Link>
   );
 };
@@ -34,12 +41,10 @@ export function MobileNavLink({
   external,
   onClick,
 }: { href: string; label: string; external?: boolean; onClick: () => void }) {
-  const segment = useSelectedLayoutSegment();
+  const pathname = usePathname();
   const router = useRouter();
-
-  const isActive = segment
-    ? href.startsWith(`/${segment}`)
-    : href === "/";
+  const normalizedPathname = getNormalizedPathname(pathname);
+  const isActive = isPathActive(normalizedPathname, href);
 
   return (
     <button
@@ -63,4 +68,39 @@ export function MobileNavLink({
       {label}
     </button>
   );
+}
+
+function getNormalizedPathname(pathname: string | null) {
+  if (!pathname) {
+    return "/";
+  }
+
+  const trimmedPathname =
+    pathname.length > 1 && pathname.endsWith("/")
+      ? pathname.slice(0, -1)
+      : pathname;
+
+  const localeStrippedPath = locales.reduce((current, code) => {
+    const prefix = `/${code}`;
+
+    if (current === prefix) {
+      return "/";
+    }
+
+    if (current.startsWith(`${prefix}/`)) {
+      return current.slice(prefix.length) || "/";
+    }
+
+    return current;
+  }, trimmedPathname);
+
+  return localeStrippedPath.length === 0 ? "/" : localeStrippedPath;
+}
+
+function isPathActive(currentPath: string, href: string) {
+  if (href === "/") {
+    return currentPath === "/";
+  }
+
+  return currentPath === href || currentPath.startsWith(`${href}/`);
 }

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -21,6 +21,7 @@ import {
   ChevronDown,
   ChevronRight,
   LogIn,
+  MoreVertical,
   UserPlus,
   UsersRound,
   type LucideIcon,
@@ -168,7 +169,7 @@ export function Navigation() {
           homeAriaLabel={t("ariaHome")}
         />
       ) : (
-        <div className="container flex items-center justify-between">
+        <div className="container flex items-center justify-between gap-6">
           <div className="flex items-center justify-between w-full sm:w-auto sm:gap-12 lg:gap-20">
             <Link href="/" aria-label={t("ariaHome")} className="block shrink-0">
               <Logo scale={logoScale} />
@@ -177,9 +178,9 @@ export function Navigation() {
             <DesktopLinks className="hidden lg:flex" />
           </div>
           <div className="hidden sm:flex items-center gap-3 md:gap-4">
-            <LanguageSwitcher className="hidden md:flex" />
             <MembersMenu className="flex-shrink-0" />
             <ScheduleCallButton className="flex-shrink-0" />
+            <SettingsMenu className="flex-shrink-0" />
           </div>
         </div>
       )}
@@ -264,6 +265,56 @@ function LoggedInNavLink({
         </span>
       ) : null}
     </span>
+  );
+}
+
+function SettingsMenu({ className }: { className?: string }) {
+  const t = useTranslations("Navigation");
+  const [open, setOpen] = useState(false);
+  const contentId = "navigation-settings";
+
+  return (
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+      <PopoverPrimitive.Trigger asChild>
+        <button
+          type="button"
+          aria-label={t("settingsMenu.triggerLabel")}
+          aria-controls={contentId}
+          aria-expanded={open}
+          aria-haspopup="menu"
+          className={cn(
+            "relative inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/12 bg-white/10 text-white/70",
+            "transition-colors duration-200 hover:bg-white/15 hover:text-white",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black",
+            "data-[state=open]:border-white/20 data-[state=open]:bg-white/15 data-[state=open]:text-white",
+            className,
+          )}
+        >
+          <MoreVertical className="h-4 w-4" aria-hidden="true" />
+          <span className="sr-only">{t("settingsMenu.triggerLabel")}</span>
+        </button>
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Content
+        align="end"
+        sideOffset={16}
+        id={contentId}
+        className={cn(
+          "z-[120] w-56 rounded-2xl border border-white/12 bg-black/85 p-4 shadow-lg shadow-sky-500/15 backdrop-blur-xl",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out",
+          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        )}
+      >
+        <div role="menu" aria-label={t("settingsMenu.aria")} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-2">
+            <p className="px-1 text-[10px] font-semibold uppercase tracking-[0.32em] text-white/40">
+              {t("language")}
+            </p>
+            <LanguageSwitcher className="w-full justify-between text-sm text-white/80" />
+          </div>
+        </div>
+      </PopoverPrimitive.Content>
+    </PopoverPrimitive.Root>
   );
 }
 
@@ -594,6 +645,13 @@ function ScheduleCallButton({
 function MobileLinks({ className }: { className?: string }) {
   const [isOpen, setIsOpen] = useState(false);
   const t = useTranslations("Navigation");
+  const primaryLinks = [
+    { key: "home", href: "/", label: t("links.home") },
+    { key: "about", href: "/about", label: t("links.about") },
+    { key: "blog", href: "/blog", label: t("links.blog") },
+    { key: "solutions", href: "/pricing", label: t("links.pricing") },
+    { key: "contact", href: "/contact", label: t("links.contact") },
+  ];
   return (
     <div className={className}>
       <Drawer open={isOpen} onOpenChange={setIsOpen}>
@@ -613,37 +671,15 @@ function MobileLinks({ className }: { className?: string }) {
           </DrawerHeader>
           <div className="relative w-full mx-auto antialiased z-[110]">
             <ul className="flex flex-col px-8 divide-y divide-white/25">
-              <li>
-                <MobileNavLink onClick={() => setIsOpen(false)} href="/" label={t("links.home")} />
-              </li>
-              <li>
-                <MobileNavLink
-                  onClick={() => setIsOpen(false)}
-                  href="/about"
-                  label={t("links.about")}
-                />
-              </li>
-              <li>
-                <MobileNavLink
-                  onClick={() => setIsOpen(false)}
-                  href="/blog"
-                  label={t("links.blog")}
-                />
-              </li>
-              <li>
-                <MobileNavLink
-                  onClick={() => setIsOpen(false)}
-                  href="/pricing"
-                  label={t("links.pricing")}
-                />
-              </li>
-              <li>
-                <MobileNavLink
-                  onClick={() => setIsOpen(false)}
-                  href="/contact"
-                  label={t("links.contact")}
-                />
-              </li>
+              {primaryLinks.map((item) => (
+                <li key={item.key}>
+                  <MobileNavLink
+                    onClick={() => setIsOpen(false)}
+                    href={item.href}
+                    label={item.label}
+                  />
+                </li>
+              ))}
             </ul>
           </div>
           <DrawerFooter>
@@ -673,21 +709,21 @@ function MobileLinks({ className }: { className?: string }) {
 
 function DesktopLinks({ className }: { className: string }) {
   const t = useTranslations("Navigation");
+  const primaryLinks = [
+    { key: "home", href: "/", label: t("links.home") },
+    { key: "about", href: "/about", label: t("links.about") },
+    { key: "blog", href: "/blog", label: t("links.blog") },
+    { key: "solutions", href: "/pricing", label: t("links.pricing") },
+    { key: "contact", href: "/contact", label: t("links.contact") },
+  ];
 
   return (
-    <ul className={cn("items-center hidden gap-8 lg:flex xl:gap-12", className)}>
-      <li>
-        <DesktopNavLink href="/about" label={t("links.about")} />
-      </li>
-      <li>
-        <DesktopNavLink href="/blog" label={t("links.blog")} />
-      </li>
-      <li>
-        <DesktopNavLink href="/pricing" label={t("links.pricing")} />
-      </li>
-      <li>
-        <DesktopNavLink href="/contact" label={t("links.contact")} />
-      </li>
+    <ul className={cn("hidden items-center gap-6 text-[15px] font-medium lg:flex xl:gap-10", className)}>
+      {primaryLinks.map((item) => (
+        <li key={item.key}>
+          <DesktopNavLink href={item.href} label={item.label} />
+        </li>
+      ))}
     </ul>
   );
 }

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -41,6 +41,10 @@
         "staff": "Staff workspace"
       }
     },
+    "settingsMenu": {
+      "aria": "Quick settings",
+      "triggerLabel": "Open quick settings"
+    },
     "links": {
       "home": "Home",
       "about": "About",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -41,6 +41,10 @@
         "staff": "Teamdashboard"
       }
     },
+    "settingsMenu": {
+      "aria": "Snelle instellingen",
+      "triggerLabel": "Snelle instellingen openen"
+    },
     "links": {
       "home": "Home",
       "about": "Over ons",


### PR DESCRIPTION
## Plan
- Audit the existing navigation layout to understand desktop versus mobile link handling.
- Rework desktop nav link styling to add the requested Home entry and brighter SaaS visual treatment.
- Introduce a quick settings trigger to house the language selector and update translations accordingly.
- Restore the Contact destination and intensify the requested active-state glow treatment.

## Summary
- Added a Home link to the desktop navigation and refreshed spacing so the header reads more balanced.
- Ensured the Contact destination renders across desktop and mobile by centralizing the primary navigation list.
- Updated desktop link styling with pill treatments and a brighter blue glow on the active item for a premium consultancy feel.
- Replaced the inline language selector with a grey quick-settings popover button that now contains the language switcher.

## Testing
- `pnpm --filter www run lint` *(fails: missing next-intl package in lint environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb0e5d9e0832a91f2e0b35a9418d9