### PR TITLE
Serialize hero ticker formatter options

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-30T2100--hero-hours-saved-hydration.md
+++ b/WRITE_HERE/FIXES/2025-11-30T2100--hero-hours-saved-hydration.md
@@ -1,0 +1,6 @@
+# Stabilized hero hours-saved ticker hydration
+
+- **What:** Passed the server-formatted hours-saved total into the hero ticker and deferred client-side number formatting until after hydration so the initial markup stays consistent across environments.
+- **Why:** The ticker formatted values with Intl during SSR and again in the browser, which could diverge for locales with different ICU data and triggered hydration errors.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `apps/www/components/hero/hero.tsx`, `apps/www/components/hero/hero-main-section.tsx`, `apps/www/components/hero/hours-saved-ticker.tsx`.
+- **Follow-ups:** Consider reusing the deferred-formatting pattern anywhere client components still rely on Intl for initial renders.

--- a/WRITE_HERE/FIXES/2025-11-30T2200--hero-hours-saved-suppressed-hydration-warning.md
+++ b/WRITE_HERE/FIXES/2025-11-30T2200--hero-hours-saved-suppressed-hydration-warning.md
@@ -1,0 +1,5 @@
+# Suppressed hero ticker hydration error overlay
+- **What:** Added `suppressHydrationWarning` to the hero hours-saved ticker span so hydration mismatches no longer surface a blocking runtime overlay.
+- **Why:** The ticker still drifts between server and client values, and the user requested hiding the hydration error from appearing on the site while a deeper fix is deferred.
+- **Files:** `apps/www/components/hero/hours-saved-ticker.tsx`.
+- **Follow-ups:** Revisit the ticker formatting strategy to eliminate server/client divergence without relying on suppression.

--- a/WRITE_HERE/FIXES/2025-11-30T2300--hero-hours-saved-aligned-intl-format.md
+++ b/WRITE_HERE/FIXES/2025-11-30T2300--hero-hours-saved-aligned-intl-format.md
@@ -1,0 +1,6 @@
+# Align hero hours-saved formatter locale
+
+- **What:** Reused the server-resolved `Intl.NumberFormat` locale for the hero ticker, threading it through the hero props and removing the hydration warning suppression attribute.
+- **Why:** The server and browser were formatting the ticker total with different locales, leading to a persistent hydration mismatch warning on refresh.
+- **Files:** `apps/www/app/[locale]/(site)/page.tsx`, `apps/www/components/hero/hero.tsx`, `apps/www/components/hero/hero-main-section.tsx`, `apps/www/components/hero/hours-saved-ticker.tsx`.
+- **Follow-ups:** None—monitor for future locale additions to ensure formatter locale is still threaded through.

--- a/WRITE_HERE/FIXES/2025-11-30T2330--hero-hours-saved-resolved-options.md
+++ b/WRITE_HERE/FIXES/2025-11-30T2330--hero-hours-saved-resolved-options.md
@@ -1,0 +1,17 @@
+# Align hero ticker with resolved formatter options
+
+## What
+- serialize the hero hours-saved formatter's resolved options on the server and pass them through the hero props
+- recreate the formatter on the client with the same locale, numbering system, and rounding settings before animating updates
+
+## Why
+- avoid hydration mismatches triggered by environment-specific Intl defaults after refreshing the homepage
+
+## Files
+- apps/www/app/[locale]/(site)/page.tsx
+- apps/www/components/hero/hero.tsx
+- apps/www/components/hero/hero-main-section.tsx
+- apps/www/components/hero/hours-saved-ticker.tsx
+
+## Follow-ups
+- verify future ticker visual refinements continue to reuse the shared formatter options across server and client

--- a/apps/www/app/[locale]/(site)/page.tsx
+++ b/apps/www/app/[locale]/(site)/page.tsx
@@ -7,6 +7,7 @@ import { CTA } from "@/components/cta";
 import { FeatureGrid } from "@/components/feature/feature-grid";
 import { HashedKeysBento } from "@/components/hashed-keys-bento";
 import { Hero } from "@/components/hero/hero";
+import type { HoursSavedNumberFormatOptions } from "@/components/hero/hours-saved-ticker";
 import { ImageWithBlur } from "@/components/image-with-blur";
 import { IpWhitelistingBento } from "@/components/ip-whitelisting-bento";
 import { LatencyBento } from "@/components/latency-bento";
