### PR TITLE
Refresh pricing page packages

### DIFF
--- a/WRITE_HERE/UPDATES/2025-12-02T1530--pricing-package-refresh.md
+++ b/WRITE_HERE/UPDATES/2025-12-02T1530--pricing-package-refresh.md
@@ -1,0 +1,6 @@
+# Pricing page package refresh
+
+- **What:** Replaced the pricing page offer cards with five new packages, updated CTA behaviour, and refreshed English/Dutch translations for the new modules and programs.
+- **Why:** Align the pricing overview with the latest education modules, platform roadmap, AISEO beta, and introductory assessment offering.
+- **Files:** `apps/www/app/[locale]/(site)/pricing/page.tsx`, `apps/www/app/[locale]/(site)/pricing/components.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Consider updating the pricing comparison table to reflect the new packages and ensure future CTA links for the platform enrollment once the beta opens.

--- a/apps/www/app/[locale]/(site)/pricing/components.tsx
+++ b/apps/www/app/[locale]/(site)/pricing/components.tsx
@@ -83,17 +83,33 @@ export const Cost: React.FC<{ dollar: string; className?: string; frequency?: st
   );
 };
 
-export const Button: React.FC<{ label: string; href: string }> = ({ label, href }) => {
+export const Button: React.FC<{ label: string; href?: string; disabled?: boolean }> = ({
+  label,
+  href,
+  disabled = false,
+}) => {
+  const baseClasses =
+    "block w-full h-10 text-sm font-semibold text-center rounded-lg border duration-500";
+  const enabledClasses = "text-black bg-white border-white hover:bg-transparent hover:text-white";
+  const disabledClasses = "text-white/60 border-white/20 bg-white/5 cursor-not-allowed";
+
+  if (href && !disabled) {
+    return (
+      <div>
+        <Link href={href}>
+          <button type="button" className={`${baseClasses} ${enabledClasses}`}>
+            {label}
+          </button>
+        </Link>
+      </div>
+    );
+  }
+
   return (
     <div>
-      <Link href={href}>
-        <button
-          type="button"
-          className="block w-full h-10 text-sm font-semibold text-center text-black duration-500 bg-white border border-white rounded-lg hover:bg-transparent hover:text-white"
-        >
-          {label}
-        </button>
-      </Link>
+      <button type="button" className={`${baseClasses} ${disabledClasses}`} disabled>
+        {label}
+      </button>
     </div>
   );
 };

--- a/apps/www/app/[locale]/(site)/pricing/page.tsx
+++ b/apps/www/app/[locale]/(site)/pricing/page.tsx
@@ -1,20 +1,11 @@
 "use client";
 import { PricingChat } from "@/components/ask";
 import { CTA } from "@/components/cta";
-import { Particles } from "@/components/particles";
 import { PricingCompareTable } from "@/components/pricing/pricing-compare-table";
 import { ShinyCardGroup } from "@/components/shiny-card";
 import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/hero";
 import { cn } from "@/lib/utils";
-import {
-  Check,
-  GraduationCap,
-  Handshake,
-  Languages,
-  Sparkles,
-  Timer,
-  TrendingUp,
-} from "lucide-react";
+import { Check, GraduationCap, Handshake, Languages, Sparkles, Timer, TrendingUp } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useLocale, useTranslations } from "next-intl";
@@ -48,9 +39,10 @@ export default function PricingPage() {
     { icon: TrendingUp, label: header("highlights.roi") },
   ] as const;
 
-  const educationContactHref = "mailto:support@unkey.dev?subject=TransformAI%20Education%20Package";
-  const introductionContactHref = "mailto:support@unkey.dev?subject=TransformAI%20Introduction%20Package";
-  const enterpriseContactHref = "mailto:support@unkey.dev?subject=TransformAI%20Enterprise%20Solutions";
+  const basicEducationContactHref = "mailto:support@unkey.dev?subject=TransformAI%20Basic%20Education%20Module";
+  const advancedEducationContactHref = "mailto:support@unkey.dev?subject=TransformAI%20Advanced%20Education%20Module";
+  const aiseoBetaContactHref = "mailto:support@unkey.dev?subject=TransformAI%20AISEO%20Beta%20Application";
+  const overviewContactHref = "mailto:support@unkey.dev?subject=TransformAI%20AI%20Situation%20Overview";
   return (
     <div className="pt-[64px]">
       <PricingChat onOpenChange={setIsChatOpen} />
@@ -131,13 +123,13 @@ export default function PricingPage() {
         <PricingCompareTable />
 
         <div id="pricing-tier-grid" className="mt-12">
-          <ShinyCardGroup className="grid h-full max-w-4xl grid-cols-2 gap-6 mx-auto group">
-            <PricingCard id="pricing-tier-1" color={Color.White} className="col-span-2 md:col-span-1">
+          <ShinyCardGroup className="grid h-full max-w-6xl grid-cols-1 gap-6 mx-auto group md:grid-cols-2 xl:grid-cols-3">
+            <PricingCard id="pricing-tier-1" color={Color.White} className="col-span-1">
               <FreeCardHighlight className="absolute top-0 right-0 pointer-events-none" />
 
               <PricingCardHeader
-                title={packages("education.title")}
-                description={packages("education.description")}
+                title={packages("basicEducation.title")}
+                description={packages("basicEducation.description")}
                 className="bg-gradient-to-tr from-transparent to-[#ffffff]/10 "
                 color={Color.White}
                 icon={GraduationCap}
@@ -146,147 +138,209 @@ export default function PricingPage() {
 
               <PricingCardContent>
                 <Cost
-                  dollar={packages("education.price")}
-                  frequency={packages("education.frequency")}
+                  dollar={packages("basicEducation.price")}
+                  frequency={packages("basicEducation.frequency")}
                 />
-                <Button label={packages("education.cta")} href={educationContactHref} />
-                <Bullets title={packages("common.included")}>
+                <Button label={packages("basicEducation.cta")} href={basicEducationContactHref} />
+                <Bullets title={packages("common.included")}> 
                   <li>
-                    <Bullet Icon={Check} label={packages("education.bullets.courseV1")} color={Color.White} />
+                    <Bullet Icon={Check} label={packages("basicEducation.bullets.customLessons")} color={Color.White} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("education.bullets.courseV2")} color={Color.White} />
+                    <Bullet Icon={Check} label={packages("basicEducation.bullets.foundations")} color={Color.White} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("education.bullets.workshops")} color={Color.White} />
+                    <Bullet Icon={Check} label={packages("basicEducation.bullets.handsOn")} color={Color.White} />
                   </li>
                   <li>
                     <Bullet
                       Icon={Check}
-                      label={packages("education.bullets.trainingMaterials")}
+                      label={packages("basicEducation.bullets.catalog")}
                       color={Color.White}
                     />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("education.bullets.certification")} color={Color.White} />
+                    <Bullet Icon={Check} label={packages("basicEducation.bullets.twoHours")} color={Color.White} />
                   </li>
                 </Bullets>
               </PricingCardContent>
               <PricingCardFooter>
                 <div className="flex flex-col gap-2">
-                  <p className="text-sm font-bold text-white">{packages("education.footer.title")}</p>
-                  <p className="text-xs text-white/60">{packages("education.footer.body")}</p>
+                  <p className="text-sm font-bold text-white">{packages("basicEducation.footer.title")}</p>
+                  <p className="text-xs text-white/60">{packages("basicEducation.footer.body")}</p>
                 </div>
               </PricingCardFooter>
             </PricingCard>
 
-            <PricingCard id="pricing-tier-2" color={Color.Yellow} className="col-span-2 md:col-span-1">
+            <PricingCard id="pricing-tier-2" color={Color.Yellow} className="col-span-1">
               <ProCardHighlight className="absolute top-0 right-0 pointer-events-none" />
 
               <PricingCardHeader
-                title={packages("introduction.title")}
-                description={packages("introduction.description")}
+                title={packages("advancedEducation.title")}
+                description={packages("advancedEducation.description")}
                 className="bg-gradient-to-tr from-black/50 to-[#FFD600]/10 "
                 color={Color.Yellow}
-                icon={Handshake}
+                icon={Sparkles}
               />
               <Separator />
 
               <PricingCardContent>
                 <Cost
-                  dollar={packages("introduction.price")}
-                  frequency={packages("introduction.frequency")}
+                  dollar={packages("advancedEducation.price")}
+                  frequency={packages("advancedEducation.frequency")}
                 />
-                <Button label={packages("introduction.cta")} href={introductionContactHref} />
-                <Bullets title={packages("common.included")}>
+                <Button label={packages("advancedEducation.cta")} href={advancedEducationContactHref} />
+                <Bullets title={packages("common.included")}> 
                   <li>
-                    <Bullet Icon={Check} label={packages("introduction.bullets.aiReadiness")} color={Color.Yellow} />
+                    <Bullet Icon={Check} label={packages("advancedEducation.bullets.innovationTracks")} color={Color.Yellow} />
                   </li>
                   <li>
                     <Bullet
                       Icon={Check}
-                      label={packages("introduction.bullets.automationSetup")}
+                      label={packages("advancedEducation.bullets.customBuilds")}
                       color={Color.Yellow}
                     />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("introduction.bullets.pilotIntegration")} color={Color.Yellow} />
+                    <Bullet Icon={Check} label={packages("advancedEducation.bullets.tooling")} color={Color.Yellow} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("introduction.bullets.assessment")} color={Color.Yellow} />
+                    <Bullet Icon={Check} label={packages("advancedEducation.bullets.catalog")} color={Color.Yellow} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("introduction.bullets.guidance")} color={Color.Yellow} />
+                    <Bullet Icon={Check} label={packages("advancedEducation.bullets.mentorship")} color={Color.Yellow} />
                   </li>
                 </Bullets>
               </PricingCardContent>
               <PricingCardFooter>
                 <div className="flex flex-col gap-2">
-                  <p className="text-sm font-bold text-white">{packages("introduction.footer.title")}</p>
-                  <p className="text-xs text-white/60">{packages("introduction.footer.body")}</p>
+                  <p className="text-sm font-bold text-white">{packages("advancedEducation.footer.title")}</p>
+                  <p className="text-xs text-white/60">{packages("advancedEducation.footer.body")}</p>
                 </div>
               </PricingCardFooter>
             </PricingCard>
 
-            <PricingCard id="pricing-tier-3" color={Color.Purple} className="col-span-2">
+            <PricingCard id="pricing-tier-3" color={Color.Purple} className="col-span-1 xl:col-span-1">
               <EnterpriseCardHighlight className="absolute top-0 right-0 pointer-events-none" />
 
-              <div className="flex flex-col h-full md:flex-row">
-                <div className="flex flex-col w-full gap-8">
-                  <PricingCardHeader
-                    title={packages("enterprise.title")}
-                    description={packages("enterprise.description")}
-                    color={Color.Purple}
-                    className="bg-gradient-to-tr from-transparent to-[#9D72FF]/10 "
-                    icon={Sparkles}
-                  />
-                  <PricingCardContent>
-                    <Cost
-                      dollar={packages("enterprise.price")}
-                      frequency={packages("enterprise.frequency")}
-                    />
-                    <Link href={enterpriseContactHref}>
-                      <div className="w-full p-px rounded-lg h-10 bg-gradient-to-r from-[#02DEFC] via-[#0239FC] to-[#7002FC] overflow-hidden">
-                        <div className="bg-black rounded-[7px] h-full bg-opacity-95 hover:bg-opacity-25 duration-1000">
-                          <div className="flex items-center justify-center w-full h-full bg-gradient-to-tr from-[#02DEFC]/20 via-[#0239FC]/20 to-[#7002FC]/20  rounded-[7px]">
-                            <span className="text-sm font-semibold text-white">{packages("enterprise.cta")}</span>
-                          </div>
-                        </div>
-                      </div>
-                    </Link>
-                  </PricingCardContent>
-              </div>
-              <Separator orientation="vertical" className="hidden md:flex" />
-              <Separator orientation="horizontal" className="md:hidden" />
-              <div className="relative w-full p-8">
-                <Particles
-                  className="absolute inset-0 duration-500 opacity-50 -z-10 group-hover:opacity-100"
-                  quantity={50}
+              <div className="flex flex-col h-full">
+                <PricingCardHeader
+                  title={packages("platform.title")}
+                  description={packages("platform.description")}
                   color={Color.Purple}
-                  vx={0.1}
-                  vy={-0.1}
+                  className="bg-gradient-to-tr from-transparent to-[#9D72FF]/10 "
+                  icon={Languages}
                 />
+                <Separator />
+                <PricingCardContent>
+                  <Cost
+                    dollar={packages("platform.price")}
+                    frequency={packages("platform.frequency")}
+                  />
+                  <Button label={packages("platform.cta")} disabled />
+                  <Bullets title={packages("common.included")}>
+                    <li>
+                      <Bullet Icon={Check} label={packages("platform.bullets.operatingSystem")} color={Color.Purple} />
+                    </li>
+                    <li>
+                      <Bullet Icon={Check} label={packages("platform.bullets.efficiency")} color={Color.Purple} />
+                    </li>
+                    <li>
+                      <Bullet Icon={Check} label={packages("platform.bullets.integrations")} color={Color.Purple} />
+                    </li>
+                    <li>
+                      <Bullet Icon={Check} label={packages("platform.bullets.guidance")} color={Color.Purple} />
+                    </li>
+                    <li>
+                      <Bullet Icon={Check} label={packages("platform.bullets.insights")} color={Color.Purple} />
+                    </li>
+                  </Bullets>
+                </PricingCardContent>
+                <PricingCardFooter>
+                  <div className="flex flex-col gap-2">
+                    <p className="text-sm font-bold text-white">{packages("platform.footer.title")}</p>
+                    <p className="text-xs text-white/60">{packages("platform.footer.body")}</p>
+                  </div>
+                </PricingCardFooter>
+              </div>
+            </PricingCard>
+
+            <PricingCard color={Color.White} className="col-span-1">
+              <PricingCardHeader
+                title={packages("aiseo.title")}
+                description={packages("aiseo.description")}
+                className="bg-gradient-to-tr from-transparent to-[#ffffff]/10 "
+                color={Color.White}
+                icon={TrendingUp}
+              />
+              <Separator />
+              <PricingCardContent>
+                <Cost dollar={packages("aiseo.price")} frequency={packages("aiseo.frequency")} />
+                <Button label={packages("aiseo.cta")} href={aiseoBetaContactHref} />
                 <Bullets title={packages("common.included")}>
                   <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.tailoredIntegrations")} color={Color.Purple} />
+                    <Bullet Icon={Check} label={packages("aiseo.bullets.aiVisibility")} color={Color.White} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.researchSupport")} color={Color.Purple} />
+                    <Bullet Icon={Check} label={packages("aiseo.bullets.knowledgeGraphs")} color={Color.White} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.customModel")} color={Color.Purple} />
+                    <Bullet Icon={Check} label={packages("aiseo.bullets.searchFuture")} color={Color.White} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.consulting")} color={Color.Purple} />
+                    <Bullet Icon={Check} label={packages("aiseo.bullets.experimentation")} color={Color.White} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.continuousSupport")} color={Color.Purple} />
+                    <Bullet Icon={Check} label={packages("aiseo.bullets.reporting")} color={Color.White} />
                   </li>
                 </Bullets>
-              </div>
-            </div>
-          </PricingCard>
-        </ShinyCardGroup>
+              </PricingCardContent>
+              <PricingCardFooter>
+                <div className="flex flex-col gap-2">
+                  <p className="text-sm font-bold text-white">{packages("aiseo.footer.title")}</p>
+                  <p className="text-xs text-white/60">{packages("aiseo.footer.body")}</p>
+                </div>
+              </PricingCardFooter>
+            </PricingCard>
+
+            <PricingCard color={Color.Yellow} className="col-span-1">
+              <PricingCardHeader
+                title={packages("overview.title")}
+                description={packages("overview.description")}
+                className="bg-gradient-to-tr from-black/50 to-[#FFD600]/10 "
+                color={Color.Yellow}
+                icon={Handshake}
+              />
+              <Separator />
+              <PricingCardContent>
+                <Cost dollar={packages("overview.price")} frequency={packages("overview.frequency")} />
+                <Button label={packages("overview.cta")} href={overviewContactHref} />
+                <Bullets title={packages("common.included")}>
+                  <li>
+                    <Bullet Icon={Check} label={packages("overview.bullets.topTierAdvice")} color={Color.Yellow} />
+                  </li>
+                  <li>
+                    <Bullet Icon={Check} label={packages("overview.bullets.situationOverview")} color={Color.Yellow} />
+                  </li>
+                  <li>
+                    <Bullet Icon={Check} label={packages("overview.bullets.report")} color={Color.Yellow} />
+                  </li>
+                  <li>
+                    <Bullet Icon={Check} label={packages("overview.bullets.benchmark")} color={Color.Yellow} />
+                  </li>
+                  <li>
+                    <Bullet Icon={Check} label={packages("overview.bullets.endToEnd")} color={Color.Yellow} />
+                  </li>
+                </Bullets>
+              </PricingCardContent>
+              <PricingCardFooter>
+                <div className="flex flex-col gap-2">
+                  <p className="text-sm font-bold text-white">{packages("overview.footer.title")}</p>
+                  <p className="text-xs text-white/60">{packages("overview.footer.body")}</p>
+                </div>
+              </PricingCardFooter>
+            </PricingCard>
+          </ShinyCardGroup>
       </div>
       <BelowEnterpriseSvg className="container inset-x-0 top-0 mx-auto -mt-64 -mb-32" />
 

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -314,54 +314,94 @@
       "common": {
         "included": "What's included:"
       },
-      "education": {
-        "title": "Education Package",
-        "description": "Focused on educating the workforce and making employees future-proof for AI adoption.",
-        "price": "$6,000",
-        "frequency": "one-time investment",
-        "cta": "Request education proposal",
+      "basicEducation": {
+        "title": "Basic education module",
+        "description": "Group lessons that build AI mastery for every role across your organization.",
+        "price": "€800",
+        "frequency": "per module (2h in-person)",
+        "cta": "Book education module",
         "bullets": {
-          "courseV1": "AI Education Course V1",
-          "courseV2": "AI Education Course V2",
-          "workshops": "Workshops for teams",
-          "trainingMaterials": "Practical training materials",
-          "certification": "Certification of completion"
+          "customLessons": "Customized group lessons for every team and role",
+          "foundations": "Foundational-to-advanced coverage of core AI principles",
+          "handsOn": "Hands-on practice with prompt design, image and video generation",
+          "catalog": "20+ in-person modules to mix and match",
+          "twoHours": "Each module is a two-hour, in-person experience"
         },
         "footer": {
-          "title": "Need a tailored curriculum?",
-          "body": "We can adapt the education program to the unique roles across your organization."
+          "title": "Planning multiple learning paths?",
+          "body": "We’ll help you curate the right mix of modules for every department."
         }
       },
-      "introduction": {
-        "title": "Introduction Package",
-        "description": "Designed for companies starting their AI transition journey.",
-        "price": "$5,000",
-        "frequency": "one-time engagement",
-        "cta": "Plan your AI kickoff",
+      "advancedEducation": {
+        "title": "Advanced education module",
+        "description": "Creation-focused sessions for experienced teams ready to build new AI solutions.",
+        "price": "€1,100",
+        "frequency": "per advanced module (2h in-person)",
+        "cta": "Book advanced module",
         "bullets": {
-          "aiReadiness": "AI-readiness analysis of the company",
-          "automationSetup": "Initial workflow automation setup",
-          "pilotIntegration": "Pilot project integration",
-          "assessment": "Productivity & cost-efficiency assessment",
-          "guidance": "Strategic guidance session with our team"
+          "innovationTracks": "Engineer cutting-edge AI systems alongside our experts",
+          "customBuilds": "Curricula tailored to makers who already master the fundamentals",
+          "tooling": "Deep-dives into agent orchestration, automation, and multimodal builds",
+          "catalog": "10 advanced modules pushing the frontier of applied AI",
+          "mentorship": "Intensive mentorship to turn concepts into production-ready prototypes"
         },
         "footer": {
-          "title": "Preparing to scale further?",
-          "body": "We can expand these foundations into enterprise-wide automation and governance."
+          "title": "Already mastered the basics?",
+          "body": "We’ll co-design advanced build tracks that match your teams’ ambitions."
         }
       },
-      "enterprise": {
-        "title": "Enterprise Solutions",
-        "description": "Custom AI transformation solutions built around your organization.",
-        "price": "Custom $",
-        "frequency": "Tailored proposal",
-        "cta": "Contact Us",
+      "platform": {
+        "title": "Custom Platform Enrollment",
+        "description": "A unified platform to operationalize AI across your company.",
+        "price": "Coming soon",
+        "frequency": "Private beta in development",
+        "cta": "Coming soon",
         "bullets": {
-          "tailoredIntegrations": "Tailored AI integrations",
-          "researchSupport": "Advanced research support",
-          "customModel": "Custom model development",
-          "consulting": "Dedicated consulting",
-          "continuousSupport": "Continuous support"
+          "operatingSystem": "Central operating system for assistants, workflows, and guardrails",
+          "efficiency": "Maximize efficiency and value capture from every AI initiative",
+          "integrations": "Deep integrations with the tools your teams already use",
+          "guidance": "Guided onboarding and playbooks tuned to your industry",
+          "insights": "Insight dashboards that track adoption and ROI in real time"
+        },
+        "footer": {
+          "title": "Want early access?",
+          "body": "Join the waitlist to hear when Custom Platform Enrollment opens."
+        }
+      },
+      "aiseo": {
+        "title": "AISEO package (AIEO)",
+        "description": "Ensure AI systems recognize and recommend your brand first.",
+        "price": "Beta access",
+        "frequency": "Apply for invitation",
+        "cta": "Apply for beta",
+        "bullets": {
+          "aiVisibility": "Optimize how leading AI assistants understand and surface your company",
+          "knowledgeGraphs": "Shape the knowledge graphs that generative AI references about you",
+          "searchFuture": "Future-proof discoverability as AI-native search replaces traditional SEO",
+          "experimentation": "Partner with our team as we refine the ranking algorithms",
+          "reporting": "Transparent reporting on visibility improvements across AI channels"
+        },
+        "footer": {
+          "title": "Limited beta availability",
+          "body": "We review applications weekly and onboard companies in focused cohorts."
+        }
+      },
+      "overview": {
+        "title": "AI situation overview",
+        "description": "A two-hour strategy intensive benchmarking your position in the AI landscape.",
+        "price": "€799",
+        "frequency": "two-hour strategy session",
+        "cta": "Apply now",
+        "bullets": {
+          "topTierAdvice": "Receive top-tier advice tailored to your goals and constraints",
+          "situationOverview": "Clarify where your company stands in today’s AI landscape",
+          "report": "Detailed report with actionable next steps and priorities",
+          "benchmark": "Benchmark your progress against peers in your industry",
+          "endToEnd": "Front- and back-end opportunities mapped in one workshop"
+        },
+        "footer": {
+          "title": "Ready for what’s next?",
+          "body": "We’ll outline your roadmap options and connect you with the right experts."
         }
       }
     },

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -314,54 +314,94 @@
       "common": {
         "included": "Dit zit erin:"
       },
-      "education": {
-        "title": "Educatiepakket",
-        "description": "Richt zich op het opleiden van medewerkers en maakt teams toekomstbestendig voor AI-adoptie.",
-        "price": "$6.000",
-        "frequency": "eenmalige investering",
-        "cta": "Vraag opleidingsvoorstel aan",
+      "basicEducation": {
+        "title": "Basismodule educatie",
+        "description": "Groepslessen waarmee elke rol binnen de organisatie AI-vaardig wordt.",
+        "price": "€800",
+        "frequency": "per module (2u op locatie)",
+        "cta": "Boek educatiemodule",
         "bullets": {
-          "courseV1": "AI-opleidingsmodule V1",
-          "courseV2": "AI-opleidingsmodule V2",
-          "workshops": "Workshops voor teams",
-          "trainingMaterials": "Praktische trainingsmaterialen",
-          "certification": "Certificaat van afronding"
+          "customLessons": "Gepersonaliseerde groepslessen voor elk team en elke rol",
+          "foundations": "Van fundament tot gevorderd: alle kernprincipes van AI",
+          "handsOn": "Hands-on oefenen met prompts, beeld- en videogeneratie",
+          "catalog": "Keuze uit meer dan 20 modules op locatie",
+          "twoHours": "Iedere module duurt twee uur en wordt in persoon gegeven"
         },
         "footer": {
-          "title": "Maatwerk nodig?",
-          "body": "We stemmen het leerprogramma af op de specifieke rollen binnen jouw organisatie."
+          "title": "Meerdere leerpaden nodig?",
+          "body": "Wij helpen de juiste mix van modules per afdeling samen te stellen."
         }
       },
-      "introduction": {
-        "title": "Introductiepakket",
-        "description": "Voor bedrijven die hun AI-transitie opstarten.",
-        "price": "$5.000",
-        "frequency": "eenmalig traject",
-        "cta": "Plan jullie AI-kick-off",
+      "advancedEducation": {
+        "title": "Geavanceerde educatiemodule",
+        "description": "Maaktrajecten voor teams die klaar zijn om nieuwe AI-oplossingen te bouwen.",
+        "price": "€1.100",
+        "frequency": "per geavanceerde module (2u op locatie)",
+        "cta": "Boek geavanceerde module",
         "bullets": {
-          "aiReadiness": "AI-ready analyse van het bedrijf",
-          "automationSetup": "Eerste workflow-automatisering",
-          "pilotIntegration": "Integratie van pilotproject",
-          "assessment": "Productiviteits- en kostenevaluatie",
-          "guidance": "Strategische sessie met ons team"
+          "innovationTracks": "Ontwerp grensverleggende AI-systemen samen met onze experts",
+          "customBuilds": "Curricula op maat voor teams die de basis al beheersen",
+          "tooling": "Diepgaande sessies over agent orchestration, automatisering en multimodaal",
+          "catalog": "10 geavanceerde modules met focus op high-impact innovatie",
+          "mentorship": "Intensieve begeleiding richting productieklare prototypes"
         },
         "footer": {
-          "title": "Groeien voorbij de pilot?",
-          "body": "We helpen om deze basis uit te breiden naar organisatiebrede automatisering en governance."
+          "title": "Basis al onder controle?",
+          "body": "We ontwerpen vervolgtrajecten die passen bij de ambitie van jullie teams."
         }
       },
-      "enterprise": {
-        "title": "Enterprise-oplossingen",
-        "description": "Maatwerk AI-transformatieoplossingen rond jouw organisatie.",
-        "price": "Custom $",
-        "frequency": "Op maat gemaakte offerte",
-        "cta": "Neem contact op",
+      "platform": {
+        "title": "Custom Platform Enrollment",
+        "description": "Een platform dat AI centraal in de organisatie operationaliseert.",
+        "price": "Binnenkort beschikbaar",
+        "frequency": "Private beta in ontwikkeling",
+        "cta": "Binnenkort beschikbaar",
         "bullets": {
-          "tailoredIntegrations": "Maatwerk AI-integraties",
-          "researchSupport": "Geavanceerde onderzoeksbegeleiding",
-          "customModel": "Ontwikkeling van maatwerkmodellen",
-          "consulting": "Toegewijde consulting",
-          "continuousSupport": "Doorlopende ondersteuning"
+          "operatingSystem": "Centraal besturingssysteem voor assistants, workflows en guardrails",
+          "efficiency": "Maximaliseer efficiëntie en waarde uit alle AI-initiatieven",
+          "integrations": "Diepe integraties met de tools die jullie al gebruiken",
+          "guidance": "Begeleide onboarding en playbooks per sector",
+          "insights": "Realtime dashboards voor adoptie en ROI"
+        },
+        "footer": {
+          "title": "Interesse in vroege toegang?",
+          "body": "Schrijf je in voor de wachtlijst en hoor als de enrollment opent."
+        }
+      },
+      "aiseo": {
+        "title": "AISEO-pakket (AIEO)",
+        "description": "Zorg dat AI-systemen jullie merk als eerste herkennen en aanbevelen.",
+        "price": "Beta-toegang",
+        "frequency": "Vraag uitnodiging aan",
+        "cta": "Meld je aan voor beta",
+        "bullets": {
+          "aiVisibility": "Optimaliseer hoe toonaangevende AI-assistenten jullie organisatie begrijpen",
+          "knowledgeGraphs": "Stuur de kennisgrafen aan waar generatieve AI zich op baseert",
+          "searchFuture": "Maak jullie vindbaarheid future-proof nu AI-gestuurde search de norm wordt",
+          "experimentation": "Werk samen met ons team terwijl we de ranking-algoritmes verfijnen",
+          "reporting": "Transparante rapportages over zichtbaarheid in AI-kanalen"
+        },
+        "footer": {
+          "title": "Beperkte beta-capaciteit",
+          "body": "We beoordelen aanmeldingen wekelijks en starten cohorts gefaseerd op."
+        }
+      },
+      "overview": {
+        "title": "AI-situatieoverzicht",
+        "description": "Een strategische sessie van twee uur die jullie positie in het AI-landschap vergelijkt.",
+        "price": "€799",
+        "frequency": "twee uur strategieconsult",
+        "cta": "Meld je nu aan",
+        "bullets": {
+          "topTierAdvice": "Topadvies op maat van jullie doelen en randvoorwaarden",
+          "situationOverview": "Inzicht in waar jullie organisatie nu staat in het AI-landschap",
+          "report": "Uitgebreid rapport met concrete vervolgstappen en prioriteiten",
+          "benchmark": "Benchmark ten opzichte van branchegenoten",
+          "endToEnd": "Front- en backend-kansen in één overzicht uitgewerkt"
+        },
+        "footer": {
+          "title": "Klaar voor de volgende stap?",
+          "body": "We schetsen de roadmap-opties en koppelen je aan de juiste experts."
         }
       }
     },


### PR DESCRIPTION
## Summary
- replace the pricing card grid with the new education, platform, AISEO, and overview packages
- expand the pricing button component to support disabled CTAs while wiring updated contact links
- refresh English and Dutch translation entries for the new offers and log the change

## Plan
- inspect the existing pricing package layout and supporting button helper to understand reuse points
- update locale messages with the new package copy for English and Dutch
- rebuild the pricing grid to include the five updated packages with correct CTAs and states
- run linting to verify the page after updates and capture any environment-related blockers

## Testing
- `pnpm --filter www run lint` *(fails: ERR_MODULE_NOT_FOUND for next-intl in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6909b41ca4d4832aa6eac6633985c7ac