### PR TITLE
Add outreach templates, filtering, and neutral routing

### DIFF
--- a/WRITE_HERE/FIXES/2025-12-01T1600--restore-typecheck-for-outreach.md
+++ b/WRITE_HERE/FIXES/2025-12-01T1600--restore-typecheck-for-outreach.md
@@ -1,0 +1,6 @@
+# Restore typecheck for outreach rollout
+
+- **What:** Tightened locale typing for the post-sign-in redirect, corrected the hours-saved ticker format type, and sanitized account history parsing so TypeScript infers the expected shapes.
+- **Why:** The outreach dashboard follow-up introduced strictness issues that blocked `pnpm --filter www run typecheck`; these adjustments re-align the implementation with the existing locale and telemetry contracts.
+- **Files:** `apps/www/app/[locale]/(site)/auth/post-signin/page.tsx`, `apps/www/components/hero/hours-saved-ticker.tsx`, `apps/www/lib/account-history.ts`
+- **Follow-ups:** Keep lint suppression work on the roadmap so `pnpm --filter www run lint` can complete without legacy violations.

--- a/WRITE_HERE/UPDATES/2025-11-30T1500--outreach-dashboard-and-landing-pages.md
+++ b/WRITE_HERE/UPDATES/2025-11-30T1500--outreach-dashboard-and-landing-pages.md
@@ -1,0 +1,6 @@
+# Outreach dashboard and personalised landing pages
+
+- **What:** Added a staff-only outreach management dashboard with CSV import, bulk publishing, and metrics; introduced database support and API hooks for personalised outreach pages; and shipped the customer-facing `/outreach/[slug]` experience with countdown messaging and CTAs.
+- **Why:** Enables the team to prepare bespoke outreach links in batches and automatically serve tailored copy the moment a prospect clicks their personalised URL.
+- **Files:** `apps/www/lib/db/schema.ts`, `apps/www/drizzle/0003_outreach_pages.sql`, `apps/www/lib/outreach/**`, `apps/www/app/[locale]/(site)/dashboard/**`, `apps/www/app/[locale]/(site)/outreach/[slug]/page.tsx`, `apps/www/messages/*.json`, `apps/www/components/outreach/countdown-timer.tsx`.
+- **Follow-ups:** Wire up the public API endpoint for automated outreach entry creation; consider pagination/filtering for large outreach lists; add automated tests once dependencies for `next-intl` typing are available.

--- a/WRITE_HERE/UPDATES/2025-12-01T1400--outreach-template-filters-and-routing.md
+++ b/WRITE_HERE/UPDATES/2025-12-01T1400--outreach-template-filters-and-routing.md
@@ -1,0 +1,6 @@
+# Outreach template filters and neutral links
+
+- **What:** Added template-aware CSV import, outreach dashboard filters, neutral `/outreach/[slug]` routing, and automatic meeting tracking for outreach bookings.
+- **Why:** To let staff experiment with template variants, manage outreach pages at scale, and share locale-agnostic links that still record engagement and bookings.
+- **Files:** `apps/www/lib/db/schema.ts`, `apps/www/lib/outreach/*`, `apps/www/app/[locale]/(site)/dashboard/**`, `apps/www/app/[locale]/(site)/outreach/[slug]/page.tsx`, `apps/www/app/outreach/[slug]/page.tsx`, `middleware.ts`, `apps/www/app/select-language/page.tsx`, `apps/www/app/api/select-language/route.ts`, `apps/www/app/[locale]/(site)/meeting/**`, `apps/www/messages/*.json`.
+- **Follow-ups:** Consider adding pagination for large outreach lists and supporting additional outreach templates.

--- a/apps/www/app/[locale]/(site)/auth/post-signin/page.tsx
+++ b/apps/www/app/[locale]/(site)/auth/post-signin/page.tsx
@@ -8,10 +8,11 @@ import { getAuthSession } from "@/lib/auth";
 import { db } from "@/lib/db/client";
 import { users } from "@/lib/db/schema";
 import type { AccountHistoryInput } from "@/lib/account-history";
+import type { Locale } from "@/i18n/routing";
 
 interface PageProps {
   params: {
-    locale: string;
+    locale: Locale;
   };
 }
 

