### PR TITLE
Use configured base URL instead of localhost fallbacks

### DIFF
--- a/WRITE_HERE/FIXES/2025-12-01T1600--removed-localhost-base-urls.md
+++ b/WRITE_HERE/FIXES/2025-12-01T1600--removed-localhost-base-urls.md
@@ -1,0 +1,6 @@
+# Removed localhost base URL fallbacks
+
+- **What**: Replaced hard-coded `http://localhost` fallbacks used for social sharing, sitemap generation, and the footer meeting link with domain-agnostic URLs powered by the configured `NEXT_PUBLIC_BASE_URL`. Also updated the playground API proxy helper to respect environment URLs instead of forcing localhost.
+- **Why**: Localhost defaults were leaking into production redirects and share links, causing broken navigation whenever the deployed hostname differed from the development environment.
+- **Files**: `apps/www/components/changelog/changelog-grid-item.tsx`, `apps/www/app/sitemap.ts`, `apps/www/components/footer/footer.tsx`, `apps/www/app/[locale]/(site)/templates/[slug]/opengraph-image.tsx`, `apps/www/app/[locale]/(site)/templates/[slug]/twitter-image.tsx`, `apps/www/app/[locale]/(site)/careers/[slug]/opengraph-image.tsx`, `apps/www/app/[locale]/(site)/careers/[slug]/twitter-image.tsx`, `apps/play/app/page.tsx`.
+- **Follow-ups**: Ensure `NEXT_PUBLIC_BASE_URL` is set to the production domain in each environment.

--- a/apps/play/app/page.tsx
+++ b/apps/play/app/page.tsx
@@ -18,13 +18,26 @@ function getBaseUrl() {
     return "";
   }
 
+  const envBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  if (envBaseUrl) {
+    try {
+      return new URL(envBaseUrl).origin;
+    } catch {
+      return envBaseUrl;
+    }
+  }
+
   if (process.env.NEXT_PUBLIC_VERCEL_URL) {
     // reference for vercel.com
     return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`;
   }
 
-  // assume localhost
-  return `http://localhost:${process.env.PORT ?? 3000}`;
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+
+  // Fallback to relative requests when no host information is available.
+  return "";
 }
 
 const API_UNKEY_DEV_V2 = "https://api.unkey.com/v2/";

--- a/apps/www/app/[locale]/(site)/careers/[slug]/opengraph-image.tsx
+++ b/apps/www/app/[locale]/(site)/careers/[slug]/opengraph-image.tsx
@@ -8,9 +8,6 @@ const truncate = (str: string | null, length: number) => {
 };
 
 export const contentType = "image/png";
