### PR TITLE
Redirect chat CTA to internal meeting planner

### DIFF
--- a/WRITE_HERE/FIXES/2025-12-01T1500--chat-cta-meeting-redirect.md
+++ b/WRITE_HERE/FIXES/2025-12-01T1500--chat-cta-meeting-redirect.md
@@ -1,0 +1,13 @@
+# Route Chat CTA to meeting planner
+
+## What
+- Updated the homepage CTA component so the "Chat with us" button links to the localized meeting planner instead of the external Cal.com URL.
+
+## Why
+- The stakeholder asked that the chat CTA always lead visitors to the in-site meeting scheduling flow.
+
+## Files
+- apps/www/components/cta.tsx
+
+## Follow-ups
+- None.

--- a/apps/www/components/cta.tsx
+++ b/apps/www/components/cta.tsx
@@ -23,11 +23,10 @@ export const CTA: React.FC = () => {
         >
           <div className="flex flex-col items-center justify-center gap-6 mt-2 sm:mt-5 sm:flex-row">
             <Link
-              target="_blank"
               onClick={async () => {
                 await track("chat");
               }}
-              href="https://cal.com/team/unkey/user-interview?utm_source=banner&utm_campaign=oss"
+              href={meetingHref}
             >
               <SecondaryButton label={t("primary")} IconRight={CalendarDays} />
             </Link>


### PR DESCRIPTION
## Summary
- Update the homepage CTA so the "Chat with us" button links to the localized meeting planner instead of the external Cal.com flow
- Record the change in the FIXES log for traceability

## Plan
- Review the CTA translations and component usage on the homepage
- Point the chat CTA link at the in-app meeting planner while preserving analytics tracking
- Capture the adjustment in WRITE_HERE/FIXES for future reference

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfd64ed8e4832a81e1e981f218d4b4