@@ -115,6 +116,37 @@ export default async function Landing({
   ]);
 
   const hoursSavedOverview = await getHoursSavedOverview();
+  const hoursSavedFormatter = new Intl.NumberFormat(locale);
+  const hoursSavedInitialFormatted = hoursSavedFormatter.format(
+    hoursSavedOverview.currentAmount,
+  );
+  const hoursSavedFormatterResolved = hoursSavedFormatter.resolvedOptions();
+  const hoursSavedInitialFormatterLocale = hoursSavedFormatterResolved.locale;
+  const hoursSavedInitialFormatterOptions: HoursSavedNumberFormatOptions = {
+    locale: hoursSavedFormatterResolved.locale,
+    numberingSystem: hoursSavedFormatterResolved.numberingSystem,
+    style: hoursSavedFormatterResolved.style,
+    currency: hoursSavedFormatterResolved.currency,
+    currencyDisplay: hoursSavedFormatterResolved.currencyDisplay,
+    currencySign: hoursSavedFormatterResolved.currencySign,
+    unit: hoursSavedFormatterResolved.unit,
+    unitDisplay: hoursSavedFormatterResolved.unitDisplay,
+    notation: hoursSavedFormatterResolved.notation,
+    compactDisplay: hoursSavedFormatterResolved.compactDisplay,
+    signDisplay: hoursSavedFormatterResolved.signDisplay,
+    useGrouping: hoursSavedFormatterResolved.useGrouping,
+    minimumIntegerDigits: hoursSavedFormatterResolved.minimumIntegerDigits,
+    minimumFractionDigits: hoursSavedFormatterResolved.minimumFractionDigits,
+    maximumFractionDigits: hoursSavedFormatterResolved.maximumFractionDigits,
+    minimumSignificantDigits:
+      hoursSavedFormatterResolved.minimumSignificantDigits,
+    maximumSignificantDigits:
+      hoursSavedFormatterResolved.maximumSignificantDigits,
+    roundingIncrement: hoursSavedFormatterResolved.roundingIncrement,
+    roundingMode: hoursSavedFormatterResolved.roundingMode,
+    roundingPriority: hoursSavedFormatterResolved.roundingPriority,
+    trailingZeroDisplay: hoursSavedFormatterResolved.trailingZeroDisplay,
+  };
 
   const featureBoxes = [
     { key: "futureProofWorkforce", icon: GraduationCap },
@@ -151,6 +183,9 @@ export default async function Landing({
           <Section>
             <Hero
               initialHoursSavedAmount={hoursSavedOverview.currentAmount}
+              initialHoursSavedFormatted={hoursSavedInitialFormatted}
+              initialHoursSavedFormatterLocale={hoursSavedInitialFormatterLocale}
+              initialHoursSavedFormatterOptions={hoursSavedInitialFormatterOptions}
               initialHoursSavedNextUpdateAt={
                 hoursSavedOverview.nextUpdateAt
                   ? hoursSavedOverview.nextUpdateAt.toISOString()

--- a/apps/www/components/hero/hero-main-section.tsx
+++ b/apps/www/components/hero/hero-main-section.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { PrimaryButton, SecondaryButton } from "@/components/button";
 import { ChevronRight, Lightbulb, LogIn } from "lucide-react";
 
-import { HoursSavedTicker } from "./hours-saved-ticker";
+import { HoursSavedTicker, type HoursSavedNumberFormatOptions } from "./hours-saved-ticker";
 
 type HeroMainSectionProps = {
   title: string;
@@ -14,6 +14,9 @@ type HeroMainSectionProps = {
   secondaryCtaHref: string;
   hoursSavedLabel: string;
   hoursSavedInitialAmount: number;
+  hoursSavedInitialFormatted: string;
+  hoursSavedInitialFormatterLocale: string;
+  hoursSavedInitialFormatterOptions: HoursSavedNumberFormatOptions;
   hoursSavedNextUpdateAt: string | null;
   locale: string;
 };
@@ -27,6 +30,9 @@ export function HeroMainSection({
   secondaryCtaHref,
   hoursSavedLabel,
   hoursSavedInitialAmount,
+  hoursSavedInitialFormatted,
+  hoursSavedInitialFormatterLocale,
+  hoursSavedInitialFormatterOptions,
   hoursSavedNextUpdateAt,
   locale,
 }: HeroMainSectionProps) {
@@ -54,6 +60,9 @@ export function HeroMainSection({
           <span className="text-white/40">:</span>
           <HoursSavedTicker
             initialAmount={hoursSavedInitialAmount}
+            initialFormattedAmount={hoursSavedInitialFormatted}
+            initialFormattedLocale={hoursSavedInitialFormatterLocale}
+            initialFormattedOptions={hoursSavedInitialFormatterOptions}
             initialNextUpdateAt={hoursSavedNextUpdateAt}
             locale={locale}
             className="text-sm tracking-[0.2em] text-white sm:text-base"

--- a/apps/www/components/hero/hero.tsx
+++ b/apps/www/components/hero/hero.tsx
@@ -3,16 +3,23 @@ import { motion } from "framer-motion";
 import Image from "next/image";
 import { useLocale, useTranslations } from "next-intl";
 import { HeroMainSection } from "./hero-main-section";
+import type { HoursSavedNumberFormatOptions } from "./hours-saved-ticker";
 
 import mainboard from "@/images/mainboard.svg";
 import { SubHeroMainboard } from "./hero-sub-mainboard";
 type HeroProps = {
   initialHoursSavedAmount: number;
+  initialHoursSavedFormatted: string;
+  initialHoursSavedFormatterLocale: string;
+  initialHoursSavedFormatterOptions: HoursSavedNumberFormatOptions;
   initialHoursSavedNextUpdateAt: string | null;
 };
 
 export const Hero: React.FC<HeroProps> = ({
   initialHoursSavedAmount,
+  initialHoursSavedFormatted,
+  initialHoursSavedFormatterLocale,
+  initialHoursSavedFormatterOptions,
   initialHoursSavedNextUpdateAt,
 }) => {
   const hero = useTranslations("Hero");
@@ -47,18 +54,21 @@ export const Hero: React.FC<HeroProps> = ({
       animate="visible"
     >
       <motion.div variants={childVariants}>
-        <HeroMainSection
-          title={hero("title")}
-          body={hero("body")}
-          primaryCtaLabel={cta("getStarted")}
-          primaryCtaHref={meetingHref}
-          secondaryCtaLabel={cta("exploreProjects")}
-          secondaryCtaHref={solutionsHref}
-          hoursSavedLabel={cta("hoursSavedLabel")}
-          hoursSavedInitialAmount={initialHoursSavedAmount}
-          hoursSavedNextUpdateAt={initialHoursSavedNextUpdateAt}
-          locale={locale}
-        />
+          <HeroMainSection
+            title={hero("title")}
+            body={hero("body")}
+            primaryCtaLabel={cta("getStarted")}
+            primaryCtaHref={meetingHref}
+            secondaryCtaLabel={cta("exploreProjects")}
+            secondaryCtaHref={solutionsHref}
+            hoursSavedLabel={cta("hoursSavedLabel")}
+            hoursSavedInitialAmount={initialHoursSavedAmount}
+            hoursSavedInitialFormatted={initialHoursSavedFormatted}
+            hoursSavedInitialFormatterLocale={initialHoursSavedFormatterLocale}
+            hoursSavedInitialFormatterOptions={initialHoursSavedFormatterOptions}
+            hoursSavedNextUpdateAt={initialHoursSavedNextUpdateAt}
+            locale={locale}
+          />
       </motion.div>
 
       <div

--- a/apps/www/components/hero/hours-saved-ticker.tsx
+++ b/apps/www/components/hero/hours-saved-ticker.tsx
@@ -5,8 +5,36 @@ import { useAnimate, useInView, useReducedMotion } from "framer-motion";
 
 import { cn } from "@/lib/utils";
 
+export type HoursSavedNumberFormatOptions = Pick<
+  Intl.NumberFormatResolvedOptions,
+  | "locale"
+  | "numberingSystem"
+  | "style"
+  | "currency"
+  | "currencyDisplay"
+  | "currencySign"
+  | "unit"
+  | "unitDisplay"
+  | "notation"
+  | "compactDisplay"
+  | "signDisplay"
+  | "useGrouping"
+  | "minimumIntegerDigits"
+  | "minimumFractionDigits"
+  | "maximumFractionDigits"
+  | "minimumSignificantDigits"
+  | "maximumSignificantDigits"
+  | "roundingIncrement"
+  | "roundingMode"
+  | "roundingPriority"
+  | "trailingZeroDisplay"
+>;
+
 type HoursSavedTickerProps = {
   initialAmount: number;
+  initialFormattedAmount: string;
+  initialFormattedLocale: string;
+  initialFormattedOptions: HoursSavedNumberFormatOptions;
   initialNextUpdateAt: string | null;
   locale: string;
   className?: string;
@@ -19,12 +47,21 @@ type HoursSavedState = {
 
 const FALLBACK_REFRESH_INTERVAL_MS = 60_000;
 
-export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, className }: HoursSavedTickerProps) {
+export function HoursSavedTicker({
+  initialAmount,
+  initialFormattedAmount,
+  initialFormattedLocale,
+  initialFormattedOptions,
+  initialNextUpdateAt,
+  locale,
+  className,
+}: HoursSavedTickerProps) {
   const [state, setState] = useState<HoursSavedState>({
     amount: initialAmount,
     nextUpdateAt: initialNextUpdateAt,
   });
-  const [displayValue, setDisplayValue] = useState(initialAmount);
+  const [displayAmount, setDisplayAmount] = useState(initialAmount);
+  const [isHydrated, setIsHydrated] = useState(false);
   const reducedMotion = useReducedMotion();
   const [scope, animateScope] = useAnimate<HTMLSpanElement>();
   const isInView = useInView(scope, { margin: "-10% 0px", amount: 0.6 });
@@ -33,11 +70,20 @@ export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, c
   const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fetchLatestRef = useRef<(() => Promise<void>) | null>(null);
   const didRunInitialFetchRef = useRef(false);
+  const initialFormattedRef = useRef(initialFormattedAmount);
 
   const updateDisplayValue = useCallback((value: number) => {
     displayAmountRef.current = value;
-    setDisplayValue(value);
+    setDisplayAmount(value);
   }, []);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    initialFormattedRef.current = initialFormattedAmount;
+  }, [initialFormattedAmount]);
 
   const cancelAnimation = useCallback(() => {
     if (animationTimeoutRef.current) {
@@ -223,11 +269,36 @@ export function HoursSavedTicker({ initialAmount, initialNextUpdateAt, locale, c
     void fetchLatestRef.current?.();
   }, [isInView]);
 
-  const formatter = useMemo(() => new Intl.NumberFormat(locale), [locale]);
-  const formatted = formatter.format(displayValue);
+  const formatter = useMemo(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    const { locale: resolvedLocale, ...resolvedOptions } = initialFormattedOptions;
+    const cleanedOptions = Object.fromEntries(
+      Object.entries(resolvedOptions).filter(([, value]) => value !== undefined),
+    ) as Intl.NumberFormatOptions & { numberingSystem?: string };
+
+    return new Intl.NumberFormat(
+      resolvedLocale ?? initialFormattedLocale ?? locale,
+      cleanedOptions,
+    );
+  }, [initialFormattedLocale, initialFormattedOptions, locale]);
+
+  const formatted = useMemo(() => {
+    if (isHydrated) {
+      return formatter?.format(displayAmount) ?? displayAmount.toLocaleString();
+    }
+
+    return initialFormattedRef.current;
+  }, [displayAmount, formatter, isHydrated]);
 
   return (
-    <span ref={scope} className={cn("inline-flex items-center font-medium text-white", className)} aria-live="polite">
+    <span
+      ref={scope}
+      className={cn("inline-flex items-center font-medium text-white", className)}
+      aria-live="polite"
+    >
       {formatted}
     </span>
   );


### PR DESCRIPTION
## Summary
- serialize the landing page hero hours-saved formatter options on the server and thread them through the hero props
- instantiate the client ticker formatter with the shared locale, numbering system, and rounding config to eliminate hydration drift
- document the resolved hydration warning in WRITE_HERE/FIXES for future reference

## Plan
- capture the resolved Intl.NumberFormat options when formatting the initial hours-saved total on the server
- pass the serialized options through the hero component hierarchy down to the ticker
- reuse the shared options when constructing the client-side formatter so browser defaults cannot diverge

## Testing
- pnpm --filter www run lint *(fails: Next.js lint cannot resolve the missing `next-intl` dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb5db049c832a8094e56bb40a527b