### PR TITLE
Add staff outreach dashboard and personalised landing pages

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-30T1500--outreach-dashboard-and-landing-pages.md
+++ b/WRITE_HERE/UPDATES/2025-11-30T1500--outreach-dashboard-and-landing-pages.md
@@ -1,0 +1,6 @@
+# Outreach dashboard and personalised landing pages
+
+- **What:** Added a staff-only outreach management dashboard with CSV import, bulk publishing, and metrics; introduced database support and API hooks for personalised outreach pages; and shipped the customer-facing `/outreach/[slug]` experience with countdown messaging and CTAs.
+- **Why:** Enables the team to prepare bespoke outreach links in batches and automatically serve tailored copy the moment a prospect clicks their personalised URL.
+- **Files:** `apps/www/lib/db/schema.ts`, `apps/www/drizzle/0003_outreach_pages.sql`, `apps/www/lib/outreach/**`, `apps/www/app/[locale]/(site)/dashboard/**`, `apps/www/app/[locale]/(site)/outreach/[slug]/page.tsx`, `apps/www/messages/*.json`, `apps/www/components/outreach/countdown-timer.tsx`.
+- **Follow-ups:** Wire up the public API endpoint for automated outreach entry creation; consider pagination/filtering for large outreach lists; add automated tests once dependencies for `next-intl` typing are available.

