### PR TITLE
Disable chat responses and blur pricing details

### DIFF
--- a/WRITE_HERE/UPDATES/2025-12-02T0900--pricing-coming-soon-and-chat-placeholder.md
+++ b/WRITE_HERE/UPDATES/2025-12-02T0900--pricing-coming-soon-and-chat-placeholder.md
@@ -1,0 +1,6 @@
+# Pricing blur overlay and assistant placeholder
+
+- **What:** Disabled live assistant responses with a coming-soon message, added a "Coming soon" overlay on pricing details, updated navigation auth links to show a development notice, and refreshed highlight messaging.
+- **Why:** Prepare the site for production by hiding unfinished chat and pricing flows while keeping visitors informed.
+- **Files:** `apps/www/app/[locale]/(site)/pricing/page.tsx`, `apps/www/components/ask/*`, `apps/www/components/auth/*`, `apps/www/components/navbar/navigation.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Replace placeholder messaging and remove the pricing blur once chat and pricing data are ready.

--- a/apps/www/app/[locale]/(site)/pricing/page.tsx
+++ b/apps/www/app/[locale]/(site)/pricing/page.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useState } from "react";
 import {
   BelowEnterpriseSvg,
@@ -39,6 +39,9 @@ import {
 export default function PricingPage() {
   const header = useTranslations("Pricing.Header");
   const packages = useTranslations("Pricing.Packages");
+  const comingSoon = useTranslations("Pricing.ComingSoon");
+  const localeCode = useLocale();
+  const contactPageHref = `/${localeCode}/contact`;
   const [isChatOpen, setIsChatOpen] = useState(false);
 
   const highlightItems = [
@@ -116,171 +119,183 @@ export default function PricingPage() {
           </div>
         </div>
 
-        <PricingCompareTable />
+        <div className="relative mt-12">
+          <div
+            aria-hidden
+            className="space-y-12 pointer-events-none select-none opacity-30 blur-sm"
+          >
+            <PricingCompareTable />
 
-        <div id="pricing-tier-grid" className="mt-12">
-          <ShinyCardGroup className="grid h-full max-w-4xl grid-cols-2 gap-6 mx-auto group">
-            <PricingCard id="pricing-tier-1" color={Color.White} className="col-span-2 md:col-span-1">
-              <FreeCardHighlight className="absolute top-0 right-0 pointer-events-none" />
+            <div id="pricing-tier-grid" className="mt-12">
+              <ShinyCardGroup className="grid h-full max-w-4xl grid-cols-2 gap-6 mx-auto group">
+                <PricingCard id="pricing-tier-1" color={Color.White} className="col-span-2 md:col-span-1">
+                  <FreeCardHighlight className="absolute top-0 right-0 pointer-events-none" />
 
-              <PricingCardHeader
-                title={packages("education.title")}
-                description={packages("education.description")}
-                className="bg-gradient-to-tr from-transparent to-[#ffffff]/10 "
-                color={Color.White}
-                icon={GraduationCap}
-              />
-              <Separator />
-
-              <PricingCardContent>
-                <Cost
-                  dollar={packages("education.price")}
-                  frequency={packages("education.frequency")}
-                />
-                <Button label={packages("education.cta")} href={educationContactHref} />
-                <Bullets title={packages("common.included")}>
-                  <li>
-                    <Bullet Icon={Check} label={packages("education.bullets.courseV1")} color={Color.White} />
-                  </li>
-                  <li>
-                    <Bullet Icon={Check} label={packages("education.bullets.courseV2")} color={Color.White} />
-                  </li>
-                  <li>
-                    <Bullet Icon={Check} label={packages("education.bullets.workshops")} color={Color.White} />
-                  </li>
-                  <li>
-                    <Bullet
-                      Icon={Check}
-                      label={packages("education.bullets.trainingMaterials")}
-                      color={Color.White}
-                    />
-                  </li>
-                  <li>
-                    <Bullet Icon={Check} label={packages("education.bullets.certification")} color={Color.White} />
-                  </li>
-                </Bullets>
-              </PricingCardContent>
-              <PricingCardFooter>
-                <div className="flex flex-col gap-2">
-                  <p className="text-sm font-bold text-white">{packages("education.footer.title")}</p>
-                  <p className="text-xs text-white/60">{packages("education.footer.body")}</p>
-                </div>
-              </PricingCardFooter>
-            </PricingCard>
-
-            <PricingCard id="pricing-tier-2" color={Color.Yellow} className="col-span-2 md:col-span-1">
-              <ProCardHighlight className="absolute top-0 right-0 pointer-events-none" />
-
-              <PricingCardHeader
-                title={packages("introduction.title")}
-                description={packages("introduction.description")}
-                className="bg-gradient-to-tr from-black/50 to-[#FFD600]/10 "
-                color={Color.Yellow}
-                icon={Handshake}
-              />
-              <Separator />
-
-              <PricingCardContent>
-                <Cost
-                  dollar={packages("introduction.price")}
-                  frequency={packages("introduction.frequency")}
-                />
-                <Button label={packages("introduction.cta")} href={introductionContactHref} />
-                <Bullets title={packages("common.included")}>
-                  <li>
-                    <Bullet Icon={Check} label={packages("introduction.bullets.aiReadiness")} color={Color.Yellow} />
-                  </li>
-                  <li>
-                    <Bullet
-                      Icon={Check}
-                      label={packages("introduction.bullets.automationSetup")}
-                      color={Color.Yellow}
-                    />
-                  </li>
-                  <li>
-                    <Bullet Icon={Check} label={packages("introduction.bullets.pilotIntegration")} color={Color.Yellow} />
-                  </li>
-                  <li>
-                    <Bullet Icon={Check} label={packages("introduction.bullets.assessment")} color={Color.Yellow} />
-                  </li>
-                  <li>
-                    <Bullet Icon={Check} label={packages("introduction.bullets.guidance")} color={Color.Yellow} />
-                  </li>
-                </Bullets>
-              </PricingCardContent>
-              <PricingCardFooter>
-                <div className="flex flex-col gap-2">
-                  <p className="text-sm font-bold text-white">{packages("introduction.footer.title")}</p>
-                  <p className="text-xs text-white/60">{packages("introduction.footer.body")}</p>
-                </div>
-              </PricingCardFooter>
-            </PricingCard>
-
-            <PricingCard id="pricing-tier-3" color={Color.Purple} className="col-span-2">
-              <EnterpriseCardHighlight className="absolute top-0 right-0 pointer-events-none" />
-
-              <div className="flex flex-col h-full md:flex-row">
-                <div className="flex flex-col w-full gap-8">
                   <PricingCardHeader
-                    title={packages("enterprise.title")}
-                    description={packages("enterprise.description")}
-                    color={Color.Purple}
-                    className="bg-gradient-to-tr from-transparent to-[#9D72FF]/10 "
-                    icon={Sparkles}
+                    title={packages("education.title")}
+                    description={packages("education.description")}
+                    className="bg-gradient-to-tr from-transparent to-[#ffffff]/10 "
+                    color={Color.White}
+                    icon={GraduationCap}
                   />
+                  <Separator />
+
                   <PricingCardContent>
                     <Cost
-                      dollar={packages("enterprise.price")}
-                      frequency={packages("enterprise.frequency")}
+                      dollar={packages("education.price")}
+                      frequency={packages("education.frequency")}
                     />
-                    <Link href={enterpriseContactHref}>
-                      <div className="w-full p-px rounded-lg h-10 bg-gradient-to-r from-[#02DEFC] via-[#0239FC] to-[#7002FC] overflow-hidden">
-                        <div className="bg-black rounded-[7px] h-full bg-opacity-95 hover:bg-opacity-25 duration-1000">
-                          <div className="flex items-center justify-center w-full h-full bg-gradient-to-tr from-[#02DEFC]/20 via-[#0239FC]/20 to-[#7002FC]/20  rounded-[7px]">
-                            <span className="text-sm font-semibold text-white">{packages("enterprise.cta")}</span>
-                          </div>
-                        </div>
-                      </div>
-                    </Link>
+                    <Button label={packages("education.cta")} href={educationContactHref} />
+                    <Bullets title={packages("common.included")}>
+                      <li>
+                        <Bullet Icon={Check} label={packages("education.bullets.courseV1")} color={Color.White} />
+                      </li>
+                      <li>
+                        <Bullet Icon={Check} label={packages("education.bullets.courseV2")} color={Color.White} />
+                      </li>
+                      <li>
+                        <Bullet Icon={Check} label={packages("education.bullets.workshops")} color={Color.White} />
+                      </li>
+                      <li>
+                        <Bullet
+                          Icon={Check}
+                          label={packages("education.bullets.trainingMaterials")}
+                          color={Color.White}
+                        />
+                      </li>
+                      <li>
+                        <Bullet Icon={Check} label={packages("education.bullets.certification")} color={Color.White} />
+                      </li>
+                    </Bullets>
                   </PricingCardContent>
-              </div>
-              <Separator orientation="vertical" className="hidden md:flex" />
-              <Separator orientation="horizontal" className="md:hidden" />
-              <div className="relative w-full p-8">
-                <Particles
-                  className="absolute inset-0 duration-500 opacity-50 -z-10 group-hover:opacity-100"
-                  quantity={50}
-                  color={Color.Purple}
-                  vx={0.1}
-                  vy={-0.1}
-                />
-                <Bullets title={packages("common.included")}>
-                  <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.tailoredIntegrations")} color={Color.Purple} />
-                  </li>
-                  <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.researchSupport")} color={Color.Purple} />
-                  </li>
-                  <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.customModel")} color={Color.Purple} />
-                  </li>
-                  <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.consulting")} color={Color.Purple} />
-                  </li>
-                  <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.continuousSupport")} color={Color.Purple} />
-                  </li>
-                </Bullets>
-              </div>
-            </div>
-          </PricingCard>
-        </ShinyCardGroup>
-      </div>
-      <BelowEnterpriseSvg className="container inset-x-0 top-0 mx-auto -mt-64 -mb-32" />
+                  <PricingCardFooter>
+                    <div className="flex flex-col gap-2">
+                      <p className="text-sm font-bold text-white">{packages("education.footer.title")}</p>
+                      <p className="text-xs text-white/60">{packages("education.footer.body")}</p>
+                    </div>
+                  </PricingCardFooter>
+                </PricingCard>
 
-      <div className="-mx-4 lg:mx-0">
-        <CTA />
-      </div>
+                <PricingCard id="pricing-tier-2" color={Color.Yellow} className="col-span-2 md:col-span-1">
+                  <ProCardHighlight className="absolute top-0 right-0 pointer-events-none" />
+
+                  <PricingCardHeader
+                    title={packages("introduction.title")}
+                    description={packages("introduction.description")}
+                    className="bg-gradient-to-tr from-black/50 to-[#FFD600]/10 "
+                    color={Color.Yellow}
+                    icon={Handshake}
+                  />
+                  <Separator />
+
+                  <PricingCardContent>
+                    <Cost
+                      dollar={packages("introduction.price")}
+                      frequency={packages("introduction.frequency")}
+                    />
+                    <Button label={packages("introduction.cta")} href={introductionContactHref} />
+                    <Bullets title={packages("common.included")}>
+                      <li>
+                        <Bullet Icon={Check} label={packages("introduction.bullets.aiReadiness")} color={Color.Yellow} />
+                      </li>
+                      <li>
+                        <Bullet
+                          Icon={Check}
+                          label={packages("introduction.bullets.automationSetup")}
+                          color={Color.Yellow}
+                        />
+                      </li>
+                      <li>
+                        <Bullet Icon={Check} label={packages("introduction.bullets.pilotIntegration")} color={Color.Yellow} />
+                      </li>
+                      <li>
+                        <Bullet Icon={Check} label={packages("introduction.bullets.assessment")} color={Color.Yellow} />
+                      </li>
+                      <li>
+                        <Bullet Icon={Check} label={packages("introduction.bullets.guidance")} color={Color.Yellow} />
+                      </li>
+                    </Bullets>
+                  </PricingCardContent>
+                  <PricingCardFooter>
+                    <div className="flex flex-col gap-2">
+                      <p className="text-sm font-bold text-white">{packages("introduction.footer.title")}</p>
+                      <p className="text-xs text-white/60">{packages("introduction.footer.body")}</p>
+                    </div>
+                  </PricingCardFooter>
+                </PricingCard>
+
+                <PricingCard id="pricing-tier-3" color={Color.Purple} className="col-span-2">
+                  <EnterpriseCardHighlight className="absolute top-0 right-0 pointer-events-none" />
+
+                  <div className="flex flex-col h-full md:flex-row">
+                    <div className="flex flex-col w-full gap-8">
+                      <PricingCardHeader
+                        title={packages("enterprise.title")}
+                        description={packages("enterprise.description")}
+                        color={Color.Purple}
+                        className="bg-gradient-to-tr from-transparent to-[#9D72FF]/10 "
+                        icon={Sparkles}
+                      />
+                      <PricingCardContent>
+                        <Cost
+                          dollar={packages("enterprise.price")}
+                          frequency={packages("enterprise.frequency")}
+                        />
+                        <Link href={enterpriseContactHref}>
+                          <div className="w-full p-px rounded-lg h-10 bg-gradient-to-r from-[#02DEFC] via-[#0239FC] to-[#7002FC] overflow-hidden">
+                            <div className="bg-black rounded-[7px] h-full bg-opacity-95 hover:bg-opacity-25 duration-1000">
+                              <div className="flex items-center justify-center w-full h-full bg-gradient-to-tr from-[#02DEFC]/20 via-[#0239FC]/20 to-[#7002FC]/20  rounded-[7px]">
+                                <span className="text-sm font-semibold text-white">{packages("enterprise.cta")}</span>
+                              </div>
+                            </div>
+                          </div>
+                        </Link>
+                      </PricingCardContent>
+                  </div>
+                  <Separator orientation="vertical" className="hidden md:flex" />
+                  <Separator orientation="horizontal" className="md:hidden" />
+                  <div className="relative w-full p-8">
+                    <Particles
+                      className="absolute inset-0 duration-500 opacity-50 -z-10 group-hover:opacity-100"
+                      quantity={50}
+                      color={Color.Purple}
+                      vx={0.1}
+                      vy={-0.1}
+                    />
+                    <Bullets title={packages("common.included")}>
+                      <li>
+                        <Bullet Icon={Check} label={packages("enterprise.bullets.tailoredIntegrations")} color={Color.Purple} />
+                      </li>
+                      <li>
+                        <Bullet Icon={Check} label={packages("enterprise.bullets.researchSupport")} color={Color.Purple} />
+                      </li>
+                      <li>
+                        <Bullet Icon={Check} label={packages("enterprise.bullets.customModel")} color={Color.Purple} />
+                      </li>
+                      <li>
+                        <Bullet Icon={Check} label={packages("enterprise.bullets.consulting")} color={Color.Purple} />
+                      </li>
+                      <li>
+                        <Bullet Icon={Check} label={packages("enterprise.bullets.continuousSupport")} color={Color.Purple} />
+                      </li>
+                    </Bullets>
+                  </div>
+                </div>
+              </PricingCard>
+            </ShinyCardGroup>
+          </div>
+          <BelowEnterpriseSvg className="container inset-x-0 top-0 mx-auto -mt-64 -mb-32" />
+
+          <div className="-mx-4 lg:mx-0">
+            <CTA />
+          </div>
+        </div>
+        <div className="pointer-events-auto absolute inset-0 z-10 flex flex-col items-center justify-center gap-4 rounded-[32px] bg-neutral-950/85 px-6 py-16 text-center backdrop-blur-xl">
+          <h2 className="text-3xl font-semibold text-white sm:text-4xl">{comingSoon("title")}</h2>
+          <p className="max-w-xl text-base text-white/70">{comingSoon("subtitle")}</p>
+          <Button label={comingSoon("cta")} href={contactPageHref} />
+        </div>
+        </div>
     </div>
     </div>
   );

--- a/apps/www/components/ask/PricingChat.tsx
+++ b/apps/www/components/ask/PricingChat.tsx
@@ -47,6 +47,7 @@ export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChang
       errorTitle: t("errors.title"),
       errorBody: t("errors.body"),
       retryLabel: t("errors.retry"),
+      disabledResponse: t("disabledResponse"),
     }),
     [t],
   );
@@ -55,10 +56,9 @@ export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChang
   const [shouldRenderPanel, setShouldRenderPanel] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const hasOpenedRef = useRef(false);
+  const responseTimer = useRef<number>();
 
   const id = useId();
   const panelId = `${id}-pricing-chat`;
@@ -96,57 +96,36 @@ export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChang
   }, [isOpen]);
 
   useEffect(() => {
+    return () => {
+      if (responseTimer.current) {
+        window.clearTimeout(responseTimer.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     onOpenChange?.(isOpen);
   }, [isOpen, onOpenChange]);
 
-  const sendToAssistant = useCallback(
-    async (conversation: ChatMessage[], prompt: string | null) => {
-      setIsLoading(true);
-      setErrorMessage(null);
-      setPendingPrompt((prev) => prompt ?? prev);
+  const sendToAssistant = useCallback(() => {
+    setIsLoading(true);
 
-      try {
-        const response = await fetch("/api/assistant", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            messages: conversation.map(({ role, content }) => ({ role, content })),
-          }),
-        });
+    if (responseTimer.current) {
+      window.clearTimeout(responseTimer.current);
+    }
 
-        if (!response.ok) {
-          const error = await response.json().catch(() => null);
-          const message = typeof error?.error === "string" ? error.error : response.statusText;
-          throw new Error(message);
-        }
-
-        const data = (await response.json().catch(() => ({}))) as { message?: string };
-        const assistantText = typeof data.message === "string" ? data.message.trim() : "";
-
-        if (!assistantText) {
-          throw new Error("Empty assistant response");
-        }
-
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: crypto.randomUUID(),
-            role: "assistant",
-            content: assistantText,
-          },
-        ]);
-        setPendingPrompt(null);
-      } catch (error) {
-        console.error("Assistant request failed", error);
-        setErrorMessage(locale.errorBody);
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [locale.errorBody],
-  );
+    responseTimer.current = window.setTimeout(() => {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: crypto.randomUUID(),
+          role: "assistant",
+          content: locale.disabledResponse,
+        },
+      ]);
+      setIsLoading(false);
+    }, 480);
+  }, [locale.disabledResponse]);
 
   const openChat = useCallback(() => {
     setShouldRenderPanel(true);
@@ -178,21 +157,15 @@ export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChang
         content: trimmed,
       };
 
-      setMessages((prev) => {
-        const next = [...prev, userMessage];
-        void sendToAssistant(next, trimmed);
-        return next;
-      });
+      setMessages((prev) => [...prev, userMessage]);
+      sendToAssistant();
     },
     [sendToAssistant],
   );
 
   const handleRetry = useCallback(() => {
-    if (!pendingPrompt) {
-      return;
-    }
-    void sendToAssistant([...messages], pendingPrompt);
-  }, [messages, pendingPrompt, sendToAssistant]);
+    // No retry behaviour while the assistant is disabled.
+  }, []);
 
   const handlePrompt = useCallback(
     (prompt: string) => {
@@ -230,7 +203,7 @@ export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChang
             onClose={closeChat}
             onSend={handleSend}
             onUsePrompt={handlePrompt}
-            errorMessage={errorMessage}
+            errorMessage={null}
             onRetry={handleRetry}
           />
         ) : null}

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -59,6 +59,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
       errorTitle: t("errors.title"),
       errorBody: t("errors.body"),
       retryLabel: t("errors.retry"),
+      disabledResponse: t("disabledResponse"),
     }),
     [t],
   );
@@ -68,8 +69,6 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
   const [displayPanel, setDisplayPanel] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [isDesktop, setIsDesktop] = useState(false);
   const [hasReachedTrigger, setHasReachedTrigger] = useState(false);
   const [hasReachedBoundary, setHasReachedBoundary] = useState(false);
@@ -81,6 +80,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
   const anchorRef = useRef<HTMLDivElement>(null);
   const lastScrollYRef = useRef(0);
   const closeTimer = useRef<number>();
+  const responseTimer = useRef<number>();
   const hasOpenedRef = useRef(false);
   const anchorDismissedRef = useRef(false);
 
@@ -93,6 +93,17 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
     }
     setShouldRender(true);
   }, [isOpen]);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimer.current) {
+        window.clearTimeout(closeTimer.current);
+      }
+      if (responseTimer.current) {
+        window.clearTimeout(responseTimer.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
@@ -458,54 +469,25 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
     window.scrollTo({ top: target, behavior: "smooth" });
   }, [chatPanelId, isDesktop]);
 
-  const sendToAssistant = useCallback(
-    async (conversation: ChatMessage[], prompt: string | null) => {
-      setIsLoading(true);
-      setErrorMessage(null);
-      setPendingPrompt((prev) => prompt ?? prev);
+  const sendToAssistant = useCallback(() => {
+    setIsLoading(true);
 
-      try {
-        const response = await fetch("/api/assistant", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            messages: conversation.map(({ role, content }) => ({ role, content })),
-          }),
-        });
+    if (responseTimer.current) {
+      window.clearTimeout(responseTimer.current);
+    }
 
-        if (!response.ok) {
-          const error = await response.json().catch(() => null);
-          const message = typeof error?.error === "string" ? error.error : response.statusText;
-          throw new Error(message);
-        }
-
-        const data = (await response.json().catch(() => ({}))) as { message?: string };
-        const assistantText = typeof data.message === "string" ? data.message.trim() : "";
-
-        if (!assistantText) {
-          throw new Error("Empty assistant response");
-        }
-
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: crypto.randomUUID(),
-            role: "assistant",
-            content: assistantText,
-          },
-        ]);
-        setPendingPrompt(null);
-      } catch (error) {
-        console.error("Assistant request failed", error);
-        setErrorMessage(locale.errorBody);
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [locale.errorBody],
-  );
+    responseTimer.current = window.setTimeout(() => {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: crypto.randomUUID(),
+          role: "assistant",
+          content: locale.disabledResponse,
+        },
+      ]);
+      setIsLoading(false);
+    }, 480);
+  }, [locale.disabledResponse]);
 
   const handleSend = useCallback(
     (value: string) => {
@@ -520,21 +502,15 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
         content: trimmed,
       };
 
-      setMessages((prev) => {
-        const next = [...prev, userMessage];
-        void sendToAssistant(next, trimmed);
-        return next;
-      });
+      setMessages((prev) => [...prev, userMessage]);
+      sendToAssistant();
     },
     [sendToAssistant],
   );
 
   const handleRetry = useCallback(() => {
-    if (!pendingPrompt) {
-      return;
-    }
-    void sendToAssistant([...messages], pendingPrompt);
-  }, [messages, pendingPrompt, sendToAssistant]);
+    // No retry behaviour while the assistant is disabled.
+  }, []);
 
   const closeChat = useCallback(() => {
     setIsOpen(false);
@@ -589,7 +565,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
               onClose={closeChat}
               onSend={handleSend}
               onUsePrompt={handlePrompt}
-              errorMessage={errorMessage}
+              errorMessage={null}
               onRetry={handleRetry}
             />
           ) : null}

--- a/apps/www/components/ask/types.ts
+++ b/apps/www/components/ask/types.ts
@@ -25,4 +25,5 @@ export type ChatLocale = {
   errorTitle: string;
   errorBody: string;
   retryLabel: string;
+  disabledResponse: string;
 };

--- a/apps/www/components/auth/sign-in-form.tsx
+++ b/apps/www/components/auth/sign-in-form.tsx
@@ -72,6 +72,12 @@ export function SignInForm() {
 
   const disableButtons = isSubmitting || isGoogleSubmitting;
 
+  const showDevelopmentNotice = () => {
+    if (typeof window !== "undefined") {
+      window.alert(t("developmentNotice"));
+    }
+  };
+
   return (
     <div className="space-y-8">
       <div className="space-y-1">
@@ -175,7 +181,7 @@ export function SignInForm() {
         <button
           type="button"
           className="font-semibold text-white transition hover:text-white/80"
-          onClick={() => router.push("/create-account")}
+          onClick={showDevelopmentNotice}
           disabled={disableButtons}
         >
           {t("ctaLink")}

--- a/apps/www/components/auth/sign-up-form.tsx
+++ b/apps/www/components/auth/sign-up-form.tsx
@@ -174,6 +174,12 @@ export function SignUpForm() {
 
   const disableSubmit = isSubmitting || isGoogleSubmitting || isVerifyingStaff;
 
+  const showDevelopmentNotice = () => {
+    if (typeof window !== "undefined") {
+      window.alert(t("developmentNotice"));
+    }
+  };
+
   return (
     <div className="space-y-8">
       <div className="flex items-center justify-between">
@@ -371,7 +377,7 @@ export function SignUpForm() {
         <button
           type="button"
           className="font-semibold text-white transition hover:text-white/80"
-          onClick={() => router.push("/sign-in")}
+          onClick={showDevelopmentNotice}
           disabled={disableSubmit}
         >
           {t("signInLink")}

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -27,7 +27,13 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { forwardRef, useEffect, useState, type ComponentPropsWithoutRef } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useState,
+  type ComponentPropsWithoutRef,
+  type MouseEvent,
+} from "react";
 import { DesktopNavLink, MobileNavLink } from "./link";
 
 export function Navigation() {
@@ -383,6 +389,7 @@ function MembersMenu({ className }: { className?: string }) {
               label={t("createAccount")}
               description={t("membersMenu.createAccountDescription")}
               icon={UserPlus}
+              disabledMessage={t("membersMenu.developmentNotice")}
               onClick={() => {
                 setOpen(false);
                 if (hasConsentFor("measurement")) {
@@ -395,6 +402,7 @@ function MembersMenu({ className }: { className?: string }) {
               label={t("signIn")}
               description={t("membersMenu.signInDescription")}
               icon={LogIn}
+              disabledMessage={t("membersMenu.developmentNotice")}
               onClick={() => {
                 setOpen(false);
                 track("signin", { location: "navigation" });
@@ -467,6 +475,7 @@ const MembersDrawerMenu = ({ onNavigate }: MembersDrawerMenuProps) => {
             description={t("membersMenu.createAccountDescription")}
             icon={UserPlus}
             className="border-white/10 bg-white/5"
+            disabledMessage={t("membersMenu.developmentNotice")}
             onClick={() => {
               setOpen(false);
               onNavigate();
@@ -481,6 +490,7 @@ const MembersDrawerMenu = ({ onNavigate }: MembersDrawerMenuProps) => {
             description={t("membersMenu.signInDescription")}
             icon={LogIn}
             className="border-white/10 bg-white/5"
+            disabledMessage={t("membersMenu.developmentNotice")}
             onClick={() => {
               setOpen(false);
               onNavigate();
@@ -499,19 +509,43 @@ type MembersMenuLinkProps = {
   description: string;
   icon: LucideIcon;
   className?: string;
-  onClick?: () => void;
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+  disabledMessage?: string;
 };
 
-function MembersMenuLink({ href, label, description, icon: Icon, className, onClick }: MembersMenuLinkProps) {
+function MembersMenuLink({
+  href,
+  label,
+  description,
+  icon: Icon,
+  className,
+  onClick,
+  disabledMessage,
+}: MembersMenuLinkProps) {
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (disabledMessage) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+
+    onClick?.(event);
+
+    if (disabledMessage && typeof window !== "undefined") {
+      window.alert(disabledMessage);
+    }
+  };
+
   return (
     <Link
       href={href}
-      onClick={onClick}
+      onClick={handleClick}
       role="menuitem"
       className={cn(
         "group flex w-full items-center justify-between gap-3 rounded-xl border border-white/15 bg-white/5 px-4 py-3 text-left text-sm text-white/85 transition hover:border-white/20 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70 focus-visible:ring-offset-2 focus-visible:ring-offset-black",
+        disabledMessage ? "cursor-not-allowed opacity-70" : undefined,
         className,
       )}
+      aria-disabled={Boolean(disabledMessage)}
     >
       <span className="flex flex-col gap-1 text-left">
         <span className="flex items-center gap-2 font-semibold text-white">

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -39,7 +39,8 @@
       "continueRole": {
         "client": "Members hub",
         "staff": "Staff workspace"
-      }
+      },
+      "developmentNotice": "Still under development."
     },
     "settingsMenu": {
       "aria": "Quick settings",
@@ -305,9 +306,9 @@
       "title": "Choose the AI launch plan that matches your momentum",
       "subtitle": "Each package compresses strategy and execution into weeks, keeping leaders, teams, and ROI aligned.",
       "highlights": {
-        "speed": "AI wins in 90 days.",
+        "speed": "Highest quality AI integrations.",
         "support": "Guided by Dutch-speaking experts.",
-        "roi": "ROI benchmarks from 40+ cases."
+        "roi": "Productivity boost up to 10x."
       }
     },
     "Packages": {
@@ -431,6 +432,11 @@
         "chooseTier3": "Talk to Enterprise Solutions"
       }
     },
+    "ComingSoon": {
+      "title": "Coming soon.",
+      "subtitle": "Stay up to date?",
+      "cta": "Contact us"
+    },
     "Chat": {
       "cta": {
         "label": "Ask our TransformAI"
@@ -462,6 +468,7 @@
         "typing": "TransformAI Pricing Assistant is typing…",
         "transcriptLabel": "Conversation about pricing with the assistant"
       },
+      "disabledResponse": "TransformAI works super hard to have me working as fast as possible. For now just have a look around.",
       "errors": {
         "title": "Unable to reach the assistant",
         "body": "Please try again in a few moments.",
@@ -790,6 +797,7 @@
         "typing": "TransformAI Assistant is typing…",
         "transcriptLabel": "Conversation between you and the assistant"
       },
+      "disabledResponse": "TransformAI works super hard to have me working as fast as possible. For now just have a look around.",
       "errors": {
         "title": "Unable to reach the assistant",
         "body": "Please try again in a few moments.",
@@ -1277,6 +1285,7 @@
       },
       "haveAccount": "Already have an account?",
       "signInLink": "Sign in",
+      "developmentNotice": "Still under development.",
       "errors": {
         "intentFailed": "We couldn't verify that access code. Try again.",
         "emailInUse": "An account already exists for that email.",
@@ -1301,6 +1310,7 @@
       "submit": "Sign in",
       "cta": "Need an account?",
       "ctaLink": "Create one",
+      "developmentNotice": "Still under development.",
       "errors": {
         "invalid": "We couldn’t match those credentials. Try again."
       }

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -39,7 +39,8 @@
       "continueRole": {
         "client": "Ledenomgeving",
         "staff": "Teamdashboard"
-      }
+      },
+      "developmentNotice": "Nog in ontwikkeling."
     },
     "settingsMenu": {
       "aria": "Snelle instellingen",
@@ -305,9 +306,9 @@
       "title": "Kies het AI-traject dat past bij jullie tempo",
       "subtitle": "Elk pakket versnelt strategie naar uitvoering in weken, met begeleiding die teams meeneemt en resultaat meetbaar maakt.",
       "highlights": {
-        "speed": "AI-resultaten binnen 90 dagen.",
-        "support": "Nederlandstalige experts op locatie en remote.",
-        "roi": "ROI bewezen in 40+ klantcases."
+        "speed": "AI-integraties van de hoogste kwaliteit.",
+        "support": "Begeleid door Nederlandstalige experts.",
+        "roi": "Productiviteitsboost tot wel 10x."
       }
     },
     "Packages": {
@@ -431,6 +432,11 @@
         "chooseTier3": "Neem contact op voor enterprise"
       }
     },
+    "ComingSoon": {
+      "title": "Binnenkort beschikbaar.",
+      "subtitle": "Op de hoogte blijven?",
+      "cta": "Neem contact op"
+    },
     "Chat": {
       "cta": {
         "label": "Vraag het aan onze TransformAI"
@@ -462,6 +468,7 @@
         "typing": "TransformAI Prijsassistent is aan het typen…",
         "transcriptLabel": "Gesprek over prijzen met de assistent"
       },
+      "disabledResponse": "TransformAI werkt eraan om mij werkend te krijgen. Binnenkort ben ik beschikbaar om mee te chatten. Voor nu kijk gerust rond op de website.",
       "errors": {
         "title": "Assistent niet bereikbaar",
         "body": "Probeer het over een moment opnieuw.",
@@ -747,6 +754,7 @@
         "typing": "TransformAI-assistent is aan het typen…",
         "transcriptLabel": "Gesprek tussen jou en de assistent"
       },
+      "disabledResponse": "TransformAI werkt eraan om mij werkend te krijgen. Binnenkort ben ik beschikbaar om mee te chatten. Voor nu kijk gerust rond op de website.",
       "errors": {
         "title": "Assistent niet bereikbaar",
         "body": "Probeer het over een paar ogenblikken opnieuw.",
@@ -1234,6 +1242,7 @@
       },
       "haveAccount": "Heb je al een account?",
       "signInLink": "Log in",
+      "developmentNotice": "Nog in ontwikkeling.",
       "errors": {
         "intentFailed": "We konden de toegangscode niet valideren. Probeer het opnieuw.",
         "emailInUse": "Er bestaat al een account voor dit e-mailadres.",
@@ -1258,6 +1267,7 @@
       "submit": "Log in",
       "cta": "Nog geen account?",
       "ctaLink": "Maak er een",
+      "developmentNotice": "Nog in ontwikkeling.",
       "errors": {
         "invalid": "We konden deze inloggegevens niet vinden. Probeer het opnieuw."
       }


### PR DESCRIPTION
## Plan
- Replace live assistant requests with a locale-aware placeholder response across sticky and pricing chat components.
- Update navigation and authentication touchpoints to block unfinished account flows and surface a development notice.
- Obscure pricing comparisons with a coming-soon overlay and update associated translations in English and Dutch.
- Document the production hardening changes in WRITE_HERE/UPDATES.

## Summary
- Disabled chat API calls in the sticky and pricing assistants so each locale shows the new coming-soon response while preserving message flows.
- Blocked Create Account/Sign In navigation and form links, surfacing a localized "Still under development" alert instead of redirecting.
- Applied a full-width blur overlay to the pricing comparisons with a Coming Soon call-to-action and refreshed highlight messaging and translations in both languages.
- Logged the production readiness update in WRITE_HERE/UPDATES.

## Testing
- `pnpm --filter www run lint` *(fails: ERR_MODULE_NOT_FOUND for next-intl)*

------
https://chatgpt.com/codex/tasks/task_e_69045a9d1224832aa683ebe27f99871d