### PR TITLE
Fix special offer translations

### DIFF
--- a/WRITE_HERE/FIXES/2025-12-01T1900--special-offer-i18n-hotfix.md
+++ b/WRITE_HERE/FIXES/2025-12-01T1900--special-offer-i18n-hotfix.md
@@ -1,0 +1,6 @@
+# Special offer i18n hotfix
+
+- **What:** Switched the special offer client to pull copy via `useTranslations`, localized page metadata, and validated locales before rendering.
+- **Why:** The `/specialoffer` page showed English text regardless of the selected locale because copy was baked into server props and metadata was hard-coded.
+- **Files:** `apps/www/app/[locale]/(site)/specialoffer/page.tsx`, `apps/www/app/[locale]/(site)/specialoffer/client.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/WRITE_HERE/UPDATES/2025-12-01T1600--special-offer-packages.md
+++ b/WRITE_HERE/UPDATES/2025-12-01T1600--special-offer-packages.md
@@ -1,0 +1,6 @@
+# Special offer packages page
+
+- **What:** Added a dedicated `/specialoffer` route with premium-focused hero treatment, premium and basis package cards, and translations for both English and Dutch locales.
+- **Why:** Showcase the two bespoke engagement options requested by the client and make the premium deal stand out as the primary offer.
+- **Files:** `apps/www/app/[locale]/(site)/specialoffer/page.tsx`, `apps/www/app/[locale]/(site)/specialoffer/client.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Link the page from site navigation and consider bespoke imagery once creative assets are available.

