### PR TITLE
Align hero ticker formatting locale

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-30T2100--hero-hours-saved-hydration.md
+++ b/WRITE_HERE/FIXES/2025-11-30T2100--hero-hours-saved-hydration.md
@@ -1,0 +1,6 @@
+# Stabilized hero hours-saved ticker hydration
+
+- **What:** Passed the server-formatted hours-saved total into the hero ticker and deferred client-side number formatting until after hydration so the initial markup stays consistent across environments.
+- **Why:** The ticker formatted values with Intl during SSR and again in the browser, which could diverge for locales with different ICU data and triggered hydration errors.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `apps/www/components/hero/hero.tsx`, `apps/www/components/hero/hero-main-section.tsx`, `apps/www/components/hero/hours-saved-ticker.tsx`.
+- **Follow-ups:** Consider reusing the deferred-formatting pattern anywhere client components still rely on Intl for initial renders.

--- a/WRITE_HERE/FIXES/2025-11-30T2200--hero-hours-saved-suppressed-hydration-warning.md
+++ b/WRITE_HERE/FIXES/2025-11-30T2200--hero-hours-saved-suppressed-hydration-warning.md
@@ -1,0 +1,5 @@
+# Suppressed hero ticker hydration error overlay
+- **What:** Added `suppressHydrationWarning` to the hero hours-saved ticker span so hydration mismatches no longer surface a blocking runtime overlay.
+- **Why:** The ticker still drifts between server and client values, and the user requested hiding the hydration error from appearing on the site while a deeper fix is deferred.
+- **Files:** `apps/www/components/hero/hours-saved-ticker.tsx`.
+- **Follow-ups:** Revisit the ticker formatting strategy to eliminate server/client divergence without relying on suppression.

--- a/WRITE_HERE/FIXES/2025-11-30T2300--hero-hours-saved-aligned-intl-format.md
+++ b/WRITE_HERE/FIXES/2025-11-30T2300--hero-hours-saved-aligned-intl-format.md
@@ -1,0 +1,6 @@
+# Align hero hours-saved formatter locale
+
+- **What:** Reused the server-resolved `Intl.NumberFormat` locale for the hero ticker, threading it through the hero props and removing the hydration warning suppression attribute.
+- **Why:** The server and browser were formatting the ticker total with different locales, leading to a persistent hydration mismatch warning on refresh.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `apps/www/components/hero/hero.tsx`, `apps/www/components/hero/hero-main-section.tsx`, `apps/www/components/hero/hours-saved-ticker.tsx`.
+- **Follow-ups:** None—monitor for future locale additions to ensure formatter locale is still threaded through.

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -115,6 +115,11 @@ export default async function Landing({
   ]);
 
   const hoursSavedOverview = await getHoursSavedOverview();
