### PR TITLE
Fix chat panel chunk loading error

### DIFF
--- a/WRITE_HERE/FIXES/2025-12-01T1800--prevent-chat-panel-chunkloaderror.md
+++ b/WRITE_HERE/FIXES/2025-12-01T1800--prevent-chat-panel-chunkloaderror.md
@@ -1,0 +1,6 @@
+# Prevent chat panel ChunkLoadError
+
+- **What:** Updated the chat panel export to provide a default export and simplified the dynamic imports in the sticky and pricing chat wrappers to consume it.
+- **Why:** The runtime attempted to fetch `/_next/undefined` because the dynamic loader couldn't determine the chunk ID when resolving the named export, causing the chat widget to crash on scroll.
+- **Files:** `apps/www/components/ask/ChatPanel.tsx`, `apps/www/components/ask/StickyChat.tsx`, `apps/www/components/ask/PricingChat.tsx`
+- **Follow-ups:** Monitor bundle metrics; if the chat panel remains heavy, consider reintroducing code-splitting with an explicit chunk name helper once verified.

--- a/apps/www/components/ask/ChatPanel.tsx
+++ b/apps/www/components/ask/ChatPanel.tsx
@@ -15,7 +15,7 @@ import {
 } from "react";
 import type { ChatLocale, ChatMessage } from "./types";
 
-type ChatPanelProps = {
+export type ChatPanelProps = {
   messages: ChatMessage[];
   isOpen: boolean;
   isLoading: boolean;
@@ -30,7 +30,7 @@ type ChatPanelProps = {
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-export const ChatPanel: React.FC<ChatPanelProps> = ({
+const ChatPanel: React.FC<ChatPanelProps> = ({
   messages,
   isOpen,
   isLoading,
@@ -322,6 +322,9 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
 };
 
 ChatPanel.displayName = "ChatPanel";
+
+export { ChatPanel };
+export default ChatPanel;
 
 type MessageBubbleProps = {
   message: ChatMessage;

--- a/apps/www/components/ask/PricingChat.tsx
+++ b/apps/www/components/ask/PricingChat.tsx
@@ -9,7 +9,9 @@ import { cn } from "@/lib/utils";
 import { AskCta } from "./AskCta";
 import type { ChatLocale, ChatMessage } from "./types";
 
-const ChatPanel = dynamic(() => import("./ChatPanel").then((mod) => mod.ChatPanel), {
+type ChatPanelComponent = typeof import("./ChatPanel").default;
+
+const ChatPanel = dynamic<ChatPanelComponent>(() => import("./ChatPanel"), {
   ssr: false,
 });
 

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -18,7 +18,9 @@ import { AskCta } from "./AskCta";
 import type { ChatLocale, ChatMessage } from "./types";
 import { useStickyWithinSection } from "./use-sticky-within-section";
 
-const ChatPanel = dynamic(() => import("./ChatPanel").then((mod) => mod.ChatPanel), {
+type ChatPanelComponent = typeof import("./ChatPanel").default;
+
+const ChatPanel = dynamic<ChatPanelComponent>(() => import("./ChatPanel"), {
   ssr: false,
 });
 


### PR DESCRIPTION
## Plan
- Update the chat panel module to provide a default export that Next.js dynamic imports can resolve reliably.
- Refactor sticky and pricing chat wrappers to load the panel through the default export without custom `.then` chaining.
- Capture the fix in the repository log so future contributors know the root cause and mitigation.

## Summary
- Added a default export (while keeping the named export) for `ChatPanel` so dynamic imports have a deterministic chunk id.
- Simplified the `StickyChat` and `PricingChat` dynamic imports to consume the default export with typed loaders.
- Recorded the regression fix in `WRITE_HERE/FIXES` with context on the broken chunk URL and follow-up considerations.

## Testing
- `pnpm --filter www run typecheck` *(fails: known missing `next-intl` and drizzle type stubs in repo)*
- `pnpm --filter www run lint` *(fails: repo-wide missing `next-intl` package resolution for lint step)*

------
https://chatgpt.com/codex/tasks/task_e_68e137899244832abb7d8ceb439e4799