### PR TITLE
Fix hero hours-saved ticker hydration mismatch

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-30T2100--hero-hours-saved-hydration.md
+++ b/WRITE_HERE/FIXES/2025-11-30T2100--hero-hours-saved-hydration.md
@@ -1,0 +1,6 @@
+# Stabilized hero hours-saved ticker hydration
+
+- **What:** Passed the server-formatted hours-saved total into the hero ticker and deferred client-side number formatting until after hydration so the initial markup stays consistent across environments.
+- **Why:** The ticker formatted values with Intl during SSR and again in the browser, which could diverge for locales with different ICU data and triggered hydration errors.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `apps/www/components/hero/hero.tsx`, `apps/www/components/hero/hero-main-section.tsx`, `apps/www/components/hero/hours-saved-ticker.tsx`.
+- **Follow-ups:** Consider reusing the deferred-formatting pattern anywhere client components still rely on Intl for initial renders.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -115,6 +115,7 @@ export default async function Landing({
   ]);
 
   const hoursSavedOverview = await getHoursSavedOverview();
+  const hoursSavedInitialFormatted = hoursSavedOverview.currentAmount.toLocaleString(locale);
 
   const featureBoxes = [
     { key: "futureProofWorkforce", icon: GraduationCap },
@@ -151,6 +152,7 @@ export default async function Landing({
           <Section>
             <Hero
               initialHoursSavedAmount={hoursSavedOverview.currentAmount}
+              initialHoursSavedFormatted={hoursSavedInitialFormatted}
               initialHoursSavedNextUpdateAt={
                 hoursSavedOverview.nextUpdateAt
                   ? hoursSavedOverview.nextUpdateAt.toISOString()

--- a/apps/www/components/hero/hero-main-section.tsx
+++ b/apps/www/components/hero/hero-main-section.tsx
@@ -14,6 +14,7 @@ type HeroMainSectionProps = {
   secondaryCtaHref: string;
   hoursSavedLabel: string;
   hoursSavedInitialAmount: number;
+  hoursSavedInitialFormatted: string;
   hoursSavedNextUpdateAt: string | null;
   locale: string;
 };
@@ -27,6 +28,7 @@ export function HeroMainSection({
   secondaryCtaHref,
   hoursSavedLabel,
   hoursSavedInitialAmount,
+  hoursSavedInitialFormatted,
   hoursSavedNextUpdateAt,
   locale,
 }: HeroMainSectionProps) {
@@ -54,6 +56,7 @@ export function HeroMainSection({
           <span className="text-white/40">:</span>
           <HoursSavedTicker
             initialAmount={hoursSavedInitialAmount}
+            initialFormattedAmount={hoursSavedInitialFormatted}
             initialNextUpdateAt={hoursSavedNextUpdateAt}
             locale={locale}
             className="text-sm tracking-[0.2em] text-white sm:text-base"

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -8,11 +8,13 @@ import mainboard from "@/images/mainboard.svg";
 import { SubHeroMainboard } from "./hero-sub-mainboard";
 type HeroProps = {
   initialHoursSavedAmount: number;
+  initialHoursSavedFormatted: string;
   initialHoursSavedNextUpdateAt: string | null;
 };
 
 export const Hero: React.FC<HeroProps> = ({
   initialHoursSavedAmount,
+  initialHoursSavedFormatted,
   initialHoursSavedNextUpdateAt,
 }) => {
   const hero = useTranslations("Hero");
@@ -47,18 +49,19 @@ export const Hero: React.FC<HeroProps> = ({
       animate="visible"
     >
       <motion.div variants={childVariants}>
-        <HeroMainSection
-          title={hero("title")}
-          body={hero("body")}
-          primaryCtaLabel={cta("getStarted")}
-          primaryCtaHref={meetingHref}
-          secondaryCtaLabel={cta("exploreProjects")}
-          secondaryCtaHref={solutionsHref}
-          hoursSavedLabel={cta("hoursSavedLabel")}
-          hoursSavedInitialAmount={initialHoursSavedAmount}
-          hoursSavedNextUpdateAt={initialHoursSavedNextUpdateAt}
-          locale={locale}
-        />
+          <HeroMainSection
+            title={hero("title")}
+            body={hero("body")}
+            primaryCtaLabel={cta("getStarted")}
+            primaryCtaHref={meetingHref}
+            secondaryCtaLabel={cta("exploreProjects")}
+            secondaryCtaHref={solutionsHref}
+            hoursSavedLabel={cta("hoursSavedLabel")}
+            hoursSavedInitialAmount={initialHoursSavedAmount}
+            hoursSavedInitialFormatted={initialHoursSavedFormatted}
+            hoursSavedNextUpdateAt={initialHoursSavedNextUpdateAt}
+            locale={locale}
+          />
       </motion.div>
 
       <div

--- a/apps/www/components/hero/hours-saved-ticker.tsx
+++ b/apps/www/components/hero/hours-saved-ticker.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 
 type HoursSavedTickerProps = {
   initialAmount: number;
+  initialFormattedAmount: string;
   initialNextUpdateAt: string | null;
   locale: string;
   className?: string;
@@ -19,12 +20,19 @@ type HoursSavedState = {
 
 const FALLBACK_REFRESH_INTERVAL_MS = 60_000;
 
-export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, className }: HoursSavedTickerProps) {
+export function HoursSavedTicker({
+  initialAmount,
+  initialFormattedAmount,
+  initialNextUpdateAt,
+  locale,
+  className,
+}: HoursSavedTickerProps) {
   const [state, setState] = useState<HoursSavedState>({
     amount: initialAmount,
     nextUpdateAt: initialNextUpdateAt,
   });
-  const [displayValue, setDisplayValue] = useState(initialAmount);
+  const [displayAmount, setDisplayAmount] = useState(initialAmount);
+  const [isHydrated, setIsHydrated] = useState(false);
   const reducedMotion = useReducedMotion();
   const [scope, animateScope] = useAnimate<HTMLSpanElement>();
   const isInView = useInView(scope, { margin: "-10% 0px", amount: 0.6 });
@@ -33,11 +41,20 @@ export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, c
   const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fetchLatestRef = useRef<(() => Promise<void>) | null>(null);
   const didRunInitialFetchRef = useRef(false);
+  const initialFormattedRef = useRef(initialFormattedAmount);
 
   const updateDisplayValue = useCallback((value: number) => {
     displayAmountRef.current = value;
-    setDisplayValue(value);
+    setDisplayAmount(value);
   }, []);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    initialFormattedRef.current = initialFormattedAmount;
+  }, [initialFormattedAmount]);
 
   const cancelAnimation = useCallback(() => {
     if (animationTimeoutRef.current) {
@@ -223,8 +240,21 @@ export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, c
     void fetchLatestRef.current?.();
   }, [isInView]);
 
-  const formatter = useMemo(() => new Intl.NumberFormat(locale), [locale]);
-  const formatted = formatter.format(displayValue);
+  const formatter = useMemo(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    return new Intl.NumberFormat(locale);
+  }, [locale]);
+
+  const formatted = useMemo(() => {
+    if (isHydrated) {
+      return formatter?.format(displayAmount) ?? displayAmount.toLocaleString();
+    }
+
+    return initialFormattedRef.current;
+  }, [displayAmount, formatter, isHydrated]);
 
   return (
     <span ref={scope} className={cn("inline-flex items-center font-medium text-white", className)} aria-live="polite">


### PR DESCRIPTION
## Summary
- Pass the server-formatted hours-saved total into the hero ticker so the initial markup matches the server render
- Thread the formatted value through the hero components and hydrate-safe ticker props
- Defer client-side Intl formatting until after hydration to avoid locale-dependent mismatches

## Plan
- Audit the hero ticker to identify locale-sensitive formatting done during render
- Surface the preformatted hours-saved string from the landing page to the hero components
- Update the ticker to wait for hydration before invoking Intl so hydration sees identical markup

## Testing
- pnpm --filter www lint *(fails: next lint cannot resolve `next-intl` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb5db049c832a8094e56bb40a527b