+  const hoursSavedFormatter = new Intl.NumberFormat(locale);
+  const hoursSavedInitialFormatted = hoursSavedFormatter.format(
+    hoursSavedOverview.currentAmount,
+  );
+  const hoursSavedInitialFormatterLocale = hoursSavedFormatter.resolvedOptions().locale;
 
   const featureBoxes = [
     { key: "futureProofWorkforce", icon: GraduationCap },
@@ -151,6 +156,8 @@ export default async function Landing({
           <Section>
             <Hero
               initialHoursSavedAmount={hoursSavedOverview.currentAmount}
+              initialHoursSavedFormatted={hoursSavedInitialFormatted}
+              initialHoursSavedFormatterLocale={hoursSavedInitialFormatterLocale}
               initialHoursSavedNextUpdateAt={
                 hoursSavedOverview.nextUpdateAt
                   ? hoursSavedOverview.nextUpdateAt.toISOString()

--- a/apps/www/components/hero/hero-main-section.tsx
+++ b/apps/www/components/hero/hero-main-section.tsx
@@ -14,6 +14,8 @@ type HeroMainSectionProps = {
   secondaryCtaHref: string;
   hoursSavedLabel: string;
   hoursSavedInitialAmount: number;
+  hoursSavedInitialFormatted: string;
+  hoursSavedInitialFormatterLocale: string;
   hoursSavedNextUpdateAt: string | null;
   locale: string;
 };
@@ -27,6 +29,8 @@ export function HeroMainSection({
   secondaryCtaHref,
   hoursSavedLabel,
   hoursSavedInitialAmount,
+  hoursSavedInitialFormatted,
+  hoursSavedInitialFormatterLocale,
   hoursSavedNextUpdateAt,
   locale,
 }: HeroMainSectionProps) {
@@ -54,6 +58,8 @@ export function HeroMainSection({
           <span className="text-white/40">:</span>
           <HoursSavedTicker
             initialAmount={hoursSavedInitialAmount}
+            initialFormattedAmount={hoursSavedInitialFormatted}
+            initialFormattedLocale={hoursSavedInitialFormatterLocale}
             initialNextUpdateAt={hoursSavedNextUpdateAt}
             locale={locale}
             className="text-sm tracking-[0.2em] text-white sm:text-base"

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -8,11 +8,15 @@ import mainboard from "@/images/mainboard.svg";
 import { SubHeroMainboard } from "./hero-sub-mainboard";
 type HeroProps = {
   initialHoursSavedAmount: number;
+  initialHoursSavedFormatted: string;
+  initialHoursSavedFormatterLocale: string;
   initialHoursSavedNextUpdateAt: string | null;
 };
 
 export const Hero: React.FC<HeroProps> = ({
   initialHoursSavedAmount,
+  initialHoursSavedFormatted,
+  initialHoursSavedFormatterLocale,
   initialHoursSavedNextUpdateAt,
 }) => {
   const hero = useTranslations("Hero");
@@ -47,18 +51,20 @@ export const Hero: React.FC<HeroProps> = ({
       animate="visible"
     >
       <motion.div variants={childVariants}>
-        <HeroMainSection
-          title={hero("title")}
-          body={hero("body")}
-          primaryCtaLabel={cta("getStarted")}
-          primaryCtaHref={meetingHref}
-          secondaryCtaLabel={cta("exploreProjects")}
-          secondaryCtaHref={solutionsHref}
-          hoursSavedLabel={cta("hoursSavedLabel")}
-          hoursSavedInitialAmount={initialHoursSavedAmount}
-          hoursSavedNextUpdateAt={initialHoursSavedNextUpdateAt}
-          locale={locale}
-        />
+          <HeroMainSection
+            title={hero("title")}
+            body={hero("body")}
+            primaryCtaLabel={cta("getStarted")}
+            primaryCtaHref={meetingHref}
+            secondaryCtaLabel={cta("exploreProjects")}
+            secondaryCtaHref={solutionsHref}
+            hoursSavedLabel={cta("hoursSavedLabel")}
+            hoursSavedInitialAmount={initialHoursSavedAmount}
+            hoursSavedInitialFormatted={initialHoursSavedFormatted}
+            hoursSavedInitialFormatterLocale={initialHoursSavedFormatterLocale}
+            hoursSavedNextUpdateAt={initialHoursSavedNextUpdateAt}
+            locale={locale}
+          />
       </motion.div>
 
       <div

--- a/apps/www/components/hero/hours-saved-ticker.tsx
+++ b/apps/www/components/hero/hours-saved-ticker.tsx
@@ -7,6 +7,8 @@ import { cn } from "@/lib/utils";
 
 type HoursSavedTickerProps = {
   initialAmount: number;
+  initialFormattedAmount: string;
+  initialFormattedLocale: string;
   initialNextUpdateAt: string | null;
   locale: string;
   className?: string;
@@ -19,12 +21,20 @@ type HoursSavedState = {
 
 const FALLBACK_REFRESH_INTERVAL_MS = 60_000;
 
-export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, className }: HoursSavedTickerProps) {
+export function HoursSavedTicker({
+  initialAmount,
+  initialFormattedAmount,
+  initialFormattedLocale,
+  initialNextUpdateAt,
+  locale,
+  className,
+}: HoursSavedTickerProps) {
   const [state, setState] = useState<HoursSavedState>({
     amount: initialAmount,
     nextUpdateAt: initialNextUpdateAt,
   });
-  const [displayValue, setDisplayValue] = useState(initialAmount);
+  const [displayAmount, setDisplayAmount] = useState(initialAmount);
+  const [isHydrated, setIsHydrated] = useState(false);
   const reducedMotion = useReducedMotion();
   const [scope, animateScope] = useAnimate<HTMLSpanElement>();
   const isInView = useInView(scope, { margin: "-10% 0px", amount: 0.6 });
@@ -33,11 +43,20 @@ export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, c
   const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fetchLatestRef = useRef<(() => Promise<void>) | null>(null);
   const didRunInitialFetchRef = useRef(false);
+  const initialFormattedRef = useRef(initialFormattedAmount);
 
   const updateDisplayValue = useCallback((value: number) => {
     displayAmountRef.current = value;
-    setDisplayValue(value);
+    setDisplayAmount(value);
   }, []);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    initialFormattedRef.current = initialFormattedAmount;
+  }, [initialFormattedAmount]);
 
   const cancelAnimation = useCallback(() => {
     if (animationTimeoutRef.current) {
@@ -223,11 +242,28 @@ export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, c
     void fetchLatestRef.current?.();
   }, [isInView]);
 
-  const formatter = useMemo(() => new Intl.NumberFormat(locale), [locale]);
-  const formatted = formatter.format(displayValue);
+  const formatter = useMemo(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    return new Intl.NumberFormat(initialFormattedLocale ?? locale);
+  }, [initialFormattedLocale, locale]);
+
+  const formatted = useMemo(() => {
+    if (isHydrated) {
+      return formatter?.format(displayAmount) ?? displayAmount.toLocaleString();
+    }
+
+    return initialFormattedRef.current;
+  }, [displayAmount, formatter, isHydrated]);
 
   return (
-    <span ref={scope} className={cn("inline-flex items-center font-medium text-white", className)} aria-live="polite">
+    <span
+      ref={scope}
+      className={cn("inline-flex items-center font-medium text-white", className)}
+      aria-live="polite"
+    >
       {formatted}
     </span>
   );


### PR DESCRIPTION
## Summary
- align the server and client hour ticker formatting by reusing the resolved Intl locale when rendering the hero
- thread the formatter locale through the hero composition and drop the hydration warning suppression flag on the ticker span
- log the hydration fix in WRITE_HERE/FIXES for future reference

## Plan
- capture the formatter locale produced by Intl.NumberFormat on the server
- pass that locale through the hero props into the hours-saved ticker
- format ticker updates with the shared locale after hydration so the markup stays identical

## Testing
- pnpm --filter www run lint *(fails: Next.js lint cannot resolve the missing `next-intl` package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb5db049c832a8094e56bb40a527b