### PR TITLE
Make About page chat CTA locale-aware

### DIFF
--- a/WRITE_HERE/FIXES/2025-10-03T1140--about-chat-cta-redirect.md
+++ b/WRITE_HERE/FIXES/2025-10-03T1140--about-chat-cta-redirect.md
@@ -1,0 +1,6 @@
+# Fix About chat CTA redirect
+
+- **What**: Updated the About page hero button to open the meeting scheduling experience at TransformAI's chat URL.
+- **Why**: The button incorrectly linked to a blog article, preventing visitors from starting a meeting.
+- **Files**: `apps/www/app/[locale]/(site)/about/page.tsx`
+- **Follow-ups**: None.

--- a/WRITE_HERE/FIXES/2025-10-03T1210--about-chat-cta-relative-path.md
+++ b/WRITE_HERE/FIXES/2025-10-03T1210--about-chat-cta-relative-path.md
@@ -1,0 +1,6 @@
+# Make About chat CTA locale-aware
+
+- **What**: Pointed the About page hero "Chat with us" button to the relative `/meeting` route so Next.js applies the active locale automatically.
+- **Why**: The previous localhost-bound link broke in production and forced English even for Dutch visitors.
+- **Files**: `apps/www/app/[locale]/(site)/about/page.tsx`
+- **Follow-ups**: None.

--- a/apps/www/app/[locale]/(site)/about/page.tsx
+++ b/apps/www/app/[locale]/(site)/about/page.tsx
@@ -267,7 +267,7 @@ export default async function Page({ params }: PageProps) {
             </div>
           </div>
           <div className="mt-12">
-            <Link href="/blog/introducing-ratelimiting" target="">
+            <Link href="/meeting" target="">
               <RainbowDarkButton label={heroCta} IconRight={ArrowRight} />
             </Link>
             <SectionTitle


### PR DESCRIPTION
## Plan
- Verify the About page hero CTA still points at the hard-coded localhost meeting URL.
- Update the CTA to use the relative `/meeting` route so Next.js applies the active locale.
- Record the follow-up fix in the WRITE_HERE/FIXES log.

## Summary
- Swapped the About page "Chat with us" button to link to `/meeting`, letting the locale middleware handle Dutch and English visitors correctly.
- Documented the change with a new WRITE_HERE/FIXES entry.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfb60c3f4c832ab8036f212ed2cc01