### PR TITLE
Fix About page chat CTA redirect

### DIFF
--- a/WRITE_HERE/FIXES/2025-10-03T1140--about-chat-cta-redirect.md
+++ b/WRITE_HERE/FIXES/2025-10-03T1140--about-chat-cta-redirect.md
@@ -1,0 +1,6 @@
+# Fix About chat CTA redirect
+
+- **What**: Updated the About page hero button to open the meeting scheduling experience at TransformAI's chat URL.
+- **Why**: The button incorrectly linked to a blog article, preventing visitors from starting a meeting.
+- **Files**: `apps/www/app/[locale]/(site)/about/page.tsx`
+- **Follow-ups**: None.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -267,7 +267,7 @@ export default async function Page({ params }: PageProps) {
             </div>
           </div>
           <div className="mt-12">
-            <Link href="/blog/introducing-ratelimiting" target="">
+            <Link href="http://localhost:3002/en/meeting" target="">
               <RainbowDarkButton label={heroCta} IconRight={ArrowRight} />
             </Link>
             <SectionTitle


### PR DESCRIPTION
## Plan
- Inspect the About page hero CTA to confirm the current destination.
- Update the CTA to route users to the meeting scheduling experience.
- Capture the bug fix in the FIXES log for project history.

## Summary
- Pointed the About page "Chat with us" button at the meeting scheduler URL so visitors can book directly.
- Logged the change in WRITE_HERE/FIXES for traceability.

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfb60c3f4c832ab8036f212ed2cc01