--- a/WRITE_HERE/UPDATES/2025-12-01T1730--special-offer-exclusivity-refresh.md
+++ b/WRITE_HERE/UPDATES/2025-12-01T1730--special-offer-exclusivity-refresh.md
@@ -1,0 +1,6 @@
+# Special offer exclusivity refresh
+
+- **What:** Refreshed the special offer page copy in English and Dutch with exclusive pilot messaging, updated CTA labels, and added a limited-time notice plus shiny particle treatment for the premium card.
+- **Why:** Addressed feedback to emphasise exclusivity, surface pilot-only pricing, and make the premium package visually stand out while localising the experience.
+- **Files:** `apps/www/app/[locale]/(site)/specialoffer/page.tsx`, `apps/www/app/[locale]/(site)/specialoffer/client.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Consider adding navigation entry points once the offer goes live and evaluate performance of the particle effect on lower-powered devices.

--- a/apps/www/app/[locale]/(site)/specialoffer/client.tsx
+++ b/apps/www/app/[locale]/(site)/specialoffer/client.tsx
@@ -1,0 +1,432 @@
+"use client";
+
+import type React from "react";
+
+import { useTranslations } from "next-intl";
+
+import { Particles } from "@/components/particles";
+import { ShinyCardGroup } from "@/components/shiny-card";
+import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/hero";
+import {
+  Bullet,
+  Bullets,
+  Button,
+  Color,
+  Cost,
+  PricingCard,
+  PricingCardContent,
+  PricingCardFooter,
+  PricingCardHeader,
+  Separator,
+} from "../pricing/components";
+import { cn } from "@/lib/utils";
+import {
+  BarChart3,
+  Boxes,
+  CalendarClock,
+  CalendarDays,
+  Check,
+  ClipboardCheck,
+  ClipboardList,
+  Crown,
+  Gift,
+  Layers,
+  Map,
+  MapPinned,
+  Rocket,
+  Scale,
+  Server,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+
+type SpecialOfferContent = {
+  hero: {
+    eyebrow: string;
+    title: string;
+    subtitle: string;
+    highlight: string;
+    notice: string;
+  };
+  packages: {
+    common: {
+      included: string;
+      exVat: string;
+    };
+    premium: {
+      badge: string;
+      title: string;
+      tagline: string;
+      description: string;
+      price: string;
+      ctaLabel: string;
+      ctaHref: string;
+      bullets: Array<{ title: string; description?: string }>;
+      guarantee: { title: string; description: string };
+      bonus: {
+        title: string;
+        items: Array<{ title: string; description: string }>;
+      };
+    };
+    basic: {
+      badge: string;
+      title: string;
+      tagline: string;
+      description: string;
+      price: string;
+      ctaLabel: string;
+      ctaHref: string;
+      bullets: Array<{ title: string; description?: string }>;
+      footer?: string;
+    };
+  };
+};
+
+type PackageCardProps = {
+  id: string;
+  color: Color;
+  badgeColor: string;
+  badgeTextColor: string;
+  badgeLabel: string;
+  headerTitle: string;
+  headerTagline: string;
+  headerDescription: string;
+  headerIcon: React.ComponentType<React.ComponentProps<typeof Crown>>;
+  price: string;
+  priceNote: string;
+  cta: { label: string; href: string };
+  bullets: Array<{ title: string; description?: string }>;
+  bulletIcons: Array<React.ComponentType<React.ComponentProps<typeof Crown>>>;
+  bulletColor: Color;
+  bulletsTitle: string;
+  footer?: React.ReactNode;
+  highlight?: React.ReactNode;
+};
+
+function PackageCard({
+  id,
+  color,
+  badgeColor,
+  badgeTextColor,
+  badgeLabel,
+  headerTitle,
+  headerTagline,
+  headerDescription,
+  headerIcon: HeaderIcon,
+  price,
+  priceNote,
+  cta,
+  bullets,
+  bulletIcons,
+  bulletColor,
+  bulletsTitle,
+  footer,
+  highlight,
+}: PackageCardProps) {
+  return (
+    <PricingCard id={id} color={color} className="h-full">
+      {highlight}
+      <PricingCardHeader
+        title={headerTitle}
+        description={
+          <>
+            <span className="block text-[11px] uppercase tracking-[0.35em] text-white/50">
+              {headerTagline}
+            </span>
+            {headerDescription}
+          </>
+        }
+        icon={HeaderIcon}
+        color={color}
+        className={cn("flex-col items-start gap-8 bg-gradient-to-br", {
+          "from-purple-500/15 via-purple-400/5 to-fuchsia-400/10": color === Color.Purple,
+          "from-white/10 via-white/5 to-white/0": color === Color.White,
+        })}
+      />
+      <Separator />
+      <PricingCardContent>
+        <div className="flex flex-col gap-6">
+          <span
+            className="inline-flex items-center self-start rounded-full px-3 py-1 text-xs font-semibold"
+            style={{
+              background: badgeColor,
+              color: badgeTextColor,
+            }}
+          >
+            {badgeLabel}
+          </span>
+          <Cost dollar={price} frequency={priceNote} />
+          <Button label={cta.label} href={cta.href} />
+          <Bullets title={bulletsTitle}>
+            {bullets.map((bullet, index) => {
+              const Icon = bulletIcons[index] ?? Check;
+              return (
+                <li key={`${id}-bullet-${index}`}>
+                  <div className="space-y-2">
+                    <Bullet Icon={Icon} label={bullet.title} color={bulletColor} />
+                    {bullet.description ? (
+                      <p className="text-sm text-white/60">{bullet.description}</p>
+                    ) : null}
+                  </div>
+                </li>
+              );
+            })}
+          </Bullets>
+        </div>
+      </PricingCardContent>
+      {footer ? <PricingCardFooter>{footer}</PricingCardFooter> : null}
+    </PricingCard>
+  );
+}
+
+export function SpecialOfferClient() {
+  const t = useTranslations("SpecialOffer");
+
+  const content: SpecialOfferContent = {
+    hero: {
+      eyebrow: t("hero.eyebrow"),
+      title: t("hero.title"),
+      subtitle: t("hero.subtitle"),
+      highlight: t("hero.highlight"),
+      notice: t("hero.notice"),
+    },
+    packages: {
+      common: {
+        included: t("packages.common.included"),
+        exVat: t("packages.common.exVat"),
+      },
+      premium: {
+        badge: t("packages.premium.badge"),
+        title: t("packages.premium.title"),
+        tagline: t("packages.premium.tagline"),
+        description: t("packages.premium.description"),
+        price: t("packages.premium.price"),
+        ctaLabel: t("packages.premium.cta"),
+        ctaHref: "mailto:support@unkey.dev?subject=TransformAI%20Premium%20Deal%20Package",
+        bullets: [
+          {
+            title: t("packages.premium.bullets.bootcamp.title"),
+            description: t("packages.premium.bullets.bootcamp.description"),
+          },
+          {
+            title: t("packages.premium.bullets.assessment.title"),
+            description: t("packages.premium.bullets.assessment.description"),
+          },
+          {
+            title: t("packages.premium.bullets.comparison.title"),
+            description: t("packages.premium.bullets.comparison.description"),
+          },
+          {
+            title: t("packages.premium.bullets.solutions.title"),
+            description: t("packages.premium.bullets.solutions.description"),
+          },
+          {
+            title: t("packages.premium.bullets.policy.title"),
+            description: t("packages.premium.bullets.policy.description"),
+          },
+          {
+            title: t("packages.premium.bullets.roadmap.title"),
+            description: t("packages.premium.bullets.roadmap.description"),
+          },
+          {
+            title: t("packages.premium.bullets.systems.title"),
+            description: t("packages.premium.bullets.systems.description"),
+          },
+        ],
+        guarantee: {
+          title: t("packages.premium.guarantee.title"),
+          description: t("packages.premium.guarantee.description"),
+        },
+        bonus: {
+          title: t("packages.premium.bonus.title"),
+          items: [
+            {
+              title: t("packages.premium.bonus.items.0.title"),
+              description: t("packages.premium.bonus.items.0.description"),
+            },
+            {
+              title: t("packages.premium.bonus.items.1.title"),
+              description: t("packages.premium.bonus.items.1.description"),
+            },
+          ],
+        },
+      },
+      basic: {
+        badge: t("packages.basic.badge"),
+        title: t("packages.basic.title"),
+        tagline: t("packages.basic.tagline"),
+        description: t("packages.basic.description"),
+        price: t("packages.basic.price"),
+        ctaLabel: t("packages.basic.cta"),
+        ctaHref: "mailto:support@unkey.dev?subject=TransformAI%20Basis%20Pakket",
+        bullets: [
+          {
+            title: t("packages.basic.bullets.bootcamp.title"),
+            description: t("packages.basic.bullets.bootcamp.description"),
+          },
+          {
+            title: t("packages.basic.bullets.assessment.title"),
+            description: t("packages.basic.bullets.assessment.description"),
+          },
+          {
+            title: t("packages.basic.bullets.quickWins.title"),
+            description: t("packages.basic.bullets.quickWins.description"),
+          },
+          {
+            title: t("packages.basic.bullets.roadmap.title"),
+            description: t("packages.basic.bullets.roadmap.description"),
+          },
+          {
+            title: t("packages.basic.bullets.backendFocus.title"),
+            description: t("packages.basic.bullets.backendFocus.description"),
+          },
+        ],
+        footer: t("packages.basic.footer"),
+      },
+    },
+  };
+
+  const premiumBulletIcons = [
+    CalendarClock,
+    ClipboardCheck,
+    BarChart3,
+    Boxes,
+    Scale,
+    Map,
+    Layers,
+  ];
+
+  const basicBulletIcons = [CalendarDays, ClipboardList, Sparkles, MapPinned, Server];
+
+  return (
+    <div className="relative isolate overflow-hidden pt-24 pb-24">
+      <TopRightShiningLight />
+      <TopLeftShiningLight />
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute left-1/2 top-0 h-[420px] w-[720px] -translate-x-1/2 rounded-full bg-gradient-to-r from-purple-500/40 via-sky-400/20 to-fuchsia-500/30 blur-3xl" />
+      </div>
+      <section className="relative mx-auto flex max-w-4xl flex-col items-center px-4 text-center">
+        <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.06] px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-white/70">
+          <Sparkles className="h-4 w-4 text-purple-200" />
+          {content.hero.eyebrow}
+        </span>
+        <h1 className="mt-6 text-balance text-4xl font-semibold leading-tight text-transparent bg-gradient-to-r from-white via-white to-white/70 bg-clip-text sm:text-5xl">
+          {content.hero.title}
+        </h1>
+        <p className="mt-4 max-w-3xl text-balance text-base text-white/70 sm:text-lg">
+          {content.hero.subtitle}
+        </p>
+        <div className="mt-6 inline-flex items-center gap-3 rounded-full border border-purple-400/40 bg-purple-500/10 px-4 py-2 text-sm text-purple-100">
+          <Crown className="h-4 w-4" />
+          {content.hero.highlight}
+        </div>
+        <p className="mt-5 max-w-2xl text-pretty text-sm text-white/50 sm:text-base">
+          {content.hero.notice}
+        </p>
+      </section>
+
+      <div className="mt-16 px-4">
+        <ShinyCardGroup className="mx-auto grid max-w-5xl gap-6 md:[grid-template-columns:1.15fr_1fr]">
+          <PackageCard
+            id="specialoffer-premium"
+            color={Color.Purple}
+            badgeColor="rgba(147, 51, 234, 0.15)"
+            badgeTextColor="#F6E9FF"
+            badgeLabel={content.packages.premium.badge}
+            headerTitle={content.packages.premium.title}
+            headerTagline={content.packages.premium.tagline}
+            headerDescription={content.packages.premium.description}
+            headerIcon={Crown}
+            price={content.packages.premium.price}
+            priceNote={content.packages.common.exVat}
+            cta={{ label: content.packages.premium.ctaLabel, href: content.packages.premium.ctaHref }}
+            bullets={content.packages.premium.bullets}
+            bulletIcons={premiumBulletIcons}
+            bulletColor={Color.Purple}
+            bulletsTitle={content.packages.common.included}
+            highlight={
+              <>
+                <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+                  <div className="absolute inset-0 bg-gradient-to-br from-purple-500/15 via-fuchsia-500/10 to-purple-200/5" />
+                  <Particles
+                    className="pointer-events-none absolute inset-0 opacity-60 [mask-image:radial-gradient(circle_at_center,white,transparent)]"
+                    quantity={90}
+                    staticity={40}
+                    ease={60}
+                    color="#E9D5FF"
+                    vx={0.08}
+                    vy={0.08}
+                  />
+                </div>
+                <div className="absolute -top-10 right-8 pointer-events-none hidden md:block">
+                  <div className="rounded-full border border-purple-500/30 bg-purple-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-purple-50">
+                    {content.packages.premium.badge}
+                  </div>
+                </div>
+              </>
+            }
+            footer={
+              <div className="flex flex-col gap-6">
+                <div className="flex items-start gap-3">
+                  <div className="mt-1 flex h-9 w-9 items-center justify-center rounded-lg bg-purple-500/20">
+                    <ShieldCheck className="h-5 w-5 text-purple-100" />
+                  </div>
+                  <div className="text-left">
+                    <p className="text-sm font-semibold text-white">
+                      {content.packages.premium.guarantee.title}
+                    </p>
+                    <p className="mt-1 text-sm text-white/65">
+                      {content.packages.premium.guarantee.description}
+                    </p>
+                  </div>
+                </div>
+                <div className="rounded-3xl border border-purple-500/20 bg-purple-500/10 p-5 text-left">
+                  <div className="flex items-center gap-3">
+                    <Gift className="h-5 w-5 text-purple-100" />
+                    <p className="text-sm font-semibold text-white">
+                      {content.packages.premium.bonus.title}
+                    </p>
+                  </div>
+                  <ul className="mt-4 space-y-3 text-sm text-white/70">
+                    {content.packages.premium.bonus.items.map((item, index) => (
+                      <li key={`premium-bonus-${index}`}>
+                        <p className="font-medium text-white">{item.title}</p>
+                        <p className="text-white/60">{item.description}</p>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            }
+          />
+
+          <PackageCard
+            id="specialoffer-basic"
+            color={Color.White}
+            badgeColor="rgba(148, 163, 184, 0.2)"
+            badgeTextColor="rgba(226,232,240,1)"
+            badgeLabel={content.packages.basic.badge}
+            headerTitle={content.packages.basic.title}
+            headerTagline={content.packages.basic.tagline}
+            headerDescription={content.packages.basic.description}
+            headerIcon={Rocket}
+            price={content.packages.basic.price}
+            priceNote={content.packages.common.exVat}
+            cta={{ label: content.packages.basic.ctaLabel, href: content.packages.basic.ctaHref }}
+            bullets={content.packages.basic.bullets}
+            bulletIcons={basicBulletIcons}
+            bulletColor={Color.White}
+            bulletsTitle={content.packages.common.included}
+            footer={
+              content.packages.basic.footer ? (
+                <p className="text-center text-sm text-white/60 md:text-left">
+                  {content.packages.basic.footer}
+                </p>
+              ) : undefined
+            }
+          />
+        </ShinyCardGroup>
+      </div>
+    </div>
+  );
+}

--- a/apps/www/app/[locale]/(site)/specialoffer/page.tsx
+++ b/apps/www/app/[locale]/(site)/specialoffer/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+
+import { isLocale } from "@/i18n/routing";
+
+import { SpecialOfferClient } from "./client";
+
+type PageProps = {
+  params: {
+    locale: string;
+  };
+};
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { locale } = params;
+
+  if (!isLocale(locale)) {
+    notFound();
+  }
+
+  const t = await getTranslations({
+    locale,
+    namespace: "SpecialOffer",
+  });
+
+  return {
+    title: t("metadata.title"),
+    description: t("metadata.description"),
+    openGraph: {
+      title: t("metadata.openGraph.title"),
+      description: t("metadata.openGraph.description"),
+    },
+    twitter: {
+      title: t("metadata.twitter.title"),
+      description: t("metadata.twitter.description"),
+    },
+  };
+}
+
+export default function SpecialOfferPage({ params }: PageProps) {
+  const { locale } = params;
+
+  if (!isLocale(locale)) {
+    notFound();
+  }
+
+  return <SpecialOfferClient />;
+}

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -469,6 +469,119 @@
       }
     }
   },
+  "SpecialOffer": {
+    "hero": {
+      "eyebrow": "Exclusive special offer",
+      "title": "Exclusive premium-first AI transformation packages for Dutch companies",
+      "subtitle": "Lock in an exclusive engagement tailored to your ambition—start with the Basis Pakket for focused backend wins or choose the Het koopje pakket for an all-in acceleration.",
+      "highlight": "Our exclusive Premium Deal package is designed to be your first and most powerful move.",
+      "notice": "This exclusive special offer is tailored for companies in our pilot programme, unlocking preferential pricing. Limited time only."
+    },
+    "packages": {
+      "common": {
+        "included": "What's included",
+        "exVat": "excl. VAT"
+      },
+      "premium": {
+        "badge": "Most exclusive & comprehensive",
+        "title": "Het koopje pakket",
+        "tagline": "Exclusive Premium Deal package",
+        "description": "Intensive one-week AI transformation project with senior specialists on-site and remote, reserved for our pilot partners.",
+        "price": "€9.100",
+        "cta": "Request access",
+        "bullets": {
+          "bootcamp": {
+            "title": "1-week project: 2 days on-site, 4 days of reporting, 1 day presentation",
+            "description": "We embed with your team, analyse the organisation, and present a crystal-clear narrative for every stakeholder."
+          },
+          "assessment": {
+            "title": "Detailed assessment of your current position",
+            "description": "The assessment report scores your company on AI adoption, data readiness, and operational maturity."
+          },
+          "comparison": {
+            "title": "Benchmark against your field and adjacent industries",
+            "description": "See how you perform versus peers so you can frame decisions with real market context."
+          },
+          "solutions": {
+            "title": "Full catalogue of integration possibilities",
+            "description": "Every solution is mapped with complexity, cost, and expected impact so you can prioritise with confidence."
+          },
+          "policy": {
+            "title": "Co-created AI governance and policy",
+            "description": "We align with your values and legal requirements to define responsible AI guardrails."
+          },
+          "roadmap": {
+            "title": "Robust AI roadmap",
+            "description": "A staged implementation plan showing what to deliver, by whom, and when."
+          },
+          "systems": {
+            "title": "Covers both frontend and backend systems",
+            "description": "The transformation plan spans customer-facing and internal platforms for a complete rollout."
+          }
+        },
+        "guarantee": {
+          "title": "Money-back guarantee",
+          "description": "If we do not deliver the promised insights and roadmap, you receive your investment back."
+        },
+        "bonus": {
+          "title": "Exclusive premium bonuses",
+          "items": [
+            {
+              "title": "Founder-to-founder advisory session",
+              "description": "Personal guidance on long-term AI positioning so leadership knows how to steer beyond the project."
+            },
+            {
+              "title": "2 free education modules (worth €1.400)",
+              "description": "In-person training delivered later to upskill your team without extra cost."
+            }
+          ]
+        }
+      },
+      "basic": {
+        "badge": "Exclusive starter option",
+        "title": "Basis Pakket",
+        "tagline": "Get started package",
+        "description": "Three-day accelerator to understand your AI baseline and unlock immediate backend wins with exclusive pilot pricing.",
+        "price": "€3.400",
+        "cta": "Request access",
+        "bullets": {
+          "bootcamp": {
+            "title": "3-day bootcamp: 1 day on-site, 1 day reporting, 1 day presentation",
+            "description": "We partner with your team for a rapid discovery, craft the report, and present the findings."
+          },
+          "assessment": {
+            "title": "Detailed assessment of your current position",
+            "description": "Measures how your backend uses AI today, covering data, processes, and tooling."
+          },
+          "quickWins": {
+            "title": "Quick wins playbook",
+            "description": "We highlight fast-to-implement improvements and outline exactly how to deploy them."
+          },
+          "roadmap": {
+            "title": "Backend roadmap",
+            "description": "Creates the first-stage roadmap to guide your backend team through the next steps."
+          },
+          "backendFocus": {
+            "title": "Backend-focused engagement",
+            "description": "The assessment and recommendations zero in on backend systems to keep scope sharp."
+          }
+        },
+        "footer": "Need support across frontend as well? The Het koopje pakket covers the full stack."
+      }
+    },
+    "metadata": {
+      "title": "Exclusive Special Offer Packages | TransformAI",
+      "description": "Unlock exclusive pilot pricing on TransformAI's Basis Pakket and Het koopje pakket—bespoke AI engagements for ambitious Dutch companies.",
+      "openGraph": {
+        "title": "Exclusive Special Offer Packages | TransformAI",
+        "description": "Discover TransformAI's exclusive pilot offer with premium and basis packages tailored for decisive teams."
+      },
+      "twitter": {
+        "title": "Exclusive Special Offer Packages | TransformAI",
+        "description": "Secure limited-time pilot pricing on TransformAI's premium and basis AI transformation packages."
+      }
+    }
+  },
   "Hero": {
     "title": "Your Transformation Partner for the Age of AI",
     "body": "We help companies adapt successfully and sustainably to the challenges and opportunities that Artificial Intelligence brings.",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -469,6 +469,119 @@
       }
     }
   },
+  "SpecialOffer": {
+    "hero": {
+      "eyebrow": "Exclusieve special",
+      "title": "Exclusieve AI-transformatie pakketten voor Nederlandse bedrijven",
+      "subtitle": "Kies een exclusieve aanpak die past bij jullie ambitie: start met het Basis Pakket voor gerichte backend-impact of kies Het koopje pakket voor een totale versnelling.",
+      "highlight": "Ons exclusieve Premium Deal pakket is gemaakt als jullie krachtigste eerste stap.",
+      "notice": "Deze exclusieve aanbieding is bedoeld voor bedrijven in onze pilot en geeft toegang tot een voorkeurtarief. Alleen tijdelijk beschikbaar."
+    },
+    "packages": {
+      "common": {
+        "included": "Inclusief",
+        "exVat": "excl. btw"
+      },
+      "premium": {
+        "badge": "Meest exclusief en compleet",
+        "title": "Het koopje pakket",
+        "tagline": "Exclusief Premium Deal pakket",
+        "description": "Intensief éénweekstraject met senior specialisten op locatie en remote, gereserveerd voor onze pilotpartners.",
+        "price": "€9.100",
+        "cta": "Request access",
+        "bullets": {
+          "bootcamp": {
+            "title": "1-week traject: 2 dagen on-site, 4 dagen rapportage, 1 dag presentatie",
+            "description": "We werken naast jouw team, analyseren de organisatie en presenteren een helder verhaal voor elke stakeholder."
+          },
+          "assessment": {
+            "title": "Diepgaande nulmeting van de huidige positie",
+            "description": "Het rapport scoort jullie op AI-gebruik, data-gereedheid en operationele volwassenheid."
+          },
+          "comparison": {
+            "title": "Vergelijking met jouw sector en aanverwante branches",
+            "description": "Ontdek hoe jullie presteren ten opzichte van peers zodat beslissingen op marktcijfers rusten."
+          },
+          "solutions": {
+            "title": "Volledig overzicht van integratie-opties",
+            "description": "Elke oplossing krijgt een inschatting van complexiteit, kosten en resultaat voor heldere prioritering."
+          },
+          "policy": {
+            "title": "AI-beleid op maat",
+            "description": "We verankeren jullie waarden en juridische vereisten in concrete AI-richtlijnen."
+          },
+          "roadmap": {
+            "title": "Robuuste AI-roadmap",
+            "description": "Een gefaseerd plan dat laat zien wat wanneer geleverd wordt en door wie."
+          },
+          "systems": {
+            "title": "Behandelt zowel frontend als backend systemen",
+            "description": "De transformatieroute dekt klantgerichte en interne platforms voor een volledige uitrol."
+          }
+        },
+        "guarantee": {
+          "title": "Geld-terug-garantie",
+          "description": "Leveren we de beloofde inzichten en roadmap niet? Dan krijg je de investering terug."
+        },
+        "bonus": {
+          "title": "Exclusieve premium bonussen",
+          "items": [
+            {
+              "title": "Founder-to-founder advies sessie",
+              "description": "Persoonlijk advies over lange termijn AI-positionering zodat de directie vooruit kan kijken."
+            },
+            {
+              "title": "2 gratis opleidingsmodules (t.w.v. €1.400)",
+              "description": "Latere sessies op locatie om je team zonder extra kosten op te leiden."
+            }
+          ]
+        }
+      },
+      "basic": {
+        "badge": "Exclusieve starter",
+        "title": "Basis Pakket",
+        "tagline": "Get started pakket",
+        "description": "Driedaagse versneller om je AI-nulmeting te doen en directe backend-kansen te pakken met exclusieve pilotvoorwaarden.",
+        "price": "€3.400",
+        "cta": "Request access",
+        "bullets": {
+          "bootcamp": {
+            "title": "3-daagse bootcamp: 1 dag on-site, 1 dag rapportage, 1 dag presentatie",
+            "description": "We doorlopen de ontdekking, schrijven het rapport en presenteren de conclusies met je team."
+          },
+          "assessment": {
+            "title": "Diepgaande nulmeting van de huidige positie",
+            "description": "Brengt het huidige AI-gebruik in je backend, processen en tooling scherp in kaart."
+          },
+          "quickWins": {
+            "title": "Quick wins draaiboek",
+            "description": "We benoemen snelle verbeteringen en leggen uit hoe je ze direct implementeert."
+          },
+          "roadmap": {
+            "title": "Backend roadmap",
+            "description": "Bouwt de eerste roadmap waarmee het backend-team de volgende stappen kan plannen."
+          },
+          "backendFocus": {
+            "title": "Focus op backend",
+            "description": "Analyse en aanbevelingen richten zich volledig op de backend-systemen voor maximale scherpte."
+          }
+        },
+        "footer": "Ook front-end meenemen? Het koopje pakket dekt de volledige stack."
+      }
+    },
+    "metadata": {
+      "title": "Exclusieve special offer pakketten | TransformAI",
+      "description": "Profiteer van exclusieve pilotprijzen voor het Basis Pakket en Het koopje pakket van TransformAI—maatwerk AI-trajecten voor ambitieuze Nederlandse bedrijven.",
+      "openGraph": {
+        "title": "Exclusieve special offer pakketten | TransformAI",
+        "description": "Ontdek TransformAI's exclusieve pilotaanbod met premium en basis pakketten voor vooruitstrevende teams."
+      },
+      "twitter": {
+        "title": "Exclusieve special offer pakketten | TransformAI",
+        "description": "Zeker tijdelijk pilottarief op de premium en basis AI-transformatiepakketten van TransformAI."
+      }
+    }
+  },
   "Hero": {
     "title": "Jouw transformatiepartner voor het AI-tijdperk",
     "body": "Wij helpen bedrijven zich succesvol en duurzaam aan te passen aan de kansen en uitdagingen die Kunstmatige Intelligentie met zich meebrengt.",


### PR DESCRIPTION
## Summary
- have the special offer client derive hero and package copy with `useTranslations` so locale switches render the right language
- localize the route metadata through `getTranslations` and guard invalid locale access
- extend the English and Dutch message catalogs with metadata strings and log the fix in `WRITE_HERE/FIXES`

## Testing
- pnpm --filter www run lint *(fails: next-intl missing in workspace)*

## Plan
- update the special offer client to pull copy from next-intl instead of server props
- wire the page metadata into the translation namespace with locale validation
- add the new metadata strings to en/nl catalogs and record the fix


------
https://chatgpt.com/codex/tasks/task_e_6904029a3064832aa8e8ed5956448904