### PR TITLE
Fix CTA analytics tracking import

### DIFF
--- a/WRITE_HERE/FIXES/2025-12-01T1700--fix-cta-analytics-import.md
+++ b/WRITE_HERE/FIXES/2025-12-01T1700--fix-cta-analytics-import.md
@@ -1,0 +1,6 @@
+# Fix CTA analytics import
+
+- **What:** Updated the CTA component to use the browser-safe `track` helper from `@vercel/analytics` instead of the server-only export.
+- **Why:** Clicking the "Chat with us" button threw a runtime error because the server variant was being executed in the client bundle.
+- **Files:** `apps/www/components/cta.tsx`
+- **Follow-ups:** None.

--- a/apps/www/components/cta.tsx
+++ b/apps/www/components/cta.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { SectionTitle } from "@/components/section";
-import { track } from "@vercel/analytics/server";
+import { track } from "@vercel/analytics";
 import { CalendarDays, ChevronRight } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import Link from "next/link";


### PR DESCRIPTION
## Plan
- Inspect the CTA component to confirm how analytics tracking is wired in the client bundle.
- Swap the server-only analytics helper with the browser-compatible alternative.
- Log the bug fix in `WRITE_HERE/FIXES` for project tracking.

## Summary
- Import the client-safe `track` helper from `@vercel/analytics` inside the CTA component to prevent runtime errors when clicking the chat CTA.
- Document the correction in a new `WRITE_HERE/FIXES` entry.

## Testing
- `pnpm --filter www run lint` *(fails: next-intl dependency missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdb202c7c832a8ab3dc22c55442c2