--- a/apps/www/app/[locale]/(site)/dashboard/components/outreach-manager.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/components/outreach-manager.tsx
@@ -1,0 +1,968 @@
+"use client";
+
+import {
+  type ChangeEvent,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Checkbox } from "@/components/template/checkbox";
+import type { SerializedOutreachPageRecord } from "@/lib/outreach";
+import { toOutreachSlug } from "@/lib/outreach/slug";
+import { cn } from "@/lib/utils";
+
+import { deleteOutreachPageAction, importOutreachEntriesAction } from "../outreach/actions";
+
+interface OutreachManagerProps {
+  locale: string;
+  initialPages: SerializedOutreachPageRecord[];
+}
+
+interface PreviewRow {
+  name: string;
+  text: string;
+  slug: string;
+  templateId: number;
+}
+
+interface ParseError {
+  row: number;
+  message: string;
+}
+
+type UploadStatus =
+  | { state: "idle" }
+  | { state: "success"; created: number; updated: number }
+  | { state: "error"; message: string }
+  | { state: "validation"; message: string };
+
+type TableStatus =
+  | { state: "idle" }
+  | { state: "success"; message: string }
+  | { state: "error"; message: string };
+
+type SortField = "createdAt" | "lastVisitedAt" | "visitCount";
+
+type VisitFilter = "any" | "visited" | "notVisited";
+
+type BookedFilter = "any" | "yes" | "no";
+
+interface FilterState {
+  sortField: SortField;
+  sortDirection: "asc" | "desc";
+  visitStatus: VisitFilter;
+  booked: BookedFilter;
+  templates: number[];
+  exactDate: string;
+}
+
+const TEXT_HEADER_CANDIDATES = ["text to display", "text", "copy", "message"];
+const TEMPLATE_HEADER_CANDIDATES = ["template", "template id", "variant"];
+const DEFAULT_FILTERS: FilterState = {
+  sortField: "createdAt",
+  sortDirection: "desc",
+  visitStatus: "any",
+  booked: "any",
+  templates: [],
+  exactDate: "",
+};
+
+function parseCsv(content: string): { rows: PreviewRow[]; errors: ParseError[] } {
+  const rows: string[][] = [];
+  let current = "";
+  let row: string[] = [];
+  let inQuotes = false;
+
+  for (let i = 0; i < content.length; i += 1) {
+    const char = content[i];
+
+    if (char === "\"") {
+      if (inQuotes && content[i + 1] === "\"") {
+        current += "\"";
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === "," && !inQuotes) {
+      row.push(current);
+      current = "";
+      continue;
+    }
+
+    if ((char === "\n" || char === "\r") && !inQuotes) {
+      if (char === "\r" && content[i + 1] === "\n") {
+        i += 1;
+      }
+      row.push(current);
+      rows.push(row);
+      row = [];
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.length > 0 || row.length > 0) {
+    row.push(current);
+    rows.push(row);
+  }
+
+  const filtered = rows.filter((cells) => cells.some((cell) => cell.trim().length > 0));
+
+  if (filtered.length === 0) {
+    return { rows: [], errors: [{ row: 0, message: "empty" }] };
+  }
+
+  const header = filtered[0].map((cell) => cell.trim().toLowerCase());
+  const nameIndex = header.findIndex((cell) => cell === "name");
+  const textIndex = header.findIndex((cell) => TEXT_HEADER_CANDIDATES.includes(cell));
+  const templateIndex = header.findIndex((cell) => TEMPLATE_HEADER_CANDIDATES.includes(cell));
+
+  if (nameIndex === -1 || textIndex === -1 || templateIndex === -1) {
+    return { rows: [], errors: [{ row: 0, message: "missingColumns" }] };
+  }
+
+  const previewRows: PreviewRow[] = [];
+  const errors: ParseError[] = [];
+
+  for (let i = 1; i < filtered.length; i += 1) {
+    const raw = filtered[i];
+    const name = (raw[nameIndex] ?? "").trim();
+    const text = (raw[textIndex] ?? "").trim();
+
+    if (!name && !text) {
+      continue;
+    }
+
+    if (!name || !text) {
+      errors.push({ row: i + 1, message: "missingValues" });
+      continue;
+    }
+
+    const slug = toOutreachSlug(name);
+
+    if (!slug) {
+      errors.push({ row: i + 1, message: "invalidSlug" });
+      continue;
+    }
+
+    const templateCell = (raw[templateIndex] ?? "").trim();
+    const templateId = Number.parseInt(templateCell, 10);
+
+    if (!Number.isFinite(templateId) || templateId < 1) {
+      errors.push({ row: i + 1, message: "invalidTemplate" });
+      continue;
+    }
+
+    previewRows.push({ name, text, slug, templateId });
+  }
+
+  return { rows: previewRows, errors };
+}
+
+function formatDate(
+  locale: string,
+  value: string | null,
+  options?: Intl.DateTimeFormatOptions,
+) {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const formatter = new Intl.DateTimeFormat(locale, options);
+    return formatter.format(new Date(value));
+  } catch (error) {
+    return new Date(value).toISOString();
+  }
+}
+
+function truncate(value: string, max = 120) {
+  if (value.length <= max) {
+    return value;
+  }
+
+  return `${value.slice(0, max - 1)}…`;
+}
+
+function getSortValue(
+  page: SerializedOutreachPageRecord,
+  field: SortField,
+  direction: "asc" | "desc",
+) {
+  switch (field) {
+    case "createdAt":
+      return new Date(page.createdAt).getTime();
+    case "lastVisitedAt":
+      if (!page.lastVisitedAt) {
+        return direction === "asc"
+          ? Number.POSITIVE_INFINITY
+          : Number.NEGATIVE_INFINITY;
+      }
+      return new Date(page.lastVisitedAt).getTime();
+    case "visitCount":
+      return page.visitCount;
+    default:
+      return 0;
+  }
+}
+
+export function OutreachManager({ locale, initialPages }: OutreachManagerProps) {
+  const t = useTranslations("DashboardOutreach");
+  const [pages, setPages] = useState(initialPages);
+  const [preview, setPreview] = useState<PreviewRow[] | null>(null);
+  const [parseErrors, setParseErrors] = useState<ParseError[]>([]);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [status, setStatus] = useState<UploadStatus>({ state: "idle" });
+  const [tableStatus, setTableStatus] = useState<TableStatus>({ state: "idle" });
+  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
+  const [isImporting, startImportTransition] = useTransition();
+  const [isDeleting, startDeleteTransition] = useTransition();
+  const [deletingSlug, setDeletingSlug] = useState<string | null>(null);
+
+  const metrics = useMemo(() => {
+    const total = pages.length;
+    const visited = pages.filter((page) => page.visitCount > 0).length;
+    const untouched = total - visited;
+    const booked = pages.filter((page) => page.bookedMeeting).length;
+
+    return { total, visited, untouched, booked };
+  }, [pages]);
+
+  const templateOptions = useMemo(() => {
+    const unique = new Set<number>();
+    for (const page of pages) {
+      unique.add(page.templateId);
+    }
+    return Array.from(unique).sort((a, b) => a - b);
+  }, [pages]);
+
+  const templatePreviews = useMemo(
+    () => [
+      {
+        id: 1,
+        title: t("templates.items.1.title"),
+        body: t("templates.items.1.body"),
+        points: [
+          t("templates.items.1.points.0"),
+          t("templates.items.1.points.1"),
+          t("templates.items.1.points.2"),
+        ],
+      },
+    ],
+    [t],
+  );
+
+  useEffect(() => {
+    setFilters((prev) => {
+      if (prev.templates.length === 0) {
+        return prev;
+      }
+      const valid = prev.templates.filter((id) => templateOptions.includes(id));
+      if (valid.length === prev.templates.length) {
+        return prev;
+      }
+      return { ...prev, templates: valid };
+    });
+  }, [templateOptions]);
+
+  const filteredPages = useMemo(() => {
+    const filtered = pages.filter((page) => {
+      if (filters.visitStatus === "visited" && page.visitCount === 0) {
+        return false;
+      }
+
+      if (filters.visitStatus === "notVisited" && page.visitCount > 0) {
+        return false;
+      }
+
+      if (filters.booked === "yes" && !page.bookedMeeting) {
+        return false;
+      }
+
+      if (filters.booked === "no" && page.bookedMeeting) {
+        return false;
+      }
+
+      if (filters.templates.length > 0 && !filters.templates.includes(page.templateId)) {
+        return false;
+      }
+
+      if (filters.exactDate) {
+        const createdDate = new Date(page.createdAt).toISOString().slice(0, 10);
+        if (createdDate !== filters.exactDate) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+
+    const directionMultiplier = filters.sortDirection === "asc" ? 1 : -1;
+
+    return filtered.sort((a, b) => {
+      const valueA = getSortValue(a, filters.sortField, filters.sortDirection);
+      const valueB = getSortValue(b, filters.sortField, filters.sortDirection);
+
+      if (valueA === valueB) {
+        return a.slug.localeCompare(b.slug);
+      }
+
+      return valueA > valueB ? directionMultiplier : -directionMultiplier;
+    });
+  }, [filters, pages]);
+
+  const hasParseErrors = parseErrors.length > 0;
+  const hasActiveFilters = useMemo(() => {
+    return (
+      filters.sortField !== DEFAULT_FILTERS.sortField ||
+      filters.sortDirection !== DEFAULT_FILTERS.sortDirection ||
+      filters.visitStatus !== DEFAULT_FILTERS.visitStatus ||
+      filters.booked !== DEFAULT_FILTERS.booked ||
+      filters.templates.length > 0 ||
+      filters.exactDate !== DEFAULT_FILTERS.exactDate
+    );
+  }, [filters]);
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      setPreview(null);
+      setParseErrors([]);
+      setFileName(null);
+      setStatus({ state: "idle" });
+      return;
+    }
+
+    const text = await file.text();
+    const result = parseCsv(text);
+
+    if (result.errors.length > 0) {
+      setStatus({ state: "validation", message: t("upload.validation") });
+    } else {
+      setStatus({ state: "idle" });
+    }
+
+    setPreview(result.rows.length > 0 ? result.rows : null);
+    setParseErrors(result.errors);
+    setFileName(file.name);
+    event.target.value = "";
+  };
+
+  const handlePush = () => {
+    if (!preview || preview.length === 0) {
+      setStatus({ state: "validation", message: t("upload.validation") });
+      return;
+    }
+
+    startImportTransition(async () => {
+      setStatus({ state: "idle" });
+      setTableStatus({ state: "idle" });
+
+      const payload = preview.map((row) => ({
+        name: row.name,
+        text: row.text,
+        templateId: row.templateId,
+      }));
+
+      const result = await importOutreachEntriesAction(locale, payload);
+
+      if (!result.success) {
+        if (result.error === "validation") {
+          setStatus({ state: "validation", message: t("status.validation") });
+        } else if (result.error === "unauthorized") {
+          setStatus({ state: "error", message: t("status.unauthorized") });
+        } else {
+          setStatus({ state: "error", message: t("status.error") });
+        }
+        return;
+      }
+
+      setPages(result.pages);
+      setPreview(null);
+      setParseErrors([]);
+      setFileName(null);
+      setStatus({ state: "success", created: result.created, updated: result.updated });
+    });
+  };
+
+  const handleDelete = (slug: string) => {
+    setTableStatus({ state: "idle" });
+    setDeletingSlug(slug);
+
+    startDeleteTransition(async () => {
+      const result = await deleteOutreachPageAction(locale, { slug });
+
+      if (!result.success) {
+        const message =
+          result.error === "unauthorized"
+            ? t("status.unauthorized")
+            : result.error === "not_found"
+            ? t("table.delete.notFound")
+            : t("table.delete.error");
+        setTableStatus({ state: "error", message });
+        setDeletingSlug(null);
+        return;
+      }
+
+      setPages(result.pages);
+      setTableStatus({ state: "success", message: t("table.delete.success", { slug }) });
+      setDeletingSlug(null);
+    });
+  };
+
+  const toggleTemplateFilter = (templateId: number, checked: boolean) => {
+    setFilters((prev) => {
+      const templates = new Set(prev.templates);
+      if (checked) {
+        templates.add(templateId);
+      } else {
+        templates.delete(templateId);
+      }
+      return { ...prev, templates: Array.from(templates).sort((a, b) => a - b) };
+    });
+  };
+
+  const clearFilters = () => {
+    setFilters(DEFAULT_FILTERS);
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <Card className="border-white/10 bg-white/[0.03] text-white">
+          <CardHeader className="space-y-1 pb-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+              {t("metrics.total.label")}
+            </p>
+            <CardTitle className="text-2xl font-semibold">{metrics.total}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-white/60">
+            {t("metrics.total.caption", { count: metrics.total })}
+          </CardContent>
+        </Card>
+        <Card className="border-white/10 bg-white/[0.03] text-white">
+          <CardHeader className="space-y-1 pb-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+              {t("metrics.visited.label")}
+            </p>
+            <CardTitle className="text-2xl font-semibold">{metrics.visited}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-white/60">
+            {t("metrics.visited.caption", { count: metrics.visited })}
+          </CardContent>
+        </Card>
+        <Card className="border-white/10 bg-white/[0.03] text-white">
+          <CardHeader className="space-y-1 pb-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+              {t("metrics.untouched.label")}
+            </p>
+            <CardTitle className="text-2xl font-semibold">{metrics.untouched}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-white/60">
+            {t("metrics.untouched.caption", { count: metrics.untouched })}
+          </CardContent>
+        </Card>
+        <Card className="border-white/10 bg-white/[0.03] text-white">
+          <CardHeader className="space-y-1 pb-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/50">
+              {t("metrics.booked.label")}
+            </p>
+            <CardTitle className="text-2xl font-semibold">{metrics.booked}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-white/60">
+            {t("metrics.booked.caption", { count: metrics.booked })}
+          </CardContent>
+        </Card>
+      </section>
+
+      <Card className="border-white/10 bg-white/[0.03] text-white">
+        <CardHeader className="space-y-3">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+              {t("templates.eyebrow")}
+            </p>
+            <CardTitle className="text-2xl font-semibold">{t("templates.title")}</CardTitle>
+            <p className="text-sm text-white/60">{t("templates.description")}</p>
+          </div>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-2">
+          {templatePreviews.map((template) => (
+            <div
+              key={template.id}
+              className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] p-6"
+            >
+              <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-sky-500/15 via-transparent to-fuchsia-500/20" />
+              <div className="relative space-y-3">
+                <Badge
+                  className="w-fit border-white/20 bg-white/10 text-[11px] uppercase tracking-[0.3em] text-white/70"
+                  variant="outline"
+                >
+                  {t("templates.badge", { id: template.id })}
+                </Badge>
+                <h3 className="text-xl font-semibold text-white">{template.title}</h3>
+                <p className="text-sm text-white/70">{template.body}</p>
+                <ul className="space-y-2 text-sm text-white/65">
+                  {template.points.map((point, index) => (
+                    <li key={`${template.id}-point-${index}`} className="flex items-start gap-2">
+                      <span aria-hidden className="mt-1 h-1.5 w-1.5 rounded-full bg-sky-400" />
+                      <span>{point}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card className="border-white/10 bg-white/[0.04] text-white">
+        <CardHeader className="space-y-3">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+              {t("upload.eyebrow")}
+            </p>
+            <CardTitle className="text-2xl font-semibold">{t("upload.title")}</CardTitle>
+            <p className="text-sm text-white/60">{t("upload.description")}</p>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <label className="group relative inline-flex h-11 w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-dashed border-white/20 bg-black/20 px-4 text-sm text-white/70 transition hover:border-white/40 hover:bg-black/30 sm:w-auto">
+              <div className="flex flex-col">
+                <span className="font-medium">{t("upload.cta")}</span>
+                <span className="text-xs text-white/40">
+                  {fileName ? t("upload.fileSelected", { name: fileName }) : t("upload.noFile")}
+                </span>
+              </div>
+              <Input
+                accept=".csv,text/csv"
+                className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                onChange={handleFileChange}
+                type="file"
+              />
+            </label>
+            {preview ? (
+              <Button
+                className="w-full sm:w-auto"
+                disabled={isImporting}
+                onClick={handlePush}
+              >
+                {isImporting
+                  ? t("upload.pushing")
+                  : t("upload.push", { count: preview.length })}
+              </Button>
+            ) : null}
+          </div>
+          {hasParseErrors ? (
+            <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-200">
+              <p className="font-medium">{t("upload.errors.title", { count: parseErrors.length })}</p>
+              <ul className="mt-2 space-y-1">
+                {parseErrors.map((error, index) => (
+                  <li key={`${error.row}-${index}`} className="text-xs">
+                    {t(`upload.errors.${error.message}` as const, { row: error.row })}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          {status.state === "success" ? (
+            <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-200">
+              {t("status.success", { created: status.created, updated: status.updated })}
+            </div>
+          ) : null}
+          {status.state === "error" || status.state === "validation" ? (
+            <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-200">
+              {status.message}
+            </div>
+          ) : null}
+        </CardHeader>
+        {preview ? (
+          <CardContent>
+            <div className="mb-3 text-sm text-white/50">
+              {t("upload.previewLabel", { count: preview.length })}
+            </div>
+            <ScrollArea className="max-h-64 rounded-xl border border-white/10">
+              <Table>
+                <TableHeader className="bg-white/5">
+                  <TableRow className="border-white/10">
+                    <TableHead className="text-xs uppercase tracking-wide text-white/60">
+                      {t("upload.previewColumns.name")}
+                    </TableHead>
+                    <TableHead className="text-xs uppercase tracking-wide text-white/60">
+                      {t("upload.previewColumns.slug")}
+                    </TableHead>
+                    <TableHead className="text-xs uppercase tracking-wide text-white/60">
+                      {t("upload.previewColumns.template")}
+                    </TableHead>
+                    <TableHead className="text-xs uppercase tracking-wide text-white/60">
+                      {t("upload.previewColumns.text")}
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {preview.map((row) => (
+                    <TableRow key={`${row.slug}-${row.name}`} className="border-white/10">
+                      <TableCell className="align-top text-sm font-medium text-white">{row.name}</TableCell>
+                      <TableCell className="align-top text-xs text-white/60">{row.slug}</TableCell>
+                      <TableCell className="align-top text-xs text-white/60">
+                        {t("upload.previewColumns.templateLabel", { id: row.templateId })}
+                      </TableCell>
+                      <TableCell className="align-top text-sm text-white/70 whitespace-pre-line">
+                        {truncate(row.text, 200)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </ScrollArea>
+          </CardContent>
+        ) : null}
+      </Card>
+
+      <Card className="border-white/10 bg-white/[0.02] text-white">
+        <CardHeader className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+            {t("table.eyebrow")}
+          </p>
+          <CardTitle className="text-2xl font-semibold">{t("table.title")}</CardTitle>
+          <p className="text-sm text-white/60">{t("table.description")}</p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <div className="space-y-2">
+              <Label className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+                {t("filters.sortBy")}
+              </Label>
+              <Select
+                value={filters.sortField}
+                onValueChange={(value) =>
+                  setFilters((prev) => ({ ...prev, sortField: value as SortField }))
+                }
+              >
+                <SelectTrigger className="h-11 rounded-xl border-white/20 bg-black/30 text-sm text-white/80">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="border-white/10 bg-slate-900 text-white">
+                  <SelectItem value="createdAt">{t("filters.sortOptions.createdAt")}</SelectItem>
+                  <SelectItem value="lastVisitedAt">{t("filters.sortOptions.lastVisitedAt")}</SelectItem>
+                  <SelectItem value="visitCount">{t("filters.sortOptions.visitCount")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+                {t("filters.sortOrder")}
+              </Label>
+              <Select
+                value={filters.sortDirection}
+                onValueChange={(value) =>
+                  setFilters((prev) => ({ ...prev, sortDirection: value as "asc" | "desc" }))
+                }
+              >
+                <SelectTrigger className="h-11 rounded-xl border-white/20 bg-black/30 text-sm text-white/80">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="border-white/10 bg-slate-900 text-white">
+                  <SelectItem value="desc">{t("filters.order.desc")}</SelectItem>
+                  <SelectItem value="asc">{t("filters.order.asc")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+                {t("filters.visitStatus")}
+              </Label>
+              <Select
+                value={filters.visitStatus}
+                onValueChange={(value) =>
+                  setFilters((prev) => ({ ...prev, visitStatus: value as VisitFilter }))
+                }
+              >
+                <SelectTrigger className="h-11 rounded-xl border-white/20 bg-black/30 text-sm text-white/80">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="border-white/10 bg-slate-900 text-white">
+                  <SelectItem value="any">{t("filters.visitOptions.any")}</SelectItem>
+                  <SelectItem value="visited">{t("filters.visitOptions.visited")}</SelectItem>
+                  <SelectItem value="notVisited">{t("filters.visitOptions.notVisited")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+                {t("filters.booked")}
+              </Label>
+              <Select
+                value={filters.booked}
+                onValueChange={(value) =>
+                  setFilters((prev) => ({ ...prev, booked: value as BookedFilter }))
+                }
+              >
+                <SelectTrigger className="h-11 rounded-xl border-white/20 bg-black/30 text-sm text-white/80">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="border-white/10 bg-slate-900 text-white">
+                  <SelectItem value="any">{t("filters.bookedOptions.any")}</SelectItem>
+                  <SelectItem value="yes">{t("filters.bookedOptions.yes")}</SelectItem>
+                  <SelectItem value="no">{t("filters.bookedOptions.no")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+                {t("filters.addedOn")}
+              </Label>
+              <Input
+                className="h-11 rounded-xl border-white/20 bg-black/30 text-sm text-white/80"
+                type="date"
+                value={filters.exactDate}
+                onChange={(event) =>
+                  setFilters((prev) => ({ ...prev, exactDate: event.target.value }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+                {t("filters.templates")}
+              </Label>
+              <div className="flex flex-wrap gap-2">
+                {templateOptions.length === 0 ? (
+                  <p className="text-xs text-white/50">{t("filters.templatesEmpty")}</p>
+                ) : (
+                  templateOptions.map((templateId) => {
+                    const checked = filters.templates.includes(templateId);
+                    const inputId = `template-filter-${templateId}`;
+                    return (
+                      <label
+                        key={inputId}
+                        className={cn(
+                          "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition",
+                          checked
+                            ? "border-sky-400/70 bg-sky-500/20 text-white"
+                            : "border-white/15 bg-white/5 text-white/70 hover:border-white/30",
+                        )}
+                        htmlFor={inputId}
+                      >
+                        <Checkbox
+                          id={inputId}
+                          checked={checked}
+                          className="h-3.5 w-3.5 border-white/30"
+                          onCheckedChange={(value) =>
+                            toggleTemplateFilter(templateId, value === true)
+                          }
+                        />
+                        <span>{t("filters.templateLabel", { id: templateId })}</span>
+                      </label>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+          </div>
+          {hasActiveFilters ? (
+            <Button
+              className="w-full sm:w-auto"
+              onClick={clearFilters}
+              variant="ghost"
+            >
+              {t("filters.clear")}
+            </Button>
+          ) : null}
+
+          {tableStatus.state !== "idle" ? (
+            <div
+              className={cn(
+                "rounded-xl border p-4 text-sm",
+                tableStatus.state === "success"
+                  ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-100"
+                  : "border-red-500/30 bg-red-500/10 text-red-100",
+              )}
+            >
+              {tableStatus.message}
+            </div>
+          ) : null}
+
+          {pages.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-white/15 bg-black/30 p-8 text-center text-sm text-white/50">
+              {t("table.empty")}
+            </div>
+          ) : filteredPages.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-white/15 bg-black/30 p-8 text-center text-sm text-white/50">
+              {t("table.noMatches")}
+            </div>
+          ) : (
+            <ScrollArea className="max-h-[540px] rounded-xl border border-white/10">
+              <Table>
+                <TableHeader className="bg-white/5">
+                  <TableRow className="border-white/10">
+                    <TableHead className="w-[160px] text-xs uppercase tracking-wide text-white/60">
+                      {t("table.columns.company")}
+                    </TableHead>
+                    <TableHead className="w-[200px] text-xs uppercase tracking-wide text-white/60">
+                      {t("table.columns.link")}
+                    </TableHead>
+                    <TableHead className="w-[120px] text-xs uppercase tracking-wide text-white/60">
+                      {t("table.columns.template")}
+                    </TableHead>
+                    <TableHead className="text-xs uppercase tracking-wide text-white/60">
+                      {t("table.columns.text")}
+                    </TableHead>
+                    <TableHead className="w-[140px] text-xs uppercase tracking-wide text-white/60">
+                      {t("table.columns.visits")}
+                    </TableHead>
+                    <TableHead className="w-[160px] text-xs uppercase tracking-wide text-white/60">
+                      {t("table.columns.added")}
+                    </TableHead>
+                    <TableHead className="w-[160px] text-xs uppercase tracking-wide text-white/60">
+                      {t("table.columns.booked")}
+                    </TableHead>
+                    <TableHead className="w-[160px] text-xs uppercase tracking-wide text-white/60">
+                      {t("table.columns.updated")}
+                    </TableHead>
+                    <TableHead className="w-[120px] text-xs uppercase tracking-wide text-white/60">
+                      {t("table.columns.actions")}
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredPages.map((page) => {
+                    const lastVisitedLabel = formatDate(locale, page.lastVisitedAt, {
+                      dateStyle: "medium",
+                      timeStyle: "short",
+                    });
+                    const createdLabel = formatDate(locale, page.createdAt, {
+                      dateStyle: "medium",
+                      timeStyle: "short",
+                    });
+                    const updatedLabel = formatDate(locale, page.updatedAt, {
+                      dateStyle: "medium",
+                      timeStyle: "short",
+                    });
+                    const bookedLabel = formatDate(locale, page.bookedMeetingAt, {
+                      dateStyle: "medium",
+                      timeStyle: "short",
+                    });
+
+                    const isDeletingRow = isDeleting && deletingSlug === page.slug;
+
+                    return (
+                      <TableRow key={page.id} className="border-white/10">
+                        <TableCell className="align-top text-sm font-medium text-white">
+                          <div className="space-y-1">
+                            <p>{page.displayName}</p>
+                            <Badge
+                              className={cn(
+                                "w-fit",
+                                page.visitCount > 0
+                                  ? "border-emerald-400/40 bg-emerald-400/10 text-emerald-100"
+                                  : "border-white/20 bg-white/5 text-white/70",
+                              )}
+                              variant="outline"
+                            >
+                              {page.visitCount > 0
+                                ? t("table.status.visited", { count: page.visitCount })
+                                : t("table.status.pending")}
+                            </Badge>
+                          </div>
+                        </TableCell>
+                        <TableCell className="align-top text-xs text-white/60">
+                          <div className="space-y-1">
+                            <code className="block rounded bg-black/40 px-2 py-1 text-[11px] text-white/70">
+                              /outreach/{page.slug}
+                            </code>
+                            <Link
+                              className="text-xs font-medium text-white/70 hover:text-white"
+                              href={`/outreach/${page.slug}`}
+                              target="_blank"
+                            >
+                              {t("table.openLink")}
+                            </Link>
+                          </div>
+                        </TableCell>
+                        <TableCell className="align-top text-xs text-white/60">
+                          {t("filters.templateLabel", { id: page.templateId })}
+                        </TableCell>
+                        <TableCell className="align-top text-sm text-white/70 whitespace-pre-line">
+                          {truncate(page.displayText, 220)}
+                        </TableCell>
+                        <TableCell className="align-top text-xs text-white/60">
+                          <div className="space-y-1">
+                            <p className="font-semibold text-white">{page.visitCount}</p>
+                            <p className="text-[11px] text-white/40">
+                              {lastVisitedLabel ?? t("table.status.notVisited")}
+                            </p>
+                          </div>
+                        </TableCell>
+                        <TableCell className="align-top text-xs text-white/60">
+                          {createdLabel ?? "—"}
+                        </TableCell>
+                        <TableCell className="align-top text-xs text-white/60">
+                          <div className="space-y-1">
+                            <Badge
+                              className={cn(
+                                "w-fit",
+                                page.bookedMeeting
+                                  ? "border-emerald-400/40 bg-emerald-400/10 text-emerald-100"
+                                  : "border-white/20 bg-white/5 text-white/70",
+                              )}
+                              variant="outline"
+                            >
+                              {page.bookedMeeting
+                                ? t("table.bookedStatus.yes")
+                                : t("table.bookedStatus.no")}
+                            </Badge>
+                            <p className="text-[11px] text-white/40">
+                              {bookedLabel ?? ""}
+                            </p>
+                          </div>
+                        </TableCell>
+                        <TableCell className="align-top text-xs text-white/60">
+                          {updatedLabel ?? "—"}
+                        </TableCell>
+                        <TableCell className="align-top text-xs text-white/60">
+                          <Button
+                            className="text-xs"
+                            disabled={isDeletingRow}
+                            onClick={() => handleDelete(page.slug)}
+                            size="sm"
+                            variant="ghost"
+                          >
+                            {isDeletingRow
+                              ? t("table.delete.pending")
+                              : t("table.delete.label")}
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </ScrollArea>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/www/app/[locale]/(site)/dashboard/outreach/actions.ts
+++ b/apps/www/app/[locale]/(site)/dashboard/outreach/actions.ts
@@ -1,0 +1,104 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { getAuthSession } from "@/lib/auth";
+import {
+  deleteOutreachPage,
+  importOutreachEntries,
+  listOutreachPages,
+  serializeOutreachPages,
+} from "@/lib/outreach";
+import { locales } from "@/i18n/routing";
+
+const entrySchema = z.object({
+  name: z.string().min(1).max(200),
+  text: z.string().min(1).max(4000),
+  templateId: z.number().int().min(1).max(50),
+});
+
+const deleteSchema = z.object({
+  slug: z.string().min(1).max(160),
+});
+
+export async function importOutreachEntriesAction(locale: string, payload: unknown) {
+  const session = await getAuthSession();
+
+  if (session?.user?.role !== "staff") {
+    return { success: false as const, error: "unauthorized" as const };
+  }
+
+  const parsed = z.array(entrySchema).min(1).safeParse(payload);
+
+  if (!parsed.success) {
+    return {
+      success: false as const,
+      error: "validation" as const,
+      issues: parsed.error.flatten().fieldErrors,
+    };
+  }
+
+  try {
+    const result = await importOutreachEntries(parsed.data);
+    const pages = await listOutreachPages();
+
+    await revalidatePath(`/${locale}/dashboard`);
+    await revalidatePath(`/${locale}/dashboard/outreach`);
+
+    for (const slug of result.slugs) {
+      await revalidatePath(`/outreach/${slug}`);
+      for (const localeCode of locales) {
+        await revalidatePath(`/${localeCode}/outreach/${slug}`);
+      }
+    }
+
+    return {
+      success: true as const,
+      created: result.created,
+      updated: result.updated,
+      pages: serializeOutreachPages(pages),
+    };
+  } catch (error) {
+    console.error("Failed to import outreach entries", error);
+    return { success: false as const, error: "unknown" as const };
+  }
+}
+
+export async function deleteOutreachPageAction(locale: string, payload: unknown) {
+  const session = await getAuthSession();
+
+  if (session?.user?.role !== "staff") {
+    return { success: false as const, error: "unauthorized" as const };
+  }
+
+  const parsed = deleteSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return {
+      success: false as const,
+      error: "validation" as const,
+      issues: parsed.error.flatten().fieldErrors,
+    };
+  }
+
+  const deleted = await deleteOutreachPage(parsed.data.slug);
+
+  if (!deleted) {
+    return { success: false as const, error: "not_found" as const };
+  }
+
+  const pages = await listOutreachPages();
+
+  await revalidatePath(`/${locale}/dashboard`);
+  await revalidatePath(`/${locale}/dashboard/outreach`);
+  await revalidatePath(`/outreach/${parsed.data.slug}`);
+  for (const localeCode of locales) {
+    await revalidatePath(`/${localeCode}/outreach/${parsed.data.slug}`);
+  }
+
+  return {
+    success: true as const,
+    pages: serializeOutreachPages(pages),
+  };
+}

--- a/apps/www/app/[locale]/(site)/dashboard/outreach/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/outreach/page.tsx
@@ -1,0 +1,42 @@
+import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
+
+import { OutreachManager } from "../components/outreach-manager";
+import { getAuthSession } from "@/lib/auth";
+import { listOutreachPages, serializeOutreachPages } from "@/lib/outreach";
+
+interface PageProps {
+  params: {
+    locale: string;
+  };
+}
+
+export default async function OutreachDashboardPage({ params }: PageProps) {
+  const { locale } = params;
+  const session = await getAuthSession();
+
+  if (session?.user?.role !== "staff") {
+    redirect(`/${locale}/newsupdates`);
+  }
+
+  const t = await getTranslations({ locale, namespace: "DashboardOutreach" });
+  const pages = await listOutreachPages();
+  const serializedPages = serializeOutreachPages(pages);
+
+  return (
+    <div className="bg-black py-12 sm:py-16">
+      <div className="container max-w-5xl space-y-6">
+        <header className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">{t("eyebrow")}</p>
+          <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">{t("title")}</h1>
+          <p className="text-sm text-white/60 sm:text-base">{t("subtitle")}</p>
+          <p className="text-xs font-medium uppercase tracking-[0.3em] text-white/50">
+            {t("currentUser", { email: session.user.email ?? "" })}
+          </p>
+        </header>
+
+        <OutreachManager initialPages={serializedPages} locale={locale} />
+      </div>
+    </div>
+  );
+}

--- a/apps/www/app/[locale]/(site)/dashboard/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/page.tsx
@@ -14,7 +14,7 @@ import {
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { getAuthSession } from "@/lib/auth";
 import { db } from "@/lib/db/client";
-import { users } from "@/lib/db/schema";
+import { outreachPages, users } from "@/lib/db/schema";
 import { formatDateWithZone } from "@/lib/date";
 import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
 import { getUpcomingMeetings } from "@/lib/meetings/queries";
@@ -46,6 +46,7 @@ export default async function DashboardPage({ params }: PageProps) {
     staffAccounts,
     visitorOverview,
     hoursSavedOverview,
+    outreachCountRows,
   ] = await Promise.all([
     db
       .select({
@@ -77,12 +78,15 @@ export default async function DashboardPage({ params }: PageProps) {
       .orderBy(desc(users.createdAt)),
     getVisitorOverview(),
     getHoursSavedOverview(),
+    db.select({ total: sql<number>`count(*)` }).from(outreachPages),
   ]);
 
   const totals: Record<string, number> = { client: 0, staff: 0 };
   for (const row of roleCounts) {
     totals[row.role] = Number(row.total);
   }
+
+  const outreachTotal = outreachCountRows[0]?.total ?? 0;
 
   const links = [
     {
@@ -98,6 +102,13 @@ export default async function DashboardPage({ params }: PageProps) {
       eyebrow: t("sections.planning.eyebrow"),
       title: t("sections.planning.title"),
       description: t("sections.planning.description"),
+    },
+    {
+      key: "outreach" as const,
+      href: `/${locale}/dashboard/outreach`,
+      eyebrow: t("sections.outreach.eyebrow"),
+      title: t("sections.outreach.title"),
+      description: t("sections.outreach.description"),
     },
   ];
 
@@ -125,6 +136,12 @@ export default async function DashboardPage({ params }: PageProps) {
       label: t("metrics.hoursSaved.title"),
       value: hoursSavedOverview.currentAmount.toLocaleString(locale),
       caption: t("metrics.hoursSaved.caption", { count: hoursSavedOverview.currentAmount }),
+    },
+    {
+      key: "outreach" as const,
+      label: t("metrics.outreach.title"),
+      value: outreachTotal.toLocaleString(locale),
+      caption: t("metrics.outreach.caption", { count: outreachTotal }),
     },
   ];
 

--- a/apps/www/app/[locale]/(site)/meeting/actions.ts
+++ b/apps/www/app/[locale]/(site)/meeting/actions.ts
@@ -19,6 +19,7 @@ export async function scheduleMeetingAction(
     email: String(formData.get("email") ?? ""),
     description: String(formData.get("description") ?? ""),
     locale: String(formData.get("locale") ?? "en"),
+    outreachSlug: String(formData.get("outreachSlug") ?? ""),
   };
 
   const parsed = meetingBookingSchema.safeParse(input);
@@ -57,6 +58,10 @@ export async function scheduleMeetingAction(
   const slot = result.slot;
   if (slot?.startAt && slot?.endAt) {
     await revalidatePath(`/${parsed.data.locale}/meeting`);
+    if (parsed.data.outreachSlug) {
+      await revalidatePath(`/${parsed.data.locale}/outreach/${parsed.data.outreachSlug}`);
+      await revalidatePath(`/outreach/${parsed.data.outreachSlug}`);
+    }
     return {
       status: "success" as const,
       slot: {

--- a/apps/www/app/[locale]/(site)/meeting/components/scheduler.tsx
+++ b/apps/www/app/[locale]/(site)/meeting/components/scheduler.tsx
@@ -40,6 +40,7 @@ type SchedulerDay = {
 type SchedulerProps = {
   days: SchedulerDay[];
   locale: string;
+  outreachSlug?: string | null;
 };
 
 const statusDotMap: Record<SchedulerDay["status"], string> = {
@@ -306,7 +307,7 @@ function TakenSlot({
   );
 }
 
-export function MeetingScheduler({ days, locale }: SchedulerProps) {
+export function MeetingScheduler({ days, locale, outreachSlug }: SchedulerProps) {
   const t = useTranslations("Meeting");
   const router = useRouter();
   const [selectedDayKey, setSelectedDayKey] = useState(() => {
@@ -517,12 +518,26 @@ export function MeetingScheduler({ days, locale }: SchedulerProps) {
         >
           <input type="hidden" name="slotId" value={selectedSlotId ?? ""} />
           <input type="hidden" name="locale" value={locale} />
+          <input type="hidden" name="outreachSlug" value={outreachSlug ?? ""} />
 
           <div className="space-y-4">
             <div>
               <h3 className="text-xl font-semibold text-white">{t("Form.heading")}</h3>
               <p className="mt-1 text-sm text-white/70">{t("Form.caption")}</p>
             </div>
+
+            {outreachSlug ? (
+              <div className="rounded-2xl border border-sky-400/40 bg-sky-500/10 p-4 text-xs text-sky-100 sm:text-sm">
+                <p className="font-medium tracking-wide uppercase text-sky-100/80">
+                  {t("Form.outreachTracking.title")}
+                </p>
+                <p className="mt-1 text-sky-100/80">
+                  {t("Form.outreachTracking.body", {
+                    slug: outreachSlug,
+                  })}
+                </p>
+              </div>
+            ) : null}
 
             {state.status === "success" && successMessage ? (
               <div className="rounded-2xl border border-emerald-400/40 bg-emerald-500/10 p-4 text-sm text-emerald-100">

--- a/apps/www/app/[locale]/(site)/meeting/page.tsx
+++ b/apps/www/app/[locale]/(site)/meeting/page.tsx
@@ -9,6 +9,7 @@ interface PageProps {
   params: {
     locale: string;
   };
+  searchParams?: Record<string, string | string[] | undefined>;
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
@@ -23,10 +24,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 
-export default async function MeetingPage({ params }: PageProps) {
+export default async function MeetingPage({ params, searchParams }: PageProps) {
   const { locale } = params;
   const t = await getTranslations({ locale, namespace: "Meeting" });
   const calendar = await getMeetingCalendar();
+  const outreachSlugParam = searchParams?.outreach;
+  const outreachSlug = Array.isArray(outreachSlugParam)
+    ? outreachSlugParam[0]
+    : outreachSlugParam ?? null;
 
   const days = calendar.map((day) => ({
     dateKey: day.dateKey,
@@ -63,7 +68,7 @@ export default async function MeetingPage({ params }: PageProps) {
           <p className="text-lg text-white/70 sm:text-xl">{t("Hero.subtitle")}</p>
         </div>
 
-        <MeetingScheduler days={days} locale={locale} />
+        <MeetingScheduler days={days} locale={locale} outreachSlug={outreachSlug} />
       </div>
     </div>
   );

--- a/apps/www/app/[locale]/(site)/outreach/[slug]/page.tsx
+++ b/apps/www/app/[locale]/(site)/outreach/[slug]/page.tsx
@@ -1,0 +1,160 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import { notFound } from "next/navigation";
+
+import { CTA } from "@/components/cta";
+import { Badge } from "@/components/ui/badge";
+import { CountdownTimer } from "@/components/outreach/countdown-timer";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { getOutreachPageBySlug, recordOutreachVisit } from "@/lib/outreach";
+
+interface PageProps {
+  params: {
+    locale: string;
+    slug: string;
+  };
+}
+
+export const dynamic = "force-dynamic";
+
+export default async function OutreachLandingPage({ params }: PageProps) {
+  const { locale, slug } = params;
+  const t = await getTranslations({ locale, namespace: "OutreachPage" });
+  const record = await recordOutreachVisit(slug);
+
+  if (!record) {
+    notFound();
+  }
+
+  const firstVisit = record.firstVisitedAt ?? record.createdAt;
+  const countdownTarget = new Date(firstVisit);
+  countdownTarget.setHours(countdownTarget.getHours() + 48);
+  const meetingHref = `/${locale}/meeting?outreach=${record.slug}` as const;
+  const templateLabel = t("templateBadge", { id: record.templateId });
+
+  const paragraphs = record.displayText
+    .split(/\r?\n\r?\n+/)
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0);
+  const leadParagraph = paragraphs[0] ?? record.displayText;
+  const detailParagraphs = paragraphs.slice(1);
+
+  return (
+    <div className="bg-black text-white">
+      <section className="relative overflow-hidden">
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(76,161,255,0.25),rgba(0,0,0,0.9))]" />
+        <div className="container flex flex-col gap-6 py-24 sm:gap-8 sm:py-32">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">
+              {t("eyebrow")}
+            </p>
+            <Badge className="w-fit border-white/20 bg-white/5 text-[11px] uppercase tracking-[0.3em] text-white/60" variant="outline">
+              {templateLabel}
+            </Badge>
+            <h1 className="max-w-3xl text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
+              {t("headline", { company: record.displayName })}
+            </h1>
+            <p className="text-sm text-white/50">/outreach/{record.slug}</p>
+          </div>
+
+          <div className="max-w-2xl space-y-4 text-base leading-relaxed text-white/70 sm:text-lg">
+            <p className="whitespace-pre-line">{leadParagraph}</p>
+          </div>
+
+          <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:items-center">
+            <Link
+              className={cn(
+                buttonVariants({ size: "lg" }),
+                "w-full sm:w-auto bg-white text-black hover:bg-white/90",
+              )}
+              href={meetingHref}
+            >
+              {t("primaryCta")}
+            </Link>
+            <Link
+              className={cn(
+                buttonVariants({ variant: "outline", size: "lg" }),
+                "w-full sm:w-auto border-white/40 text-white/80 hover:bg-white/10",
+              )}
+              href={`/${locale}/newsupdates`}
+            >
+              {t("secondaryCta")}
+            </Link>
+          </div>
+
+          {record.bookedMeeting ? (
+            <div className="rounded-2xl border border-emerald-400/40 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+              {t("bookedBanner")}
+            </div>
+          ) : null}
+
+          <div className="mt-6 flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-6 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-white/50">
+                {t("timer.eyebrow")}
+              </p>
+              <CountdownTimer
+                expiredLabel={t("timer.expired")}
+                runningTemplate={t("timer.running")}
+                target={countdownTarget.toISOString()}
+              />
+            </div>
+            <p className="text-xs text-white/50 sm:text-sm">{t("timer.helper")}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-white/10 bg-black/90 py-16 sm:py-24">
+        <div className="container space-y-8">
+          <div className="max-w-3xl space-y-3">
+            <h2 className="text-3xl font-semibold tracking-tight sm:text-[38px]">
+              {t("bodyTitle", { company: record.displayName })}
+            </h2>
+            <p className="text-base text-white/60 sm:text-lg">{t("bodySubtitle")}</p>
+          </div>
+
+          <div className="grid gap-6 text-base leading-relaxed text-white/70 sm:grid-cols-[minmax(0,1fr)]">
+            {(detailParagraphs.length > 0 ? detailParagraphs : [leadParagraph]).map((paragraph, index) => (
+              <div key={`detail-${index}`} className="rounded-2xl border border-white/10 bg-white/[0.03] p-6">
+                <p className="whitespace-pre-line text-sm sm:text-base">{paragraph}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-6 sm:p-8">
+            <h3 className="text-xl font-semibold text-white sm:text-2xl">{t("commitment.title")}</h3>
+            <p className="mt-3 text-sm leading-relaxed text-white/70 sm:text-base">
+              {t("commitment.body")}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <CTA />
+    </div>
+  );
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { locale, slug } = params;
+  const page = await getOutreachPageBySlug(slug);
+
+  if (!page) {
+    return {};
+  }
+
+  const t = await getTranslations({ locale, namespace: "OutreachPage" });
+  const title = t("metaTitle", { company: page.displayName });
+  const description = t("metaDescription");
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+    },
+  };
+}

--- a/apps/www/app/api/select-language/route.ts
+++ b/apps/www/app/api/select-language/route.ts
@@ -6,9 +6,19 @@ const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
 export async function POST(request: NextRequest) {
   const formData = await request.formData();
   const locale = resolveLocale(formData.get("locale"));
+  const nextPath = resolveNext(formData.get("next"));
 
   const redirectUrl = request.nextUrl.clone();
-  redirectUrl.pathname = `/${locale}`;
+  if (nextPath) {
+    const normalized = nextPath.startsWith("/") ? nextPath : `/${nextPath}`;
+    if (normalized.startsWith(`/${locale}/`) || normalized === `/${locale}`) {
+      redirectUrl.pathname = normalized;
+    } else {
+      redirectUrl.pathname = `/${locale}${normalized}`;
+    }
+  } else {
+    redirectUrl.pathname = `/${locale}`;
+  }
   redirectUrl.search = "";
 
   const response = NextResponse.redirect(redirectUrl, { status: 303 });
@@ -28,4 +38,12 @@ function resolveLocale(value: FormDataEntryValue | null): Locale {
   }
 
   return defaultLocale;
+}
+
+function resolveNext(value: FormDataEntryValue | null): string | null {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  return null;
 }

--- a/apps/www/app/outreach/[slug]/page.tsx
+++ b/apps/www/app/outreach/[slug]/page.tsx
@@ -1,0 +1,28 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { isLocale } from "@/i18n/routing";
+
+interface PageProps {
+  params: {
+    slug: string;
+  };
+  searchParams?: Record<string, string | string[] | undefined>;
+}
+
+export const dynamic = "force-dynamic";
+
+export default function OutreachRedirectPage({ params }: PageProps) {
+  const cookieLocale = cookies().get("NEXT_LOCALE")?.value;
+  const locale = cookieLocale && isLocale(cookieLocale) ? cookieLocale : null;
+  const targetSlug = params.slug;
+
+  if (locale) {
+    redirect(`/${locale}/outreach/${targetSlug}`);
+  }
+
+  const nextPath = `/outreach/${targetSlug}`;
+  const encodedNext = encodeURIComponent(nextPath);
+
+  redirect(`/select-language?next=${encodedNext}`);
+}

--- a/apps/www/app/select-language/page.tsx
+++ b/apps/www/app/select-language/page.tsx
@@ -8,7 +8,13 @@ type LanguageOption = {
   label: string;
 };
 
-export default async function SelectLanguagePage() {
+interface SelectLanguagePageProps {
+  searchParams?: Record<string, string | string[] | undefined>;
+}
+
+export default async function SelectLanguagePage({
+  searchParams,
+}: SelectLanguagePageProps) {
   const cookieLocale = cookies().get("NEXT_LOCALE")?.value;
   const previewLocale = cookieLocale && isLocale(cookieLocale) ? cookieLocale : defaultLocale;
   const messages = (await import("@/messages/en.json")).default;
@@ -17,6 +23,9 @@ export default async function SelectLanguagePage() {
     namespace: "Language",
     messages,
   });
+
+  const nextParam = searchParams?.next;
+  const nextPath = Array.isArray(nextParam) ? nextParam[0] : nextParam ?? "";
 
   const options: Array<LanguageOption> = [
     { locale: "en", label: t("english") },
@@ -53,6 +62,7 @@ export default async function SelectLanguagePage() {
                 {t("selectTitle")}
               </h1>
               <form action="/api/select-language" method="post" className="mt-4 grid w-full gap-4 text-left">
+                <input type="hidden" name="next" value={nextPath} />
                 {options.map(({ locale, label }) => (
                   <button
                     key={locale}

--- a/apps/www/components/hero/hours-saved-ticker.tsx
+++ b/apps/www/components/hero/hours-saved-ticker.tsx
@@ -6,7 +6,7 @@ import { useAnimate, useInView, useReducedMotion } from "framer-motion";
 import { cn } from "@/lib/utils";
 
 export type HoursSavedNumberFormatOptions = Pick<
-  Intl.NumberFormatResolvedOptions,
+  Intl.ResolvedNumberFormatOptions,
   | "locale"
   | "numberingSystem"
   | "style"

--- a/apps/www/components/outreach/countdown-timer.tsx
+++ b/apps/www/components/outreach/countdown-timer.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+interface CountdownTimerProps {
+  target: string;
+  runningTemplate: string;
+  expiredLabel: string;
+}
+
+function buildLabel(
+  target: string,
+  runningTemplate: string,
+  expiredLabel: string,
+): { label: string; expired: boolean } {
+  const targetTime = new Date(target).getTime();
+  const now = Date.now();
+  const diff = targetTime - now;
+
+  if (!Number.isFinite(targetTime) || diff <= 0) {
+    return { label: expiredLabel, expired: true };
+  }
+
+  const totalSeconds = Math.floor(diff / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const parts: string[] = [];
+
+  if (days > 0) {
+    parts.push(`${days}d`);
+  }
+
+  parts.push(`${hours.toString().padStart(2, "0")}h`);
+  parts.push(`${minutes.toString().padStart(2, "0")}m`);
+  parts.push(`${seconds.toString().padStart(2, "0")}s`);
+
+  const formatted = parts.join(" ");
+
+  return {
+    label: runningTemplate.replace("{time}", formatted),
+    expired: false,
+  };
+}
+
+export function CountdownTimer({ target, runningTemplate, expiredLabel }: CountdownTimerProps) {
+  const initial = useMemo(() => buildLabel(target, runningTemplate, expiredLabel), [
+    target,
+    runningTemplate,
+    expiredLabel,
+  ]);
+  const [label, setLabel] = useState(initial.label);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      const next = buildLabel(target, runningTemplate, expiredLabel);
+      setLabel(next.label);
+
+      if (next.expired) {
+        window.clearInterval(interval);
+      }
+    }, 1000);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [target, runningTemplate, expiredLabel]);
+
+  return <p className="text-lg font-semibold text-white">{label}</p>;
+}

--- a/apps/www/drizzle/0003_outreach_pages.sql
+++ b/apps/www/drizzle/0003_outreach_pages.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "outreach_pages" (
+  "id" text PRIMARY KEY NOT NULL,
+  "slug" text NOT NULL,
+  "display_name" text NOT NULL,
+  "display_text" text NOT NULL,
+  "visit_count" integer DEFAULT 0 NOT NULL,
+  "first_visited_at" timestamp with time zone,
+  "last_visited_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "outreach_pages_slug_unique" ON "outreach_pages" ("slug");

--- a/apps/www/drizzle/0004_outreach_templates.sql
+++ b/apps/www/drizzle/0004_outreach_templates.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "outreach_pages"
+  ADD COLUMN "template_id" integer NOT NULL DEFAULT 1,
+  ADD COLUMN "booked_meeting" boolean NOT NULL DEFAULT false,
+  ADD COLUMN "booked_meeting_at" timestamp with time zone;

--- a/apps/www/lib/account-history.ts
+++ b/apps/www/lib/account-history.ts
@@ -42,8 +42,9 @@ function writeCookieValue(name: string, value: string, maxAgeSeconds: number) {
 function sanitizeEntries(entries: AccountHistoryEntry[]): AccountHistoryEntry[] {
   return entries
     .filter((entry) => Boolean(entry?.id) && Boolean(entry?.email))
-    .map((entry) => ({
-      ...entry,
+    .map<AccountHistoryEntry>((entry) => ({
+      id: entry.id,
+      email: entry.email,
       name: entry.name ?? null,
       role: entry.role === "staff" ? "staff" : "client",
       lastActiveAt: entry.lastActiveAt ?? new Date(0).toISOString(),

--- a/apps/www/lib/db/schema.ts
+++ b/apps/www/lib/db/schema.ts
@@ -203,6 +203,33 @@ export const hoursSavedIncrements = pgTable(
   }),
 );
 
+export const outreachPages = pgTable(
+  "outreach_pages",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    slug: text("slug").notNull(),
+    displayName: text("display_name").notNull(),
+    displayText: text("display_text").notNull(),
+    templateId: integer("template_id").notNull().default(1),
+    bookedMeeting: boolean("booked_meeting").notNull().default(false),
+    bookedMeetingAt: timestamp("booked_meeting_at", { mode: "date", withTimezone: true }),
+    visitCount: integer("visit_count").notNull().default(0),
+    firstVisitedAt: timestamp("first_visited_at", { mode: "date", withTimezone: true }),
+    lastVisitedAt: timestamp("last_visited_at", { mode: "date", withTimezone: true }),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => ({
+    slugIdx: uniqueIndex("outreach_pages_slug_unique").on(table.slug),
+  }),
+);
+
 export const usersRelations = relations(users, ({ many }) => ({
   accounts: many(accounts),
   sessions: many(sessions),

--- a/apps/www/lib/meetings/mutations.ts
+++ b/apps/www/lib/meetings/mutations.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 
 import { db } from "@/lib/db/client";
-import { meetingBookings, meetingSlots } from "@/lib/db/schema";
+import { meetingBookings, meetingSlots, outreachPages } from "@/lib/db/schema";
 
 import { getSlotById } from "./queries";
 
@@ -58,6 +58,17 @@ export async function bookMeetingSlot(input: unknown) {
       .update(meetingSlots)
       .set({ status: "booked", updatedAt: new Date() })
       .where(eq(meetingSlots.id, data.slotId));
+
+    if (data.outreachSlug) {
+      await tx
+        .update(outreachPages)
+        .set({
+          bookedMeeting: true,
+          bookedMeetingAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(outreachPages.slug, data.outreachSlug));
+    }
 
     const updatedSlot = await tx.query.meetingSlots.findFirst({
       where: (slots, { eq }) => eq(slots.id, data.slotId),

--- a/apps/www/lib/meetings/validation.ts
+++ b/apps/www/lib/meetings/validation.ts
@@ -48,6 +48,13 @@ export const meetingBookingSchema = z.object({
   email: z.string().email().max(320),
   description: z.string().min(10).max(1000),
   locale: z.string().min(2).max(8),
+  outreachSlug: z
+    .string()
+    .min(1)
+    .max(120)
+    .optional()
+    .or(z.literal(""))
+    .transform((value) => value?.trim() || undefined),
 });
 
 export const slotTimingSchema = slotTimingObjectSchema.superRefine(

--- a/apps/www/lib/outreach/index.ts
+++ b/apps/www/lib/outreach/index.ts
@@ -1,0 +1,213 @@
+import { unstable_noStore as noStore } from "next/cache";
+
+import { db } from "@/lib/db/client";
+import { outreachPages } from "@/lib/db/schema";
+import { desc, eq, inArray } from "drizzle-orm";
+
+import { toOutreachSlug } from "./slug";
+
+export interface OutreachPageRecord {
+  id: string;
+  slug: string;
+  displayName: string;
+  displayText: string;
+  templateId: number;
+  bookedMeeting: boolean;
+  bookedMeetingAt: Date | null;
+  visitCount: number;
+  firstVisitedAt: Date | null;
+  lastVisitedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SerializedOutreachPageRecord
+  extends Omit<OutreachPageRecord, "firstVisitedAt" | "lastVisitedAt" | "bookedMeetingAt" | "createdAt" | "updatedAt"> {
+  firstVisitedAt: string | null;
+  lastVisitedAt: string | null;
+  bookedMeetingAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ImportEntry {
+  name: string;
+  text: string;
+  templateId: number;
+}
+
+interface ImportResult {
+  created: number;
+  updated: number;
+  slugs: string[];
+}
+
+export async function listOutreachPages(): Promise<OutreachPageRecord[]> {
+  noStore();
+
+  const rows = await db.query.outreachPages.findMany({
+    orderBy: [desc(outreachPages.createdAt)],
+  });
+
+  return rows.map((row) => ({
+    ...row,
+    bookedMeetingAt: row.bookedMeetingAt ?? null,
+    firstVisitedAt: row.firstVisitedAt ?? null,
+    lastVisitedAt: row.lastVisitedAt ?? null,
+  }));
+}
+
+export async function getOutreachPageBySlug(
+  slug: string,
+): Promise<OutreachPageRecord | null> {
+  noStore();
+
+  const row = await db.query.outreachPages.findFirst({
+    where: eq(outreachPages.slug, slug),
+  });
+
+  if (!row) {
+    return null;
+  }
+
+  return {
+    ...row,
+    bookedMeetingAt: row.bookedMeetingAt ?? null,
+    firstVisitedAt: row.firstVisitedAt ?? null,
+    lastVisitedAt: row.lastVisitedAt ?? null,
+  };
+}
+
+export async function recordOutreachVisit(
+  slug: string,
+): Promise<OutreachPageRecord | null> {
+  const existing = await getOutreachPageBySlug(slug);
+
+  if (!existing) {
+    return null;
+  }
+
+  const now = new Date();
+  const firstVisitedAt = existing.firstVisitedAt ?? now;
+
+  const [updated] = await db
+    .update(outreachPages)
+    .set({
+      firstVisitedAt,
+      lastVisitedAt: now,
+      visitCount: existing.visitCount + 1,
+      updatedAt: now,
+    })
+    .where(eq(outreachPages.id, existing.id))
+    .returning();
+
+  const record = updated ?? {
+    ...existing,
+    bookedMeetingAt: existing.bookedMeetingAt,
+    firstVisitedAt,
+    lastVisitedAt: now,
+    visitCount: existing.visitCount + 1,
+    updatedAt: now,
+  };
+
+  return {
+    ...record,
+    bookedMeetingAt: record.bookedMeetingAt ?? null,
+    firstVisitedAt: record.firstVisitedAt ?? null,
+    lastVisitedAt: record.lastVisitedAt ?? null,
+  };
+}
+
+export async function importOutreachEntries(entries: ImportEntry[]): Promise<ImportResult> {
+  noStore();
+
+  const cleaned = entries
+    .map((entry) => ({
+      name: entry.name.trim(),
+      text: entry.text.trim(),
+      templateId: entry.templateId,
+    }))
+    .filter((entry) => entry.name.length > 0 && entry.text.length > 0);
+
+  const deduped = new Map<string, ImportEntry>();
+
+  for (const entry of cleaned) {
+    const slug = toOutreachSlug(entry.name);
+
+    if (!slug) {
+      continue;
+    }
+
+    deduped.set(slug, entry);
+  }
+
+  const uniqueEntries = Array.from(deduped.entries()).map(([slug, entry]) => ({
+    slug,
+    name: entry.name,
+    text: entry.text,
+    templateId: entry.templateId,
+  }));
+
+  if (uniqueEntries.length === 0) {
+    return { created: 0, updated: 0, slugs: [] };
+  }
+
+  const slugList = uniqueEntries.map((entry) => entry.slug);
+  const existingRows = slugList.length
+    ? await db
+        .select({ slug: outreachPages.slug })
+        .from(outreachPages)
+        .where(inArray(outreachPages.slug, slugList))
+    : [];
+
+  const existingSet = new Set(existingRows.map((row) => row.slug));
+  const now = new Date();
+
+  for (const entry of uniqueEntries) {
+    await db
+      .insert(outreachPages)
+      .values({
+        slug: entry.slug,
+        displayName: entry.name,
+        displayText: entry.text,
+        templateId: entry.templateId,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: outreachPages.slug,
+        set: {
+          displayName: entry.name,
+          displayText: entry.text,
+          templateId: entry.templateId,
+          updatedAt: now,
+        },
+      });
+  }
+
+  const created = uniqueEntries.filter((entry) => !existingSet.has(entry.slug)).length;
+  const updated = uniqueEntries.length - created;
+
+  return { created, updated, slugs: slugList };
+}
+
+export function serializeOutreachPages(
+  pages: OutreachPageRecord[],
+): SerializedOutreachPageRecord[] {
+  return pages.map((page) => ({
+    ...page,
+    createdAt: page.createdAt.toISOString(),
+    updatedAt: page.updatedAt.toISOString(),
+    firstVisitedAt: page.firstVisitedAt ? page.firstVisitedAt.toISOString() : null,
+    lastVisitedAt: page.lastVisitedAt ? page.lastVisitedAt.toISOString() : null,
+    bookedMeetingAt: page.bookedMeetingAt ? page.bookedMeetingAt.toISOString() : null,
+  }));
+}
+
+export async function deleteOutreachPage(slug: string): Promise<boolean> {
+  const result = await db
+    .delete(outreachPages)
+    .where(eq(outreachPages.slug, slug))
+    .returning({ id: outreachPages.id });
+
+  return result.length > 0;
+}

--- a/apps/www/lib/outreach/slug.ts
+++ b/apps/www/lib/outreach/slug.ts
@@ -1,0 +1,11 @@
+export function toOutreachSlug(value: string): string {
+  const normalized = value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+
+  return normalized;
+}

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -94,6 +94,10 @@
       "submit": "Schedule meeting",
       "submitPending": "Scheduling…",
       "privacy": "We only use your email to share the meeting link and follow-up notes.",
+      "outreachTracking": {
+        "title": "Tracking outreach link",
+        "body": "We’ll record this booking against /outreach/{slug} so your personalised dashboard stays up to date."
+      },
       "success": {
         "title": "Meeting confirmed",
         "message": "The meeting will take place through Google Zoom on {date}. Ten minutes before the meeting you will receive a link to the meeting."
@@ -1306,6 +1310,145 @@
       }
     }
   },
+  "DashboardOutreach": {
+    "eyebrow": "Outreach workspace",
+    "title": "Spin up personalised outreach pages",
+    "subtitle": "Import company names and talking points, preview the batch, and push bespoke landing pages live in seconds.",
+    "currentUser": "Signed in as {email}",
+    "metrics": {
+      "total": {
+        "label": "Pages published",
+        "caption": "{count, plural, one {# live page} other {# live pages}}"
+      },
+      "visited": {
+        "label": "Pages visited",
+        "caption": "{count, plural, one {# link opened} other {# links opened}}"
+      },
+      "untouched": {
+        "label": "Awaiting first visit",
+        "caption": "{count, plural, one {# page still unused} other {# pages still unused}}"
+      },
+      "booked": {
+        "label": "Meetings booked",
+        "caption": "{count, plural, one {# meeting confirmed} other {# meetings confirmed}}"
+      }
+    },
+    "templates": {
+      "eyebrow": "Template library",
+      "title": "Choose the personalised layout",
+      "description": "Preview the current outreach templates before assigning them inside the CSV.",
+      "badge": "Template {id}",
+      "items": {
+        "1": {
+          "title": "Consultative hero with countdown",
+          "body": "Highlights the prospect name, reiterates our offer, and drives an instant booking CTA with a 48-hour timer.",
+          "points": [
+            "Hero headline personalised with the company name",
+            "Countdown timer nudging a fast response",
+            "Primary CTA deep-linking into the meeting scheduler"
+          ]
+        }
+      }
+    },
+    "upload": {
+      "eyebrow": "CSV uploader",
+      "title": "Import outreach copy",
+      "description": "Upload a CSV with Name, Text to display, and Template columns. We'll validate each row before anything goes live.",
+      "cta": "Choose CSV",
+      "fileSelected": "Selected: {name}",
+      "noFile": "No file selected yet",
+      "push": "Push {count, plural, one {# page} other {# pages}}",
+      "pushing": "Pushing…",
+      "validation": "Upload a CSV that includes Name, Text to display, and Template columns before pushing.",
+      "previewLabel": "{count, plural, one {# entry ready} other {# entries ready}}",
+      "previewColumns": {
+        "name": "Company name",
+        "slug": "Slug",
+        "template": "Template",
+        "templateLabel": "Template {id}",
+        "text": "Text to display"
+      },
+      "errors": {
+        "title": "{count, plural, one {We found # issue} other {We found # issues}}",
+        "empty": "The file looks empty—add at least one row before uploading.",
+        "missingColumns": "Add \"Name\", \"Text to display\", and \"Template\" columns to the CSV.",
+        "missingValues": "Row {row} is missing either the name or the text to display.",
+        "invalidSlug": "Row {row} cannot be converted into a valid URL slug.",
+        "invalidTemplate": "Row {row} needs a template number (1, 2, 3…)."
+      }
+    },
+    "status": {
+      "success": "Pushed {created, plural, one {# new page} other {# new pages}} and updated {updated, plural, one {# existing page} other {# existing pages}}.",
+      "validation": "Fix the highlighted CSV issues and try again.",
+      "unauthorized": "You are not authorized to manage outreach pages.",
+      "error": "We couldn't process the upload. Try again."
+    },
+    "filters": {
+      "sortBy": "Sort by",
+      "sortOrder": "Sort order",
+      "order": {
+        "asc": "Oldest first",
+        "desc": "Newest first"
+      },
+      "sortOptions": {
+        "createdAt": "Date added",
+        "lastVisitedAt": "Last visit",
+        "visitCount": "Total visits"
+      },
+      "visitStatus": "Visit status",
+      "visitOptions": {
+        "any": "All pages",
+        "visited": "Visited pages",
+        "notVisited": "Not yet visited"
+      },
+      "booked": "Booked meeting",
+      "bookedOptions": {
+        "any": "All",
+        "yes": "Booked",
+        "no": "Not booked"
+      },
+      "addedOn": "Added on",
+      "templates": "Templates",
+      "templateLabel": "Template {id}",
+      "templatesEmpty": "Templates will appear here once you've published pages.",
+      "clear": "Clear all filters"
+    },
+    "table": {
+      "eyebrow": "Published pages",
+      "title": "Live outreach links",
+      "description": "Track every personalised link, see which prospects have opened it, and refine the view with filters when the list grows.",
+      "empty": "No outreach pages have been pushed yet.",
+      "noMatches": "No outreach pages match your filters.",
+      "openLink": "Open page",
+      "delete": {
+        "label": "Delete",
+        "pending": "Deleting…",
+        "success": "Removed /outreach/{slug} successfully.",
+        "error": "We couldn't delete that outreach page. Try again.",
+        "notFound": "That outreach page has already been removed."
+      },
+      "columns": {
+        "company": "Company",
+        "link": "Link",
+        "template": "Template",
+        "text": "Displayed text",
+        "visits": "Visits",
+        "added": "Added",
+        "booked": "Booked meeting",
+        "updated": "Last updated",
+        "actions": "Actions"
+      },
+      "status": {
+        "visited": "{count, plural, one {Visited once} other {Visited # times}}",
+        "pending": "Awaiting first visit",
+        "notVisited": "Not visited yet"
+      },
+      "bookedStatus": {
+        "yes": "Booked",
+        "no": "Not booked"
+      }
+    }
+  },
   "DashboardOverview": {
     "eyebrow": "Staff workspace",
     "title": "Choose the area you want to manage",
@@ -1322,6 +1465,11 @@
         "eyebrow": "Planning",
         "title": "Coordinate the meeting agenda",
         "description": "Review availability, assign colleagues, and publish upcoming TransformAI strategy sessions."
+      },
+      "outreach": {
+        "eyebrow": "Outreach",
+        "title": "Launch personalised landing pages",
+        "description": "Upload company-specific copy and push bespoke outreach pages that come to life the moment a prospect clicks."
       }
     },
     "metrics": {
@@ -1341,6 +1489,10 @@
         "title": "Hours saved with AI",
         "caption": "{count, plural, one {# hour automated} other {# hours automated}}",
         "manage": "Open planner"
+      },
+      "outreach": {
+        "title": "Outreach pages live",
+        "caption": "{count, plural, one {# personalised link published} other {# personalised links published}}"
       },
       "ratio": {
         "title": "Client-to-staff ratio",
@@ -1399,6 +1551,28 @@
         "briefings": "Prepare January leadership briefings showcasing ROI metrics from automation pilots."
       }
     }
+  },
+  "OutreachPage": {
+    "eyebrow": "Tailored for your team",
+    "headline": "How TransformAI can accelerate {company}",
+    "templateBadge": "Template {id}",
+    "primaryCta": "Book a strategy session",
+    "secondaryCta": "Explore recent wins",
+    "timer": {
+      "eyebrow": "Hold timer",
+      "running": "Reserved for you · {time} left",
+      "expired": "This invitation window has closed",
+      "helper": "We hold this personalised plan for 48 hours from your first visit."
+    },
+    "bodyTitle": "What this collaboration unlocks for {company}",
+    "bodySubtitle": "We crafted this mini-brief after researching your public footprint and current AI readiness.",
+    "bookedBanner": "A meeting is already confirmed from this page—we’ll arrive prepared with next steps.",
+    "commitment": {
+      "title": "What to expect next",
+      "body": "Share the landing page internally or book a call above and we will tailor a concrete transformation roadmap aligned to your priorities."
+    },
+    "metaTitle": "{company} × TransformAI",
+    "metaDescription": "A bespoke TransformAI overview prepared for your team."
   },
   "hoursSaved": {
     "dialog": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -94,6 +94,10 @@
       "submit": "Afspraak inplannen",
       "submitPending": "Bezig met plannen…",
       "privacy": "We gebruiken je e-mail alleen voor de meetinglink en opvolging.",
+      "outreachTracking": {
+        "title": "Outreach-link wordt gevolgd",
+        "body": "We koppelen deze boeking aan /outreach/{slug} zodat het dashboard direct meeloopt."
+      },
       "success": {
         "title": "Meeting bevestigd",
         "message": "De meeting vindt plaats via Google Zoom op {date}. Tien minuten voor de meeting ontvang je een link."
@@ -1263,6 +1267,145 @@
       }
     }
   },
+  "DashboardOutreach": {
+    "eyebrow": "Outreach-werkruimte",
+    "title": "Zet gepersonaliseerde outreachpagina’s klaar",
+    "subtitle": "Importeer bedrijfsnamen met maatwerkboodschappen, controleer de batch en publiceer binnen enkele seconden.",
+    "currentUser": "Ingelogd als {email}",
+    "metrics": {
+      "total": {
+        "label": "Pagina’s gepubliceerd",
+        "caption": "{count, plural, one {# pagina live} other {# pagina’s live}}"
+      },
+      "visited": {
+        "label": "Pagina’s bezocht",
+        "caption": "{count, plural, one {# link geopend} other {# links geopend}}"
+      },
+      "untouched": {
+        "label": "Wacht op eerste bezoek",
+        "caption": "{count, plural, one {# pagina wacht nog} other {# pagina’s wachten nog}}"
+      },
+      "booked": {
+        "label": "Meetings geboekt",
+        "caption": "{count, plural, one {# meeting bevestigd} other {# meetings bevestigd}}"
+      }
+    },
+    "templates": {
+      "eyebrow": "Templatebibliotheek",
+      "title": "Kies de gepersonaliseerde lay-out",
+      "description": "Bekijk de huidige outreach-templates voordat je ze in de CSV toewijst.",
+      "badge": "Template {id}",
+      "items": {
+        "1": {
+          "title": "Consultatieve hero met countdown",
+          "body": "Benadrukt de bedrijfsnaam, herhaalt ons aanbod en stuurt op een directe boeking met een timer van 48 uur.",
+          "points": [
+            "Hero-headline met de bedrijfsnaam",
+            "Countdown die aanzet tot snelle reactie",
+            "Primaire CTA linkt direct naar de meetingplanner"
+          ]
+        }
+      }
+    },
+    "upload": {
+      "eyebrow": "CSV-upload",
+      "title": "Importeer outreach-tekst",
+      "description": "Upload een CSV met de kolommen Naam, Tekst voor op de pagina en Template. We controleren elke rij voordat hij live gaat.",
+      "cta": "Kies CSV",
+      "fileSelected": "Geselecteerd: {name}",
+      "noFile": "Nog geen bestand gekozen",
+      "push": "Publiceer {count, plural, one {# pagina} other {# pagina’s}}",
+      "pushing": "Publiceren…",
+      "validation": "Upload een CSV met Naam, Tekst voor op de pagina en Template voordat je publiceert.",
+      "previewLabel": "{count, plural, one {# item klaar} other {# items klaar}}",
+      "previewColumns": {
+        "name": "Bedrijfsnaam",
+        "slug": "Slug",
+        "template": "Template",
+        "templateLabel": "Template {id}",
+        "text": "Tekst op de pagina"
+      },
+      "errors": {
+        "title": "{count, plural, one {We vonden # fout} other {We vonden # fouten}}",
+        "empty": "Het bestand lijkt leeg—voeg minstens één rij toe.",
+        "missingColumns": "Voeg de kolommen \"Naam\", \"Tekst voor op de pagina\" en \"Template\" toe.",
+        "missingValues": "Rij {row} mist de naam of de tekst.",
+        "invalidSlug": "Rij {row} kan niet worden omgezet in een geldige URL-slug.",
+        "invalidTemplate": "Rij {row} heeft een templatenummer nodig (1, 2, 3…)."
+      }
+    },
+    "status": {
+      "success": "Geplaatst: {created, plural, one {# nieuwe pagina} other {# nieuwe pagina’s}} en bijgewerkt: {updated, plural, one {# bestaande pagina} other {# bestaande pagina’s}}.",
+      "validation": "Los de gemarkeerde CSV-problemen op en probeer het opnieuw.",
+      "unauthorized": "Je hebt geen rechten om outreachpagina’s te beheren.",
+      "error": "Het uploaden is mislukt. Probeer het opnieuw."
+    },
+    "filters": {
+      "sortBy": "Sorteren op",
+      "sortOrder": "Sorteervolgorde",
+      "order": {
+        "asc": "Oudste eerst",
+        "desc": "Nieuwste eerst"
+      },
+      "sortOptions": {
+        "createdAt": "Datum toegevoegd",
+        "lastVisitedAt": "Laatste bezoek",
+        "visitCount": "Totaal bezoeken"
+      },
+      "visitStatus": "Bezoekstatus",
+      "visitOptions": {
+        "any": "Alle pagina’s",
+        "visited": "Bezochte pagina’s",
+        "notVisited": "Nog niet bezocht"
+      },
+      "booked": "Meeting geboekt",
+      "bookedOptions": {
+        "any": "Alle",
+        "yes": "Geboekt",
+        "no": "Niet geboekt"
+      },
+      "addedOn": "Toegevoegd op",
+      "templates": "Templates",
+      "templateLabel": "Template {id}",
+      "templatesEmpty": "Templates verschijnen hier zodra er pagina’s live staan.",
+      "clear": "Filters wissen"
+    },
+    "table": {
+      "eyebrow": "Gepubliceerde pagina’s",
+      "title": "Live outreach-links",
+      "description": "Volg elke gepersonaliseerde link, zie wie hem opent en filter wanneer de lijst groeit.",
+      "empty": "Er zijn nog geen outreachpagina’s gepubliceerd.",
+      "noMatches": "Geen outreachpagina’s voldoen aan je filters.",
+      "openLink": "Pagina openen",
+      "delete": {
+        "label": "Verwijderen",
+        "pending": "Verwijderen…",
+        "success": "/outreach/{slug} is verwijderd.",
+        "error": "Het verwijderen is mislukt. Probeer het opnieuw.",
+        "notFound": "Deze outreachpagina was al verwijderd."
+      },
+      "columns": {
+        "company": "Bedrijf",
+        "link": "Link",
+        "template": "Template",
+        "text": "Getoonde tekst",
+        "visits": "Bezoeken",
+        "added": "Toegevoegd",
+        "booked": "Meeting geboekt",
+        "updated": "Laatst bijgewerkt",
+        "actions": "Acties"
+      },
+      "status": {
+        "visited": "{count, plural, one {Eén keer bezocht} other {# keer bezocht}}",
+        "pending": "Wacht op eerste bezoek",
+        "notVisited": "Nog niet bezocht"
+      },
+      "bookedStatus": {
+        "yes": "Geboekt",
+        "no": "Niet geboekt"
+      }
+    }
+  },
   "DashboardOverview": {
     "eyebrow": "Teamomgeving",
     "title": "Kies welke module je wilt openen",
@@ -1279,6 +1422,11 @@
         "eyebrow": "Planning",
         "title": "Stem de agenda af",
         "description": "Bekijk de beschikbaarheid, wijs collega’s toe en publiceer aankomende TransformAI-strategiesessies."
+      },
+      "outreach": {
+        "eyebrow": "Outreach",
+        "title": "Activeer gepersonaliseerde landingspagina’s",
+        "description": "Upload bedrijfsnamen met maatwerktekst en publiceer de pagina zodra een prospect klikt."
       }
     },
     "metrics": {
@@ -1298,6 +1446,10 @@
         "title": "Bespaarde uren met AI",
         "caption": "{count, plural, one {# uur geautomatiseerd} other {# uren geautomatiseerd}}",
         "manage": "Planner openen"
+      },
+      "outreach": {
+        "title": "Outreach-pagina’s live",
+        "caption": "{count, plural, one {# gepersonaliseerde link live} other {# gepersonaliseerde links live}}"
       },
       "ratio": {
         "title": "Verhouding klant/staff",
@@ -1356,6 +1508,28 @@
         "briefings": "Bereid leiderschapsbriefings voor januari voor met ROI-cijfers uit de automatiseringspilots."
       }
     }
+  },
+  "OutreachPage": {
+    "eyebrow": "Speciaal voor jullie team",
+    "headline": "Hoe TransformAI {company} versnelt",
+    "templateBadge": "Template {id}",
+    "primaryCta": "Plan een strategiegesprek",
+    "secondaryCta": "Bekijk recente resultaten",
+    "timer": {
+      "eyebrow": "Reservering",
+      "running": "Gereserveerd voor jullie · nog {time}",
+      "expired": "Dit aanbod is verlopen",
+      "helper": "We houden deze gepersonaliseerde pagina 48 uur voor jullie vrij vanaf het eerste bezoek."
+    },
+    "bodyTitle": "Wat deze samenwerking {company} oplevert",
+    "bodySubtitle": "We stelden dit mini-voorstel samen op basis van jullie publieke profiel en huidige AI-rijpheid.",
+    "bookedBanner": "Via deze pagina is al een meeting ingepland—wij bereiden concrete vervolgstappen voor.",
+    "commitment": {
+      "title": "Wat je van ons mag verwachten",
+      "body": "Deel de pagina intern of plan het gesprek hierboven; we werken graag een concrete AI-roadmap op maat uit."
+    },
+    "metaTitle": "{company} × TransformAI",
+    "metaDescription": "Een persoonlijk TransformAI-overzicht voor jullie team."
   },
   "hoursSaved": {
     "dialog": {

--- a/middleware.ts
+++ b/middleware.ts
@@ -16,6 +16,23 @@ export default function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  if (pathname === "/outreach" || pathname.startsWith("/outreach/")) {
+    const cookieLocale = request.cookies.get("NEXT_LOCALE")?.value;
+    const hasLocale = cookieLocale && locales.includes(cookieLocale as (typeof locales)[number]);
+
+    if (hasLocale) {
+      const localizedUrl = request.nextUrl.clone();
+      localizedUrl.pathname = `/${cookieLocale}${pathname}`;
+      return NextResponse.redirect(localizedUrl);
+    }
+
+    const selectLanguageUrl = request.nextUrl.clone();
+    selectLanguageUrl.pathname = "/select-language";
+    const nextPath = `${pathname}${request.nextUrl.search}`;
+    selectLanguageUrl.searchParams.set("next", nextPath);
+    return NextResponse.redirect(selectLanguageUrl);
+  }
+
   if (pathname === "/") {
     const cookieLocale = request.cookies.get("NEXT_LOCALE")?.value;
 


### PR DESCRIPTION
## Summary
- add template-aware outreach storage, CSV import, and staff dashboard filtering with deletion controls
- track outreach bookings via the meeting scheduler and surface template context on personalised pages
- expose locale-neutral `/outreach/[slug]` routing with middleware and language picker updates

## Testing
- `pnpm --filter www run typecheck` *(fails: repository still missing next-intl/drizzle type declarations in this environment)*
- `pnpm --filter www run lint` *(fails: next lint cannot resolve the next-intl package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e11408fc24832a9e89af2939c8e079