-const _baseUrl = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}`
-  : "http://localhost:3000";
 export default async function Image({ params }: { params: { slug: string } }) {
   try {
     // const satoshiBold = await fetch(new URL("@/styles/Satoshi-Bold.ttf", import.meta.url)).then(

--- a/apps/www/app/[locale]/(site)/careers/[slug]/twitter-image.tsx
+++ b/apps/www/app/[locale]/(site)/careers/[slug]/twitter-image.tsx
@@ -8,9 +8,6 @@ const truncate = (str: string | null, length: number) => {
 };
 
 export const contentType = "image/png";
-const _baseUrl = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}`
-  : "http://localhost:3000";
 export default async function Image({ params }: { params: { slug: string } }) {
   try {
     // const satoshiBold = await fetch(new URL("@/styles/Satoshi-Bold.ttf", import.meta.url)).then(

--- a/apps/www/app/[locale]/(site)/templates/[slug]/opengraph-image.tsx
+++ b/apps/www/app/[locale]/(site)/templates/[slug]/opengraph-image.tsx
@@ -8,9 +8,6 @@ const truncate = (str: string | null, length: number) => {
 };
 
 export const contentType = "image/png";
-const _baseUrl = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}`
-  : "http://localhost:3000";
 export default async function Image({ params }: { params: { slug: string } }) {
   try {
     // const satoshiBold = await fetch(new URL("@/styles/Satoshi-Bold.ttf", import.meta.url)).then(

--- a/apps/www/app/[locale]/(site)/templates/[slug]/twitter-image.tsx
+++ b/apps/www/app/[locale]/(site)/templates/[slug]/twitter-image.tsx
@@ -8,9 +8,6 @@ const truncate = (str: string | null, length: number) => {
 };
 
 export const contentType = "image/png";
-const _baseUrl = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}`
-  : "http://localhost:3000";
 export default async function Image({ params }: { params: { slug: string } }) {
   try {
     // const satoshiBold = await fetch(new URL("@/styles/Satoshi-Bold.ttf", import.meta.url)).then(

--- a/apps/www/app/sitemap.ts
+++ b/apps/www/app/sitemap.ts
@@ -1,56 +1,58 @@
 import { filterProjectPosts } from "@/lib/blog-posts";
+import { env } from "@/lib/env";
 import { allChangelogs, allGlossaries, allPolicies, allPosts } from "content-collections";
 import type { Changelog, Glossary, Policy, Post } from "content-collections";
 import type { MetadataRoute } from "next";
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = "https://www.unkey.com";
+  const baseUrl = new URL(env().NEXT_PUBLIC_BASE_URL);
+  const origin = baseUrl.origin;
 
   const posts: MetadataRoute.Sitemap = filterProjectPosts(allPosts).map((post: Post) => ({
-    url: `${baseUrl}/blog/${post.slug}`,
+    url: `${origin}/blog/${post.slug}`,
     lastModified: post.date,
   }));
 
   const policies: MetadataRoute.Sitemap = allPolicies.map((policy: Policy) => ({
-    url: `${baseUrl}/policies/${policy.slug}`,
+    url: `${origin}/policies/${policy.slug}`,
   }));
 
   const changelogs: MetadataRoute.Sitemap = allChangelogs.map((changelog: Changelog) => ({
-    url: `${baseUrl}/changelog#${changelog.slug}`,
+    url: `${origin}/changelog#${changelog.slug}`,
     lastModified: changelog.date,
   }));
 
   const glossaries: MetadataRoute.Sitemap = allGlossaries.map((glossary: Glossary) => ({
-    url: `${baseUrl}/glossary/${glossary.slug}`,
+    url: `${origin}/glossary/${glossary.slug}`,
     lastModified: glossary.updatedAt,
   }));
 
   return [
     {
-      url: "https://www.unkey.com",
+      url: origin,
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 1,
     },
     {
-      url: "https://www.unkey.com/about",
+      url: `${origin}/about`,
       lastModified: new Date(),
       changeFrequency: "yearly",
       priority: 0.6,
     },
     {
-      url: "https://www.unkey.com/blog",
+      url: `${origin}/blog`,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 1,
     },
     {
-      url: "https://www.unkey.com/changelog",
+      url: `${origin}/changelog`,
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 1,
     },
     {
-      url: "https://www.unkey.com/glossary",
+      url: `${origin}/glossary`,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 1,

--- a/apps/www/components/changelog/changelog-grid-item.tsx
+++ b/apps/www/components/changelog/changelog-grid-item.tsx
@@ -1,6 +1,7 @@
 import { MDX } from "@/components/mdx-content";
 import { Separator } from "@/components/ui/separator";
 import { formatDateUtc } from "@/lib/date";
+import { env } from "@/lib/env";
 import { cn } from "@/lib/utils";
 import type { Changelog } from "content-collections";
 import Link from "next/link";
@@ -13,9 +14,9 @@ type Props = {
 };
 
 export async function ChangelogGridItem({ className, changelog }: Props) {
-  const baseUrl = process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
-    : "http://localhost:3000";
+  const { NEXT_PUBLIC_BASE_URL } = env();
+  const shareTarget = new URL(`/changelog#${changelog.slug}`, NEXT_PUBLIC_BASE_URL);
+  const shareText = encodeURIComponent(`${changelog.title}\n\n${shareTarget.toString()}`);
 
   return (
     <div id={changelog.slug} className={cn("w-full", className)}>
@@ -63,7 +64,7 @@ export async function ChangelogGridItem({ className, changelog }: Props) {
         <MDX code={changelog.mdx} />
         <XShareButton
           className="my-2"
-          url={`https://x.com/intent/post?text=${changelog.title}%0a%0a${baseUrl}/changelog#${changelog.slug}`}
+          url={`https://x.com/intent/post?text=${shareText}`}
         />
       </div>
       <div>

--- a/apps/www/components/footer/footer.tsx
+++ b/apps/www/components/footer/footer.tsx
@@ -57,8 +57,7 @@ const navigation = [
       },
       {
         titleKey: "links.bookCall",
-        href: "http://localhost:3002/en/meeting",
-        external: true,
+        href: "/meeting",
       },
       {
         titleKey: "links.facebook",


### PR DESCRIPTION
## Summary
- update changelog sharing, sitemap generation, and the footer meeting link to use the configured base URL instead of localhost fallbacks
- drop unused localhost defaults from generated OpenGraph/Twitter image routes and document the change in the fixes log
- align the playground API proxy helper with the shared base URL handling so client fetches stay relative when no host is provided

## Plan
- audit the marketing site for localhost-based fallbacks that leak into production URLs
- replace hard-coded hosts with environment-aware or relative alternatives
- confirm remaining references to localhost are limited to documentation or examples
- record the fix and run linting to validate the updated files

## Testing
- `pnpm --filter www run lint` *(fails: missing optional dependency next-intl in this environment)*
- `pnpm --filter unkey-playground run lint` *(fails: command prompts for ESLint config interactively in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb7583f88832ab1d4fad9d9b3899a