--- a/apps/www/app/[locale]/(site)/dashboard/components/outreach-manager.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/components/outreach-manager.tsx
@@ -1,0 +1,468 @@
+"use client";
+
+import { type ChangeEvent, useMemo, useState, useTransition } from "react";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import type { SerializedOutreachPageRecord } from "@/lib/outreach";
+import { toOutreachSlug } from "@/lib/outreach/slug";
+import { cn } from "@/lib/utils";
+
+import { importOutreachEntriesAction } from "../outreach/actions";
+
+interface OutreachManagerProps {
+  locale: string;
+  initialPages: SerializedOutreachPageRecord[];
+}
+
+interface PreviewRow {
+  name: string;
+  text: string;
+  slug: string;
+}
+
+interface ParseError {
+  row: number;
+  message: string;
+}
+
+type UploadStatus =
+  | { state: "idle" }
+  | { state: "success"; created: number; updated: number }
+  | { state: "error"; message: string }
+  | { state: "validation"; message: string };
+
+const TEXT_HEADER_CANDIDATES = ["text to display", "text", "copy", "message"];
+
+function parseCsv(content: string): { rows: PreviewRow[]; errors: ParseError[] } {
+  const rows: string[][] = [];
+  let current = "";
+  let row: string[] = [];
+  let inQuotes = false;
+
+  for (let i = 0; i < content.length; i += 1) {
+    const char = content[i];
+
+    if (char === "\"") {
+      if (inQuotes && content[i + 1] === "\"") {
+        current += "\"";
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === "," && !inQuotes) {
+      row.push(current);
+      current = "";
+      continue;
+    }
+
+    if ((char === "\n" || char === "\r") && !inQuotes) {
+      if (char === "\r" && content[i + 1] === "\n") {
+        i += 1;
+      }
+      row.push(current);
+      rows.push(row);
+      row = [];
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.length > 0 || row.length > 0) {
+    row.push(current);
+    rows.push(row);
+  }
+
+  const filtered = rows.filter((cells) => cells.some((cell) => cell.trim().length > 0));
+
+  if (filtered.length === 0) {
+    return { rows: [], errors: [{ row: 0, message: "empty" }] };
+  }
+
+  const header = filtered[0].map((cell) => cell.trim().toLowerCase());
+  const nameIndex = header.findIndex((cell) => cell === "name");
+  const textIndex = header.findIndex((cell) => TEXT_HEADER_CANDIDATES.includes(cell));
+
+  if (nameIndex === -1 || textIndex === -1) {
+    return { rows: [], errors: [{ row: 0, message: "missingColumns" }] };
+  }
+
+  const previewRows: PreviewRow[] = [];
+  const errors: ParseError[] = [];
+
+  for (let i = 1; i < filtered.length; i += 1) {
+    const raw = filtered[i];
+    const name = (raw[nameIndex] ?? "").trim();
+    const text = (raw[textIndex] ?? "").trim();
+
+    if (!name && !text) {
+      continue;
+    }
+
+    if (!name || !text) {
+      errors.push({ row: i + 1, message: "missingValues" });
+      continue;
+    }
+
+    const slug = toOutreachSlug(name);
+
+    if (!slug) {
+      errors.push({ row: i + 1, message: "invalidSlug" });
+      continue;
+    }
+
+    previewRows.push({ name, text, slug });
+  }
+
+  return { rows: previewRows, errors };
+}
+
+function formatDate(locale: string, value: string | null, options?: Intl.DateTimeFormatOptions) {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const formatter = new Intl.DateTimeFormat(locale, options);
+    return formatter.format(new Date(value));
+  } catch (error) {
+    return new Date(value).toISOString();
+  }
+}
+
+function truncate(value: string, max = 120) {
+  if (value.length <= max) {
+    return value;
+  }
+
+  return `${value.slice(0, max - 1)}…`;
+}
+
+export function OutreachManager({ locale, initialPages }: OutreachManagerProps) {
+  const t = useTranslations("DashboardOutreach");
+  const [pages, setPages] = useState(initialPages);
+  const [preview, setPreview] = useState<PreviewRow[] | null>(null);
+  const [parseErrors, setParseErrors] = useState<ParseError[]>([]);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [status, setStatus] = useState<UploadStatus>({ state: "idle" });
+  const [isPending, startTransition] = useTransition();
+
+  const metrics = useMemo(() => {
+    const total = pages.length;
+    const visited = pages.filter((page) => page.visitCount > 0).length;
+    const untouched = total - visited;
+
+    return { total, visited, untouched };
+  }, [pages]);
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      setPreview(null);
+      setParseErrors([]);
+      setFileName(null);
+      setStatus({ state: "idle" });
+      return;
+    }
+
+    const text = await file.text();
+    const result = parseCsv(text);
+
+    if (result.errors.length > 0) {
+      setStatus({ state: "validation", message: t("upload.validation") });
+    } else {
+      setStatus({ state: "idle" });
+    }
+
+    setPreview(result.rows.length > 0 ? result.rows : null);
+    setParseErrors(result.errors);
+    setFileName(file.name);
+    event.target.value = "";
+  };
+
+  const handlePush = () => {
+    if (!preview || preview.length === 0) {
+      setStatus({ state: "validation", message: t("upload.validation") });
+      return;
+    }
+
+    startTransition(async () => {
+      setStatus({ state: "idle" });
+
+      const payload = preview.map((row) => ({ name: row.name, text: row.text }));
+
+      const result = await importOutreachEntriesAction(locale, payload);
+
+      if (!result.success) {
+        if (result.error === "validation") {
+          setStatus({ state: "validation", message: t("status.validation") });
+        } else if (result.error === "unauthorized") {
+          setStatus({ state: "error", message: t("status.unauthorized") });
+        } else {
+          setStatus({ state: "error", message: t("status.error") });
+        }
+        return;
+      }
+
+      setPages(result.pages);
+      setPreview(null);
+      setParseErrors([]);
+      setFileName(null);
+      setStatus({ state: "success", created: result.created, updated: result.updated });
+    });
+  };
+
+  const hasParseErrors = parseErrors.length > 0;
+
+  return (
+    <div className="space-y-6">
+      <section className="grid gap-4 sm:grid-cols-3">
+        <Card className="border-white/10 bg-white/[0.03] text-white">
+          <CardHeader className="space-y-1 pb-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+              {t("metrics.total.label")}
+            </p>
+            <CardTitle className="text-2xl font-semibold">{metrics.total}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-white/60">
+            {t("metrics.total.caption", { count: metrics.total })}
+          </CardContent>
+        </Card>
+        <Card className="border-white/10 bg-white/[0.03] text-white">
+          <CardHeader className="space-y-1 pb-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+              {t("metrics.visited.label")}
+            </p>
+            <CardTitle className="text-2xl font-semibold">{metrics.visited}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-white/60">
+            {t("metrics.visited.caption", { count: metrics.visited })}
+          </CardContent>
+        </Card>
+        <Card className="border-white/10 bg-white/[0.03] text-white">
+          <CardHeader className="space-y-1 pb-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+              {t("metrics.untouched.label")}
+            </p>
+            <CardTitle className="text-2xl font-semibold">{metrics.untouched}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-white/60">
+            {t("metrics.untouched.caption", { count: metrics.untouched })}
+          </CardContent>
+        </Card>
+      </section>
+
+      <Card className="border-white/10 bg-white/[0.04] text-white">
+        <CardHeader className="space-y-3">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+              {t("upload.eyebrow")}
+            </p>
+            <CardTitle className="text-2xl font-semibold">{t("upload.title")}</CardTitle>
+            <p className="text-sm text-white/60">{t("upload.description")}</p>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <label className="group relative inline-flex h-11 w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-dashed border-white/20 bg-black/20 px-4 text-sm text-white/70 transition hover:border-white/40 hover:bg-black/30 sm:w-auto">
+              <div className="flex flex-col">
+                <span className="font-medium">{t("upload.cta")}</span>
+                <span className="text-xs text-white/40">
+                  {fileName ? t("upload.fileSelected", { name: fileName }) : t("upload.noFile")}
+                </span>
+              </div>
+              <Input
+                accept=".csv,text/csv"
+                className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                onChange={handleFileChange}
+                type="file"
+              />
+            </label>
+            {preview ? (
+              <Button
+                className="w-full sm:w-auto"
+                disabled={isPending}
+                onClick={handlePush}
+              >
+                {isPending
+                  ? t("upload.pushing")
+                  : t("upload.push", { count: preview.length })}
+              </Button>
+            ) : null}
+          </div>
+          {hasParseErrors ? (
+            <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-200">
+              <p className="font-medium">{t("upload.errors.title", { count: parseErrors.length })}</p>
+              <ul className="mt-2 space-y-1">
+                {parseErrors.map((error, index) => (
+                  <li key={`${error.row}-${index}`} className="text-xs">
+                    {t(`upload.errors.${error.message}`, { row: error.row })}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          {status.state === "success" ? (
+            <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-200">
+              {t("status.success", { created: status.created, updated: status.updated })}
+            </div>
+          ) : null}
+          {status.state === "error" || status.state === "validation" ? (
+            <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-200">
+              {status.message}
+            </div>
+          ) : null}
+        </CardHeader>
+        {preview ? (
+          <CardContent>
+            <div className="mb-3 text-sm text-white/50">
+              {t("upload.previewLabel", { count: preview.length })}
+            </div>
+            <ScrollArea className="max-h-64 rounded-xl border border-white/10">
+              <Table>
+                <TableHeader className="bg-white/5">
+                  <TableRow className="border-white/10">
+                    <TableHead className="text-xs uppercase tracking-wide text-white/60">
+                      {t("upload.previewColumns.name")}
+                    </TableHead>
+                    <TableHead className="text-xs uppercase tracking-wide text-white/60">
+                      {t("upload.previewColumns.slug")}
+                    </TableHead>
+                    <TableHead className="text-xs uppercase tracking-wide text-white/60">
+                      {t("upload.previewColumns.text")}
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {preview.map((row) => (
+                    <TableRow key={`${row.slug}-${row.name}`} className="border-white/10">
+                      <TableCell className="align-top text-sm font-medium text-white">{row.name}</TableCell>
+                      <TableCell className="align-top text-xs text-white/60">{row.slug}</TableCell>
+                      <TableCell className="align-top text-sm text-white/70 whitespace-pre-line">
+                        {truncate(row.text, 200)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </ScrollArea>
+          </CardContent>
+        ) : null}
+      </Card>
+
+      <Card className="border-white/10 bg-white/[0.02] text-white">
+        <CardHeader className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+            {t("table.eyebrow")}
+          </p>
+          <CardTitle className="text-2xl font-semibold">{t("table.title")}</CardTitle>
+          <p className="text-sm text-white/60">{t("table.description")}</p>
+        </CardHeader>
+        <CardContent>
+          {pages.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-white/15 bg-black/30 p-8 text-center text-sm text-white/50">
+              {t("table.empty")}
+            </div>
+          ) : (
+            <ScrollArea className="max-h-[480px] rounded-xl border border-white/10">
+              <Table>
+                <TableHeader className="bg-white/5">
+                  <TableRow className="border-white/10">
+                    <TableHead className="w-[160px] text-xs uppercase tracking-wide text-white/60">
+                      {t("table.columns.company")}
+                    </TableHead>
+                    <TableHead className="w-[220px] text-xs uppercase tracking-wide text-white/60">
+                      {t("table.columns.link")}
+                    </TableHead>
+                    <TableHead className="text-xs uppercase tracking-wide text-white/60">
+                      {t("table.columns.text")}
+                    </TableHead>
+                    <TableHead className="w-[120px] text-xs uppercase tracking-wide text-white/60">
+                      {t("table.columns.visits")}
+                    </TableHead>
+                    <TableHead className="w-[160px] text-xs uppercase tracking-wide text-white/60">
+                      {t("table.columns.updated")}
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {pages.map((page) => {
+                    const firstVisitLabel = formatDate(locale, page.firstVisitedAt, {
+                      dateStyle: "medium",
+                      timeStyle: "short",
+                    });
+                    const lastUpdatedLabel = formatDate(locale, page.updatedAt, {
+                      dateStyle: "medium",
+                      timeStyle: "short",
+                    });
+
+                    return (
+                      <TableRow key={page.id} className="border-white/10">
+                        <TableCell className="align-top text-sm font-medium text-white">
+                          <div className="space-y-1">
+                            <p>{page.displayName}</p>
+                            <Badge
+                              className={cn(
+                                "w-fit",
+                                page.visitCount > 0
+                                  ? "border-emerald-400/40 bg-emerald-400/10 text-emerald-100"
+                                  : "border-white/20 bg-white/5 text-white/70",
+                              )}
+                              variant="outline"
+                            >
+                              {page.visitCount > 0
+                                ? t("table.status.visited", { count: page.visitCount })
+                                : t("table.status.pending")}
+                            </Badge>
+                          </div>
+                        </TableCell>
+                        <TableCell className="align-top text-xs text-white/60">
+                          <div className="space-y-1">
+                            <code className="block rounded bg-black/40 px-2 py-1 text-[11px] text-white/70">
+                              /{locale}/outreach/{page.slug}
+                            </code>
+                            <Link
+                              className="text-xs font-medium text-white/70 hover:text-white"
+                              href={`/${locale}/outreach/${page.slug}`}
+                              target="_blank"
+                            >
+                              {t("table.openLink")}
+                            </Link>
+                          </div>
+                        </TableCell>
+                        <TableCell className="align-top text-sm text-white/70 whitespace-pre-line">
+                          {truncate(page.displayText, 220)}
+                        </TableCell>
+                        <TableCell className="align-top text-xs text-white/60">
+                          <div className="space-y-1">
+                            <p className="font-semibold text-white">{page.visitCount}</p>
+                            <p className="text-[11px] text-white/40">
+                              {firstVisitLabel ?? t("table.status.notVisited")}
+                            </p>
+                          </div>
+                        </TableCell>
+                        <TableCell className="align-top text-xs text-white/60">
+                          {lastUpdatedLabel ?? "—"}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </ScrollArea>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/www/app/[locale]/(site)/dashboard/outreach/actions.ts
+++ b/apps/www/app/[locale]/(site)/dashboard/outreach/actions.ts
@@ -1,0 +1,56 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { getAuthSession } from "@/lib/auth";
+import {
+  importOutreachEntries,
+  listOutreachPages,
+  serializeOutreachPages,
+} from "@/lib/outreach";
+
+const entrySchema = z.object({
+  name: z.string().min(1).max(200),
+  text: z.string().min(1).max(4000),
+});
+
+export async function importOutreachEntriesAction(locale: string, payload: unknown) {
+  const session = await getAuthSession();
+
+  if (session?.user?.role !== "staff") {
+    return { success: false as const, error: "unauthorized" as const };
+  }
+
+  const parsed = z.array(entrySchema).min(1).safeParse(payload);
+
+  if (!parsed.success) {
+    return {
+      success: false as const,
+      error: "validation" as const,
+      issues: parsed.error.flatten().fieldErrors,
+    };
+  }
+
+  try {
+    const result = await importOutreachEntries(parsed.data);
+    const pages = await listOutreachPages();
+
+    await revalidatePath(`/${locale}/dashboard`);
+    await revalidatePath(`/${locale}/dashboard/outreach`);
+
+    for (const slug of result.slugs) {
+      await revalidatePath(`/${locale}/outreach/${slug}`);
+    }
+
+    return {
+      success: true as const,
+      created: result.created,
+      updated: result.updated,
+      pages: serializeOutreachPages(pages),
+    };
+  } catch (error) {
+    console.error("Failed to import outreach entries", error);
+    return { success: false as const, error: "unknown" as const };
+  }
+}

--- a/apps/www/app/[locale]/(site)/dashboard/outreach/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/outreach/page.tsx
@@ -1,0 +1,42 @@
+import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
+
+import { OutreachManager } from "../components/outreach-manager";
+import { getAuthSession } from "@/lib/auth";
+import { listOutreachPages, serializeOutreachPages } from "@/lib/outreach";
+
+interface PageProps {
+  params: {
+    locale: string;
+  };
+}
+
+export default async function OutreachDashboardPage({ params }: PageProps) {
+  const { locale } = params;
+  const session = await getAuthSession();
+
+  if (session?.user?.role !== "staff") {
+    redirect(`/${locale}/newsupdates`);
+  }
+
+  const t = await getTranslations({ locale, namespace: "DashboardOutreach" });
+  const pages = await listOutreachPages();
+  const serializedPages = serializeOutreachPages(pages);
+
+  return (
+    <div className="bg-black py-12 sm:py-16">
+      <div className="container max-w-5xl space-y-6">
+        <header className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">{t("eyebrow")}</p>
+          <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">{t("title")}</h1>
+          <p className="text-sm text-white/60 sm:text-base">{t("subtitle")}</p>
+          <p className="text-xs font-medium uppercase tracking-[0.3em] text-white/50">
+            {t("currentUser", { email: session.user.email ?? "" })}
+          </p>
+        </header>
+
+        <OutreachManager initialPages={serializedPages} locale={locale} />
+      </div>
+    </div>
+  );
+}

--- a/apps/www/app/[locale]/(site)/dashboard/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/page.tsx
@@ -14,7 +14,7 @@ import {
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { getAuthSession } from "@/lib/auth";
 import { db } from "@/lib/db/client";
-import { users } from "@/lib/db/schema";
+import { outreachPages, users } from "@/lib/db/schema";
 import { formatDateWithZone } from "@/lib/date";
 import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
 import { getUpcomingMeetings } from "@/lib/meetings/queries";
@@ -46,6 +46,7 @@ export default async function DashboardPage({ params }: PageProps) {
     staffAccounts,
     visitorOverview,
     hoursSavedOverview,
+    outreachCountRows,
   ] = await Promise.all([
     db
       .select({
@@ -77,12 +78,15 @@ export default async function DashboardPage({ params }: PageProps) {
       .orderBy(desc(users.createdAt)),
     getVisitorOverview(),
     getHoursSavedOverview(),
+    db.select({ total: sql<number>`count(*)` }).from(outreachPages),
   ]);
 
   const totals: Record<string, number> = { client: 0, staff: 0 };
   for (const row of roleCounts) {
     totals[row.role] = Number(row.total);
   }
+
+  const outreachTotal = outreachCountRows[0]?.total ?? 0;
 
   const links = [
     {
@@ -98,6 +102,13 @@ export default async function DashboardPage({ params }: PageProps) {
       eyebrow: t("sections.planning.eyebrow"),
       title: t("sections.planning.title"),
       description: t("sections.planning.description"),
+    },
+    {
+      key: "outreach" as const,
+      href: `/${locale}/dashboard/outreach`,
+      eyebrow: t("sections.outreach.eyebrow"),
+      title: t("sections.outreach.title"),
+      description: t("sections.outreach.description"),
     },
   ];
 
@@ -125,6 +136,12 @@ export default async function DashboardPage({ params }: PageProps) {
       label: t("metrics.hoursSaved.title"),
       value: hoursSavedOverview.currentAmount.toLocaleString(locale),
       caption: t("metrics.hoursSaved.caption", { count: hoursSavedOverview.currentAmount }),
+    },
+    {
+      key: "outreach" as const,
+      label: t("metrics.outreach.title"),
+      value: outreachTotal.toLocaleString(locale),
+      caption: t("metrics.outreach.caption", { count: outreachTotal }),
     },
   ];
 

--- a/apps/www/app/[locale]/(site)/outreach/[slug]/page.tsx
+++ b/apps/www/app/[locale]/(site)/outreach/[slug]/page.tsx
@@ -1,0 +1,148 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import { notFound } from "next/navigation";
+
+import { CTA } from "@/components/cta";
+import { CountdownTimer } from "@/components/outreach/countdown-timer";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { getOutreachPageBySlug, recordOutreachVisit } from "@/lib/outreach";
+
+interface PageProps {
+  params: {
+    locale: string;
+    slug: string;
+  };
+}
+
+export const dynamic = "force-dynamic";
+
+export default async function OutreachLandingPage({ params }: PageProps) {
+  const { locale, slug } = params;
+  const t = await getTranslations({ locale, namespace: "OutreachPage" });
+  const record = await recordOutreachVisit(slug);
+
+  if (!record) {
+    notFound();
+  }
+
+  const firstVisit = record.firstVisitedAt ?? record.createdAt;
+  const countdownTarget = new Date(firstVisit);
+  countdownTarget.setHours(countdownTarget.getHours() + 48);
+
+  const paragraphs = record.displayText
+    .split(/\r?\n\r?\n+/)
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0);
+  const leadParagraph = paragraphs[0] ?? record.displayText;
+  const detailParagraphs = paragraphs.slice(1);
+
+  return (
+    <div className="bg-black text-white">
+      <section className="relative overflow-hidden">
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(76,161,255,0.25),rgba(0,0,0,0.9))]" />
+        <div className="container flex flex-col gap-6 py-24 sm:gap-8 sm:py-32">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">
+              {t("eyebrow")}
+            </p>
+            <h1 className="max-w-3xl text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
+              {t("headline", { company: record.displayName })}
+            </h1>
+            <p className="text-sm text-white/50">/{locale}/outreach/{record.slug}</p>
+          </div>
+
+          <div className="max-w-2xl space-y-4 text-base leading-relaxed text-white/70 sm:text-lg">
+            <p className="whitespace-pre-line">{leadParagraph}</p>
+          </div>
+
+          <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:items-center">
+            <Link
+              className={cn(
+                buttonVariants({ size: "lg" }),
+                "w-full sm:w-auto bg-white text-black hover:bg-white/90",
+              )}
+              href={`/${locale}/meeting`}
+            >
+              {t("primaryCta")}
+            </Link>
+            <Link
+              className={cn(
+                buttonVariants({ variant: "outline", size: "lg" }),
+                "w-full sm:w-auto border-white/40 text-white/80 hover:bg-white/10",
+              )}
+              href={`/${locale}/newsupdates`}
+            >
+              {t("secondaryCta")}
+            </Link>
+          </div>
+
+          <div className="mt-6 flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-6 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-white/50">
+                {t("timer.eyebrow")}
+              </p>
+              <CountdownTimer
+                expiredLabel={t("timer.expired")}
+                runningTemplate={t("timer.running")}
+                target={countdownTarget.toISOString()}
+              />
+            </div>
+            <p className="text-xs text-white/50 sm:text-sm">{t("timer.helper")}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-white/10 bg-black/90 py-16 sm:py-24">
+        <div className="container space-y-8">
+          <div className="max-w-3xl space-y-3">
+            <h2 className="text-3xl font-semibold tracking-tight sm:text-[38px]">
+              {t("bodyTitle", { company: record.displayName })}
+            </h2>
+            <p className="text-base text-white/60 sm:text-lg">{t("bodySubtitle")}</p>
+          </div>
+
+          <div className="grid gap-6 text-base leading-relaxed text-white/70 sm:grid-cols-[minmax(0,1fr)]">
+            {(detailParagraphs.length > 0 ? detailParagraphs : [leadParagraph]).map((paragraph, index) => (
+              <div key={`detail-${index}`} className="rounded-2xl border border-white/10 bg-white/[0.03] p-6">
+                <p className="whitespace-pre-line text-sm sm:text-base">{paragraph}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-6 sm:p-8">
+            <h3 className="text-xl font-semibold text-white sm:text-2xl">{t("commitment.title")}</h3>
+            <p className="mt-3 text-sm leading-relaxed text-white/70 sm:text-base">
+              {t("commitment.body")}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <CTA />
+    </div>
+  );
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { locale, slug } = params;
+  const page = await getOutreachPageBySlug(slug);
+
+  if (!page) {
+    return {};
+  }
+
+  const t = await getTranslations({ locale, namespace: "OutreachPage" });
+  const title = t("metaTitle", { company: page.displayName });
+  const description = t("metaDescription");
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+    },
+  };
+}

--- a/apps/www/components/outreach/countdown-timer.tsx
+++ b/apps/www/components/outreach/countdown-timer.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+interface CountdownTimerProps {
+  target: string;
+  runningTemplate: string;
+  expiredLabel: string;
+}
+
+function buildLabel(
+  target: string,
+  runningTemplate: string,
+  expiredLabel: string,
+): { label: string; expired: boolean } {
+  const targetTime = new Date(target).getTime();
+  const now = Date.now();
+  const diff = targetTime - now;
+
+  if (!Number.isFinite(targetTime) || diff <= 0) {
+    return { label: expiredLabel, expired: true };
+  }
+
+  const totalSeconds = Math.floor(diff / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const parts: string[] = [];
+
+  if (days > 0) {
+    parts.push(`${days}d`);
+  }
+
+  parts.push(`${hours.toString().padStart(2, "0")}h`);
+  parts.push(`${minutes.toString().padStart(2, "0")}m`);
+  parts.push(`${seconds.toString().padStart(2, "0")}s`);
+
+  const formatted = parts.join(" ");
+
+  return {
+    label: runningTemplate.replace("{time}", formatted),
+    expired: false,
+  };
+}
+
+export function CountdownTimer({ target, runningTemplate, expiredLabel }: CountdownTimerProps) {
+  const initial = useMemo(() => buildLabel(target, runningTemplate, expiredLabel), [
+    target,
+    runningTemplate,
+    expiredLabel,
+  ]);
+  const [label, setLabel] = useState(initial.label);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      const next = buildLabel(target, runningTemplate, expiredLabel);
+      setLabel(next.label);
+
+      if (next.expired) {
+        window.clearInterval(interval);
+      }
+    }, 1000);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [target, runningTemplate, expiredLabel]);
+
+  return <p className="text-lg font-semibold text-white">{label}</p>;
+}

--- a/apps/www/drizzle/0003_outreach_pages.sql
+++ b/apps/www/drizzle/0003_outreach_pages.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "outreach_pages" (
+  "id" text PRIMARY KEY NOT NULL,
+  "slug" text NOT NULL,
+  "display_name" text NOT NULL,
+  "display_text" text NOT NULL,
+  "visit_count" integer DEFAULT 0 NOT NULL,
+  "first_visited_at" timestamp with time zone,
+  "last_visited_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "outreach_pages_slug_unique" ON "outreach_pages" ("slug");

--- a/apps/www/lib/db/schema.ts
+++ b/apps/www/lib/db/schema.ts
@@ -203,6 +203,30 @@ export const hoursSavedIncrements = pgTable(
   }),
 );
 
+export const outreachPages = pgTable(
+  "outreach_pages",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    slug: text("slug").notNull(),
+    displayName: text("display_name").notNull(),
+    displayText: text("display_text").notNull(),
+    visitCount: integer("visit_count").notNull().default(0),
+    firstVisitedAt: timestamp("first_visited_at", { mode: "date", withTimezone: true }),
+    lastVisitedAt: timestamp("last_visited_at", { mode: "date", withTimezone: true }),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => ({
+    slugIdx: uniqueIndex("outreach_pages_slug_unique").on(table.slug),
+  }),
+);
+
 export const usersRelations = relations(users, ({ many }) => ({
   accounts: many(accounts),
   sessions: many(sessions),

--- a/apps/www/lib/outreach/index.ts
+++ b/apps/www/lib/outreach/index.ts
@@ -1,0 +1,190 @@
+import { unstable_noStore as noStore } from "next/cache";
+
+import { db } from "@/lib/db/client";
+import { outreachPages } from "@/lib/db/schema";
+import { desc, eq, inArray } from "drizzle-orm";
+
+import { toOutreachSlug } from "./slug";
+
+export interface OutreachPageRecord {
+  id: string;
+  slug: string;
+  displayName: string;
+  displayText: string;
+  visitCount: number;
+  firstVisitedAt: Date | null;
+  lastVisitedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SerializedOutreachPageRecord
+  extends Omit<OutreachPageRecord, "firstVisitedAt" | "lastVisitedAt" | "createdAt" | "updatedAt"> {
+  firstVisitedAt: string | null;
+  lastVisitedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ImportEntry {
+  name: string;
+  text: string;
+}
+
+interface ImportResult {
+  created: number;
+  updated: number;
+  slugs: string[];
+}
+
+export async function listOutreachPages(): Promise<OutreachPageRecord[]> {
+  noStore();
+
+  const rows = await db.query.outreachPages.findMany({
+    orderBy: [desc(outreachPages.createdAt)],
+  });
+
+  return rows.map((row) => ({
+    ...row,
+    firstVisitedAt: row.firstVisitedAt ?? null,
+    lastVisitedAt: row.lastVisitedAt ?? null,
+  }));
+}
+
+export async function getOutreachPageBySlug(
+  slug: string,
+): Promise<OutreachPageRecord | null> {
+  noStore();
+
+  const row = await db.query.outreachPages.findFirst({
+    where: eq(outreachPages.slug, slug),
+  });
+
+  if (!row) {
+    return null;
+  }
+
+  return {
+    ...row,
+    firstVisitedAt: row.firstVisitedAt ?? null,
+    lastVisitedAt: row.lastVisitedAt ?? null,
+  };
+}
+
+export async function recordOutreachVisit(
+  slug: string,
+): Promise<OutreachPageRecord | null> {
+  const existing = await getOutreachPageBySlug(slug);
+
+  if (!existing) {
+    return null;
+  }
+
+  const now = new Date();
+  const firstVisitedAt = existing.firstVisitedAt ?? now;
+
+  const [updated] = await db
+    .update(outreachPages)
+    .set({
+      firstVisitedAt,
+      lastVisitedAt: now,
+      visitCount: existing.visitCount + 1,
+      updatedAt: now,
+    })
+    .where(eq(outreachPages.id, existing.id))
+    .returning();
+
+  const record = updated ?? {
+    ...existing,
+    firstVisitedAt,
+    lastVisitedAt: now,
+    visitCount: existing.visitCount + 1,
+    updatedAt: now,
+  };
+
+  return {
+    ...record,
+    firstVisitedAt: record.firstVisitedAt ?? null,
+    lastVisitedAt: record.lastVisitedAt ?? null,
+  };
+}
+
+export async function importOutreachEntries(entries: ImportEntry[]): Promise<ImportResult> {
+  noStore();
+
+  const cleaned = entries
+    .map((entry) => ({
+      name: entry.name.trim(),
+      text: entry.text.trim(),
+    }))
+    .filter((entry) => entry.name.length > 0 && entry.text.length > 0);
+
+  const deduped = new Map<string, ImportEntry>();
+
+  for (const entry of cleaned) {
+    const slug = toOutreachSlug(entry.name);
+
+    if (!slug) {
+      continue;
+    }
+
+    deduped.set(slug, entry);
+  }
+
+  const uniqueEntries = Array.from(deduped.entries()).map(([slug, entry]) => ({
+    slug,
+    name: entry.name,
+    text: entry.text,
+  }));
+
+  if (uniqueEntries.length === 0) {
+    return { created: 0, updated: 0, slugs: [] };
+  }
+
+  const slugList = uniqueEntries.map((entry) => entry.slug);
+  const existingRows = slugList.length
+    ? await db
+        .select({ slug: outreachPages.slug })
+        .from(outreachPages)
+        .where(inArray(outreachPages.slug, slugList))
+    : [];
+
+  const existingSet = new Set(existingRows.map((row) => row.slug));
+  const now = new Date();
+
+  for (const entry of uniqueEntries) {
+    await db
+      .insert(outreachPages)
+      .values({
+        slug: entry.slug,
+        displayName: entry.name,
+        displayText: entry.text,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: outreachPages.slug,
+        set: {
+          displayName: entry.name,
+          displayText: entry.text,
+          updatedAt: now,
+        },
+      });
+  }
+
+  const created = uniqueEntries.filter((entry) => !existingSet.has(entry.slug)).length;
+  const updated = uniqueEntries.length - created;
+
+  return { created, updated, slugs: slugList };
+}
+
+export function serializeOutreachPages(
+  pages: OutreachPageRecord[],
+): SerializedOutreachPageRecord[] {
+  return pages.map((page) => ({
+    ...page,
+    createdAt: page.createdAt.toISOString(),
+    updatedAt: page.updatedAt.toISOString(),
+    firstVisitedAt: page.firstVisitedAt ? page.firstVisitedAt.toISOString() : null,
+    lastVisitedAt: page.lastVisitedAt ? page.lastVisitedAt.toISOString() : null,
+  }));
+}

--- a/apps/www/lib/outreach/slug.ts
+++ b/apps/www/lib/outreach/slug.ts
@@ -1,0 +1,11 @@
+export function toOutreachSlug(value: string): string {
+  const normalized = value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+
+  return normalized;
+}

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -1306,6 +1306,75 @@
       }
     }
   },
+  "DashboardOutreach": {
+    "eyebrow": "Outreach workspace",
+    "title": "Spin up personalised outreach pages",
+    "subtitle": "Import company names and talking points, preview the batch, and push bespoke landing pages live in seconds.",
+    "currentUser": "Signed in as {email}",
+    "metrics": {
+      "total": {
+        "label": "Pages published",
+        "caption": "{count, plural, one {# live page} other {# live pages}}"
+      },
+      "visited": {
+        "label": "Pages visited",
+        "caption": "{count, plural, one {# link opened} other {# links opened}}"
+      },
+      "untouched": {
+        "label": "Awaiting first visit",
+        "caption": "{count, plural, one {# page still unused} other {# pages still unused}}"
+      }
+    },
+    "upload": {
+      "eyebrow": "CSV uploader",
+      "title": "Import outreach copy",
+      "description": "Upload a CSV with Name and Text to display columns. We'll validate each row before anything goes live.",
+      "cta": "Choose CSV",
+      "fileSelected": "Selected: {name}",
+      "noFile": "No file selected yet",
+      "push": "Push {count, plural, one {# page} other {# pages}}",
+      "pushing": "Pushing…",
+      "validation": "Upload a CSV that includes both Name and Text to display columns before pushing.",
+      "previewLabel": "{count, plural, one {# entry ready} other {# entries ready}}",
+      "previewColumns": {
+        "name": "Company name",
+        "slug": "Slug",
+        "text": "Text to display"
+      },
+      "errors": {
+        "title": "{count, plural, one {We found # issue} other {We found # issues}}",
+        "empty": "The file looks empty—add at least one row before uploading.",
+        "missingColumns": "Add both a \"Name\" and a \"Text to display\" column to the CSV.",
+        "missingValues": "Row {row} is missing either the name or the text to display.",
+        "invalidSlug": "Row {row} cannot be converted into a valid URL slug."
+      }
+    },
+    "status": {
+      "success": "Pushed {created, plural, one {# new page} other {# new pages}} and updated {updated, plural, one {# existing page} other {# existing pages}}.",
+      "validation": "Fix the highlighted CSV issues and try again.",
+      "unauthorized": "You are not authorized to manage outreach pages.",
+      "error": "We couldn't process the upload. Try again."
+    },
+    "table": {
+      "eyebrow": "Published pages",
+      "title": "Live outreach links",
+      "description": "Track every personalised link, see which prospects have opened it, and jump directly to the live page.",
+      "empty": "No outreach pages have been pushed yet.",
+      "openLink": "Open page",
+      "columns": {
+        "company": "Company",
+        "link": "Link",
+        "text": "Displayed text",
+        "visits": "Visits",
+        "updated": "Last updated"
+      },
+      "status": {
+        "visited": "{count, plural, one {Visited once} other {Visited # times}}",
+        "pending": "Awaiting first visit",
+        "notVisited": "Not visited yet"
+      }
+    }
+  },
   "DashboardOverview": {
     "eyebrow": "Staff workspace",
     "title": "Choose the area you want to manage",
@@ -1322,6 +1391,11 @@
         "eyebrow": "Planning",
         "title": "Coordinate the meeting agenda",
         "description": "Review availability, assign colleagues, and publish upcoming TransformAI strategy sessions."
+      },
+      "outreach": {
+        "eyebrow": "Outreach",
+        "title": "Launch personalised landing pages",
+        "description": "Upload company-specific copy and push bespoke outreach pages that come to life the moment a prospect clicks."
       }
     },
     "metrics": {
@@ -1341,6 +1415,10 @@
         "title": "Hours saved with AI",
         "caption": "{count, plural, one {# hour automated} other {# hours automated}}",
         "manage": "Open planner"
+      },
+      "outreach": {
+        "title": "Outreach pages live",
+        "caption": "{count, plural, one {# personalised link published} other {# personalised links published}}"
       },
       "ratio": {
         "title": "Client-to-staff ratio",
@@ -1399,6 +1477,26 @@
         "briefings": "Prepare January leadership briefings showcasing ROI metrics from automation pilots."
       }
     }
+  },
+  "OutreachPage": {
+    "eyebrow": "Tailored for your team",
+    "headline": "How TransformAI can accelerate {company}",
+    "primaryCta": "Book a strategy session",
+    "secondaryCta": "Explore recent wins",
+    "timer": {
+      "eyebrow": "Hold timer",
+      "running": "Reserved for you · {time} left",
+      "expired": "This invitation window has closed",
+      "helper": "We hold this personalised plan for 48 hours from your first visit."
+    },
+    "bodyTitle": "What this collaboration unlocks for {company}",
+    "bodySubtitle": "We crafted this mini-brief after researching your public footprint and current AI readiness.",
+    "commitment": {
+      "title": "What to expect next",
+      "body": "Share the landing page internally or book a call above and we will tailor a concrete transformation roadmap aligned to your priorities."
+    },
+    "metaTitle": "{company} × TransformAI",
+    "metaDescription": "A bespoke TransformAI overview prepared for your team."
   },
   "hoursSaved": {
     "dialog": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -1263,6 +1263,75 @@
       }
     }
   },
+  "DashboardOutreach": {
+    "eyebrow": "Outreach-werkruimte",
+    "title": "Zet gepersonaliseerde outreachpagina’s klaar",
+    "subtitle": "Importeer bedrijfsnamen met maatwerkboodschappen, controleer de batch en publiceer binnen enkele seconden.",
+    "currentUser": "Ingelogd als {email}",
+    "metrics": {
+      "total": {
+        "label": "Pagina’s gepubliceerd",
+        "caption": "{count, plural, one {# pagina live} other {# pagina’s live}}"
+      },
+      "visited": {
+        "label": "Pagina’s bezocht",
+        "caption": "{count, plural, one {# link geopend} other {# links geopend}}"
+      },
+      "untouched": {
+        "label": "Wacht op eerste bezoek",
+        "caption": "{count, plural, one {# pagina wacht nog} other {# pagina’s wachten nog}}"
+      }
+    },
+    "upload": {
+      "eyebrow": "CSV-upload",
+      "title": "Importeer outreach-tekst",
+      "description": "Upload een CSV met de kolommen Naam en Tekst voor op de pagina. We controleren elke rij voordat hij live gaat.",
+      "cta": "Kies CSV",
+      "fileSelected": "Geselecteerd: {name}",
+      "noFile": "Nog geen bestand gekozen",
+      "push": "Publiceer {count, plural, one {# pagina} other {# pagina’s}}",
+      "pushing": "Publiceren…",
+      "validation": "Upload een CSV met zowel Naam als Tekst voor op de pagina voordat je publiceert.",
+      "previewLabel": "{count, plural, one {# item klaar} other {# items klaar}}",
+      "previewColumns": {
+        "name": "Bedrijfsnaam",
+        "slug": "Slug",
+        "text": "Tekst op de pagina"
+      },
+      "errors": {
+        "title": "{count, plural, one {We vonden # fout} other {We vonden # fouten}}",
+        "empty": "Het bestand lijkt leeg—voeg minstens één rij toe.",
+        "missingColumns": "Voeg zowel een \"Naam\"- als een \"Tekst voor op de pagina\"-kolom toe.",
+        "missingValues": "Rij {row} mist de naam of de tekst.",
+        "invalidSlug": "Rij {row} kan niet worden omgezet in een geldige URL-slug."
+      }
+    },
+    "status": {
+      "success": "Geplaatst: {created, plural, one {# nieuwe pagina} other {# nieuwe pagina’s}} en bijgewerkt: {updated, plural, one {# bestaande pagina} other {# bestaande pagina’s}}.",
+      "validation": "Los de gemarkeerde CSV-problemen op en probeer het opnieuw.",
+      "unauthorized": "Je hebt geen rechten om outreachpagina’s te beheren.",
+      "error": "Het uploaden is mislukt. Probeer het opnieuw."
+    },
+    "table": {
+      "eyebrow": "Gepubliceerde pagina’s",
+      "title": "Live outreach-links",
+      "description": "Volg elke gepersonaliseerde link, zie wie hem opent en ga direct naar de live pagina.",
+      "empty": "Er zijn nog geen outreachpagina’s gepubliceerd.",
+      "openLink": "Pagina openen",
+      "columns": {
+        "company": "Bedrijf",
+        "link": "Link",
+        "text": "Getoonde tekst",
+        "visits": "Bezoeken",
+        "updated": "Laatst bijgewerkt"
+      },
+      "status": {
+        "visited": "{count, plural, one {Eén keer bezocht} other {# keer bezocht}}",
+        "pending": "Wacht op eerste bezoek",
+        "notVisited": "Nog niet bezocht"
+      }
+    }
+  },
   "DashboardOverview": {
     "eyebrow": "Teamomgeving",
     "title": "Kies welke module je wilt openen",
@@ -1279,6 +1348,11 @@
         "eyebrow": "Planning",
         "title": "Stem de agenda af",
         "description": "Bekijk de beschikbaarheid, wijs collega’s toe en publiceer aankomende TransformAI-strategiesessies."
+      },
+      "outreach": {
+        "eyebrow": "Outreach",
+        "title": "Activeer gepersonaliseerde landingspagina’s",
+        "description": "Upload bedrijfsnamen met maatwerktekst en publiceer de pagina zodra een prospect klikt."
       }
     },
     "metrics": {
@@ -1298,6 +1372,10 @@
         "title": "Bespaarde uren met AI",
         "caption": "{count, plural, one {# uur geautomatiseerd} other {# uren geautomatiseerd}}",
         "manage": "Planner openen"
+      },
+      "outreach": {
+        "title": "Outreach-pagina’s live",
+        "caption": "{count, plural, one {# gepersonaliseerde link live} other {# gepersonaliseerde links live}}"
       },
       "ratio": {
         "title": "Verhouding klant/staff",
@@ -1356,6 +1434,26 @@
         "briefings": "Bereid leiderschapsbriefings voor januari voor met ROI-cijfers uit de automatiseringspilots."
       }
     }
+  },
+  "OutreachPage": {
+    "eyebrow": "Speciaal voor jullie team",
+    "headline": "Hoe TransformAI {company} versnelt",
+    "primaryCta": "Plan een strategiegesprek",
+    "secondaryCta": "Bekijk recente resultaten",
+    "timer": {
+      "eyebrow": "Reservering",
+      "running": "Gereserveerd voor jullie · nog {time}",
+      "expired": "Dit aanbod is verlopen",
+      "helper": "We houden deze gepersonaliseerde pagina 48 uur voor jullie vrij vanaf het eerste bezoek."
+    },
+    "bodyTitle": "Wat deze samenwerking {company} oplevert",
+    "bodySubtitle": "We stelden dit mini-voorstel samen op basis van jullie publieke profiel en huidige AI-rijpheid.",
+    "commitment": {
+      "title": "Wat je van ons mag verwachten",
+      "body": "Deel de pagina intern of plan het gesprek hierboven; we werken graag een concrete AI-roadmap op maat uit."
+    },
+    "metaTitle": "{company} × TransformAI",
+    "metaDescription": "Een persoonlijk TransformAI-overzicht voor jullie team."
   },
   "hoursSaved": {
     "dialog": {


### PR DESCRIPTION
## Summary
- extend the database with outreach page storage and helper utilities for visit tracking and CSV imports
- add a staff-only outreach dashboard with CSV preview, bulk publishing, and live metrics on published links
- ship the personalised `/outreach/[slug]` experience with countdown messaging, CTAs, and localisation updates

## Plan
- Extend the persistence layer for outreach pages and visitation data.
- Build staff-facing CSV import and management UI under the dashboard.
- Deliver the visitor-facing outreach landing template with timer and CTA.

## Testing
- `pnpm --filter www run typecheck` *(fails: repository lacks type declarations for next-intl/drizzle in this environment)*
- `pnpm --filter www run lint` *(fails: dev server cannot resolve next-intl in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e11408fc24832a9e89af2939c8e079