### PR TITLE
Polish pricing packages layout and copy

### DIFF
--- a/WRITE_HERE/UPDATES/2025-12-02T1530--pricing-package-refresh.md
+++ b/WRITE_HERE/UPDATES/2025-12-02T1530--pricing-package-refresh.md
@@ -1,0 +1,6 @@
+# Pricing page package refresh
+
+- **What:** Replaced the pricing page offer cards with five new packages, updated CTA behaviour, and refreshed English/Dutch translations for the new modules and programs.
+- **Why:** Align the pricing overview with the latest education modules, platform roadmap, AISEO beta, and introductory assessment offering.
+- **Files:** `apps/www/app/[locale]/(site)/pricing/page.tsx`, `apps/www/app/[locale]/(site)/pricing/components.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Consider updating the pricing comparison table to reflect the new packages and ensure future CTA links for the platform enrollment once the beta opens.

--- a/WRITE_HERE/UPDATES/2025-12-02T1805--pricing-package-layout-polish.md
+++ b/WRITE_HERE/UPDATES/2025-12-02T1805--pricing-package-layout-polish.md
@@ -1,0 +1,6 @@
+# Pricing package layout polish
+
+- **What:** Added an "Other solutions" heading, tightened package copy, enabled bullet wrapping, and equalised card layouts so CTAs align.
+- **Why:** Addressed feedback that the new pricing packages overflowed their cards, lacked a section title, and rendered buttons at inconsistent heights.
+- **Files:** `apps/www/app/[locale]/(site)/pricing/page.tsx`, `apps/www/app/[locale]/(site)/pricing/components.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Swap the placeholder mailto links for final contact endpoints once confirmed.

--- a/apps/www/app/[locale]/(site)/pricing/components.tsx
+++ b/apps/www/app/[locale]/(site)/pricing/components.tsx
@@ -29,7 +29,7 @@ export const PricingCardHeader: React.FC<{
         <span className="bg-gradient-to-br text-transparent bg-gradient-stop  bg-clip-text from-white via-white via-30% to-white/30 font-medium ">
           {title}
         </span>
-        <p className="mt-4 text-sm text-white/60">{description}</p>
+        <p className="mt-4 text-sm leading-relaxed text-white/70 text-pretty">{description}</p>
       </div>
       {withIcon && Icon ? (
         <div
@@ -83,26 +83,46 @@ export const Cost: React.FC<{ dollar: string; className?: string; frequency?: st
   );
 };
 
-export const Button: React.FC<{ label: string; href: string }> = ({ label, href }) => {
+export const Button: React.FC<{ label: string; href?: string; disabled?: boolean }> = ({
+  label,
+  href,
+  disabled = false,
+}) => {
+  const baseClasses =
+    "block w-full h-10 text-sm font-semibold text-center rounded-lg border duration-500";
+  const enabledClasses = "text-black bg-white border-white hover:bg-transparent hover:text-white";
+  const disabledClasses = "text-white/60 border-white/20 bg-white/5 cursor-not-allowed";
+
+  if (href && !disabled) {
+    return (
+      <div>
+        <Link href={href}>
+          <button type="button" className={`${baseClasses} ${enabledClasses}`}>
+            {label}
+          </button>
+        </Link>
+      </div>
+    );
+  }
+
   return (
     <div>
-      <Link href={href}>
-        <button
-          type="button"
-          className="block w-full h-10 text-sm font-semibold text-center text-black duration-500 bg-white border border-white rounded-lg hover:bg-transparent hover:text-white"
-        >
-          {label}
-        </button>
-      </Link>
+      <button type="button" className={`${baseClasses} ${disabledClasses}`} disabled>
+        {label}
+      </button>
     </div>
   );
 };
 
-export const Bullets: React.FC<PropsWithChildren<{ title: string }>> = ({ children, title }) => {
+export const Bullets: React.FC<PropsWithChildren<{ title: string; className?: string }>> = ({
+  children,
+  title,
+  className,
+}) => {
   return (
-    <div>
+    <div className={cn("flex flex-col", className)}>
       <p className="text-white/50">{title}</p>
-      <ul className="flex flex-col gap-4 mt-6">{children}</ul>
+      <ul className="mt-6 flex flex-col gap-3">{children}</ul>
     </div>
   );
 };
@@ -125,7 +145,12 @@ export const Bullet: React.FC<{
       >
         <Icon className="w-3 h-3" />
       </div>
-      <span className={cn("text-sm text-white md:whitespace-nowrap sm:text-xs", textColor)}>
+      <span
+        className={cn(
+          "text-sm leading-relaxed text-white text-pretty sm:text-xs sm:leading-relaxed",
+          textColor,
+        )}
+      >
         {label}
       </span>
     </div>
@@ -138,7 +163,8 @@ export const PricingCardContent: React.FC<
   return (
     <div
       className={cn("flex gap-8 p-8", {
-        "flex-col": layout !== "horizontal",
+        "flex-row": layout === "horizontal",
+        "flex-1 flex-col": layout !== "horizontal",
       })}
     >
       {children}
@@ -183,7 +209,7 @@ export const PricingCard: React.FC<PropsWithChildren<{ color: Color; className?:
           },
         )}
       >
-        <div className="relative h-full bg-black rounded-[inherit] z-20 overflow-hidden ">
+        <div className="relative z-20 flex h-full flex-col overflow-hidden rounded-[inherit] bg-black ">
           {children}
         </div>
       </div>

--- a/apps/www/app/[locale]/(site)/pricing/page.tsx
+++ b/apps/www/app/[locale]/(site)/pricing/page.tsx
@@ -1,20 +1,11 @@
 "use client";
 import { PricingChat } from "@/components/ask";
 import { CTA } from "@/components/cta";
-import { Particles } from "@/components/particles";
 import { PricingCompareTable } from "@/components/pricing/pricing-compare-table";
 import { ShinyCardGroup } from "@/components/shiny-card";
 import { TopLeftShiningLight, TopRightShiningLight } from "@/components/svg/hero";
 import { cn } from "@/lib/utils";
-import {
-  Check,
-  GraduationCap,
-  Handshake,
-  Languages,
-  Sparkles,
-  Timer,
-  TrendingUp,
-} from "lucide-react";
+import { Check, GraduationCap, Handshake, Languages, Sparkles, Timer, TrendingUp } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useLocale, useTranslations } from "next-intl";
@@ -48,9 +39,10 @@ export default function PricingPage() {
     { icon: TrendingUp, label: header("highlights.roi") },
   ] as const;
 
-  const educationContactHref = "mailto:support@unkey.dev?subject=TransformAI%20Education%20Package";
-  const introductionContactHref = "mailto:support@unkey.dev?subject=TransformAI%20Introduction%20Package";
-  const enterpriseContactHref = "mailto:support@unkey.dev?subject=TransformAI%20Enterprise%20Solutions";
+  const basicEducationContactHref = "mailto:support@unkey.dev?subject=TransformAI%20Basic%20Education%20Module";
+  const advancedEducationContactHref = "mailto:support@unkey.dev?subject=TransformAI%20Advanced%20Education%20Module";
+  const aiseoBetaContactHref = "mailto:support@unkey.dev?subject=TransformAI%20AISEO%20Beta%20Application";
+  const overviewContactHref = "mailto:support@unkey.dev?subject=TransformAI%20AI%20Situation%20Overview";
   return (
     <div className="pt-[64px]">
       <PricingChat onOpenChange={setIsChatOpen} />
@@ -130,14 +122,20 @@ export default function PricingPage() {
 
         <PricingCompareTable />
 
+        <div className="mt-24 text-center">
+          <h2 className="text-balance text-3xl font-semibold text-white sm:text-4xl">
+            {packages("heading")}
+          </h2>
+        </div>
+
         <div id="pricing-tier-grid" className="mt-12">
-          <ShinyCardGroup className="grid h-full max-w-4xl grid-cols-2 gap-6 mx-auto group">
-            <PricingCard id="pricing-tier-1" color={Color.White} className="col-span-2 md:col-span-1">
+          <ShinyCardGroup className="grid h-full max-w-6xl grid-cols-1 gap-6 mx-auto group md:grid-cols-2 xl:grid-cols-3">
+            <PricingCard id="pricing-tier-1" color={Color.White} className="col-span-1">
               <FreeCardHighlight className="absolute top-0 right-0 pointer-events-none" />
 
               <PricingCardHeader
-                title={packages("education.title")}
-                description={packages("education.description")}
+                title={packages("basicEducation.title")}
+                description={packages("basicEducation.description")}
                 className="bg-gradient-to-tr from-transparent to-[#ffffff]/10 "
                 color={Color.White}
                 icon={GraduationCap}
@@ -146,147 +144,209 @@ export default function PricingPage() {
 
               <PricingCardContent>
                 <Cost
-                  dollar={packages("education.price")}
-                  frequency={packages("education.frequency")}
+                  dollar={packages("basicEducation.price")}
+                  frequency={packages("basicEducation.frequency")}
                 />
-                <Button label={packages("education.cta")} href={educationContactHref} />
-                <Bullets title={packages("common.included")}>
+                <Button label={packages("basicEducation.cta")} href={basicEducationContactHref} />
+                <Bullets title={packages("common.included")} className="flex-1">
                   <li>
-                    <Bullet Icon={Check} label={packages("education.bullets.courseV1")} color={Color.White} />
+                    <Bullet Icon={Check} label={packages("basicEducation.bullets.customLessons")} color={Color.White} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("education.bullets.courseV2")} color={Color.White} />
+                    <Bullet Icon={Check} label={packages("basicEducation.bullets.foundations")} color={Color.White} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("education.bullets.workshops")} color={Color.White} />
+                    <Bullet Icon={Check} label={packages("basicEducation.bullets.handsOn")} color={Color.White} />
                   </li>
                   <li>
                     <Bullet
                       Icon={Check}
-                      label={packages("education.bullets.trainingMaterials")}
+                      label={packages("basicEducation.bullets.catalog")}
                       color={Color.White}
                     />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("education.bullets.certification")} color={Color.White} />
+                    <Bullet Icon={Check} label={packages("basicEducation.bullets.twoHours")} color={Color.White} />
                   </li>
                 </Bullets>
               </PricingCardContent>
               <PricingCardFooter>
                 <div className="flex flex-col gap-2">
-                  <p className="text-sm font-bold text-white">{packages("education.footer.title")}</p>
-                  <p className="text-xs text-white/60">{packages("education.footer.body")}</p>
+                  <p className="text-sm font-bold text-white">{packages("basicEducation.footer.title")}</p>
+                  <p className="text-xs text-white/60">{packages("basicEducation.footer.body")}</p>
                 </div>
               </PricingCardFooter>
             </PricingCard>
 
-            <PricingCard id="pricing-tier-2" color={Color.Yellow} className="col-span-2 md:col-span-1">
+            <PricingCard id="pricing-tier-2" color={Color.Yellow} className="col-span-1">
               <ProCardHighlight className="absolute top-0 right-0 pointer-events-none" />
 
               <PricingCardHeader
-                title={packages("introduction.title")}
-                description={packages("introduction.description")}
+                title={packages("advancedEducation.title")}
+                description={packages("advancedEducation.description")}
                 className="bg-gradient-to-tr from-black/50 to-[#FFD600]/10 "
                 color={Color.Yellow}
-                icon={Handshake}
+                icon={Sparkles}
               />
               <Separator />
 
               <PricingCardContent>
                 <Cost
-                  dollar={packages("introduction.price")}
-                  frequency={packages("introduction.frequency")}
+                  dollar={packages("advancedEducation.price")}
+                  frequency={packages("advancedEducation.frequency")}
                 />
-                <Button label={packages("introduction.cta")} href={introductionContactHref} />
-                <Bullets title={packages("common.included")}>
+                <Button label={packages("advancedEducation.cta")} href={advancedEducationContactHref} />
+                <Bullets title={packages("common.included")} className="flex-1">
                   <li>
-                    <Bullet Icon={Check} label={packages("introduction.bullets.aiReadiness")} color={Color.Yellow} />
+                    <Bullet Icon={Check} label={packages("advancedEducation.bullets.innovationTracks")} color={Color.Yellow} />
                   </li>
                   <li>
                     <Bullet
                       Icon={Check}
-                      label={packages("introduction.bullets.automationSetup")}
+                      label={packages("advancedEducation.bullets.customBuilds")}
                       color={Color.Yellow}
                     />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("introduction.bullets.pilotIntegration")} color={Color.Yellow} />
+                    <Bullet Icon={Check} label={packages("advancedEducation.bullets.tooling")} color={Color.Yellow} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("introduction.bullets.assessment")} color={Color.Yellow} />
+                    <Bullet Icon={Check} label={packages("advancedEducation.bullets.catalog")} color={Color.Yellow} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("introduction.bullets.guidance")} color={Color.Yellow} />
+                    <Bullet Icon={Check} label={packages("advancedEducation.bullets.mentorship")} color={Color.Yellow} />
                   </li>
                 </Bullets>
               </PricingCardContent>
               <PricingCardFooter>
                 <div className="flex flex-col gap-2">
-                  <p className="text-sm font-bold text-white">{packages("introduction.footer.title")}</p>
-                  <p className="text-xs text-white/60">{packages("introduction.footer.body")}</p>
+                  <p className="text-sm font-bold text-white">{packages("advancedEducation.footer.title")}</p>
+                  <p className="text-xs text-white/60">{packages("advancedEducation.footer.body")}</p>
                 </div>
               </PricingCardFooter>
             </PricingCard>
 
-            <PricingCard id="pricing-tier-3" color={Color.Purple} className="col-span-2">
+            <PricingCard id="pricing-tier-3" color={Color.Purple} className="col-span-1 xl:col-span-1">
               <EnterpriseCardHighlight className="absolute top-0 right-0 pointer-events-none" />
 
-              <div className="flex flex-col h-full md:flex-row">
-                <div className="flex flex-col w-full gap-8">
-                  <PricingCardHeader
-                    title={packages("enterprise.title")}
-                    description={packages("enterprise.description")}
-                    color={Color.Purple}
-                    className="bg-gradient-to-tr from-transparent to-[#9D72FF]/10 "
-                    icon={Sparkles}
-                  />
-                  <PricingCardContent>
-                    <Cost
-                      dollar={packages("enterprise.price")}
-                      frequency={packages("enterprise.frequency")}
-                    />
-                    <Link href={enterpriseContactHref}>
-                      <div className="w-full p-px rounded-lg h-10 bg-gradient-to-r from-[#02DEFC] via-[#0239FC] to-[#7002FC] overflow-hidden">
-                        <div className="bg-black rounded-[7px] h-full bg-opacity-95 hover:bg-opacity-25 duration-1000">
-                          <div className="flex items-center justify-center w-full h-full bg-gradient-to-tr from-[#02DEFC]/20 via-[#0239FC]/20 to-[#7002FC]/20  rounded-[7px]">
-                            <span className="text-sm font-semibold text-white">{packages("enterprise.cta")}</span>
-                          </div>
-                        </div>
-                      </div>
-                    </Link>
-                  </PricingCardContent>
-              </div>
-              <Separator orientation="vertical" className="hidden md:flex" />
-              <Separator orientation="horizontal" className="md:hidden" />
-              <div className="relative w-full p-8">
-                <Particles
-                  className="absolute inset-0 duration-500 opacity-50 -z-10 group-hover:opacity-100"
-                  quantity={50}
+              <div className="flex flex-col h-full">
+                <PricingCardHeader
+                  title={packages("platform.title")}
+                  description={packages("platform.description")}
                   color={Color.Purple}
-                  vx={0.1}
-                  vy={-0.1}
+                  className="bg-gradient-to-tr from-transparent to-[#9D72FF]/10 "
+                  icon={Languages}
                 />
-                <Bullets title={packages("common.included")}>
+                <Separator />
+                <PricingCardContent>
+                  <Cost
+                    dollar={packages("platform.price")}
+                    frequency={packages("platform.frequency")}
+                  />
+                  <Button label={packages("platform.cta")} disabled />
+                  <Bullets title={packages("common.included")} className="flex-1">
+                    <li>
+                      <Bullet Icon={Check} label={packages("platform.bullets.operatingSystem")} color={Color.Purple} />
+                    </li>
+                    <li>
+                      <Bullet Icon={Check} label={packages("platform.bullets.efficiency")} color={Color.Purple} />
+                    </li>
+                    <li>
+                      <Bullet Icon={Check} label={packages("platform.bullets.integrations")} color={Color.Purple} />
+                    </li>
+                    <li>
+                      <Bullet Icon={Check} label={packages("platform.bullets.guidance")} color={Color.Purple} />
+                    </li>
+                    <li>
+                      <Bullet Icon={Check} label={packages("platform.bullets.insights")} color={Color.Purple} />
+                    </li>
+                  </Bullets>
+                </PricingCardContent>
+                <PricingCardFooter>
+                  <div className="flex flex-col gap-2">
+                    <p className="text-sm font-bold text-white">{packages("platform.footer.title")}</p>
+                    <p className="text-xs text-white/60">{packages("platform.footer.body")}</p>
+                  </div>
+                </PricingCardFooter>
+              </div>
+            </PricingCard>
+
+            <PricingCard color={Color.White} className="col-span-1">
+              <PricingCardHeader
+                title={packages("aiseo.title")}
+                description={packages("aiseo.description")}
+                className="bg-gradient-to-tr from-transparent to-[#ffffff]/10 "
+                color={Color.White}
+                icon={TrendingUp}
+              />
+              <Separator />
+              <PricingCardContent>
+                <Cost dollar={packages("aiseo.price")} frequency={packages("aiseo.frequency")} />
+                <Button label={packages("aiseo.cta")} href={aiseoBetaContactHref} />
+                <Bullets title={packages("common.included")} className="flex-1">
                   <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.tailoredIntegrations")} color={Color.Purple} />
+                    <Bullet Icon={Check} label={packages("aiseo.bullets.aiVisibility")} color={Color.White} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.researchSupport")} color={Color.Purple} />
+                    <Bullet Icon={Check} label={packages("aiseo.bullets.knowledgeGraphs")} color={Color.White} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.customModel")} color={Color.Purple} />
+                    <Bullet Icon={Check} label={packages("aiseo.bullets.searchFuture")} color={Color.White} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.consulting")} color={Color.Purple} />
+                    <Bullet Icon={Check} label={packages("aiseo.bullets.experimentation")} color={Color.White} />
                   </li>
                   <li>
-                    <Bullet Icon={Check} label={packages("enterprise.bullets.continuousSupport")} color={Color.Purple} />
+                    <Bullet Icon={Check} label={packages("aiseo.bullets.reporting")} color={Color.White} />
                   </li>
                 </Bullets>
-              </div>
-            </div>
-          </PricingCard>
-        </ShinyCardGroup>
+              </PricingCardContent>
+              <PricingCardFooter>
+                <div className="flex flex-col gap-2">
+                  <p className="text-sm font-bold text-white">{packages("aiseo.footer.title")}</p>
+                  <p className="text-xs text-white/60">{packages("aiseo.footer.body")}</p>
+                </div>
+              </PricingCardFooter>
+            </PricingCard>
+
+            <PricingCard color={Color.Yellow} className="col-span-1">
+              <PricingCardHeader
+                title={packages("overview.title")}
+                description={packages("overview.description")}
+                className="bg-gradient-to-tr from-black/50 to-[#FFD600]/10 "
+                color={Color.Yellow}
+                icon={Handshake}
+              />
+              <Separator />
+              <PricingCardContent>
+                <Cost dollar={packages("overview.price")} frequency={packages("overview.frequency")} />
+                <Button label={packages("overview.cta")} href={overviewContactHref} />
+                <Bullets title={packages("common.included")} className="flex-1">
+                  <li>
+                    <Bullet Icon={Check} label={packages("overview.bullets.topTierAdvice")} color={Color.Yellow} />
+                  </li>
+                  <li>
+                    <Bullet Icon={Check} label={packages("overview.bullets.situationOverview")} color={Color.Yellow} />
+                  </li>
+                  <li>
+                    <Bullet Icon={Check} label={packages("overview.bullets.report")} color={Color.Yellow} />
+                  </li>
+                  <li>
+                    <Bullet Icon={Check} label={packages("overview.bullets.benchmark")} color={Color.Yellow} />
+                  </li>
+                  <li>
+                    <Bullet Icon={Check} label={packages("overview.bullets.endToEnd")} color={Color.Yellow} />
+                  </li>
+                </Bullets>
+              </PricingCardContent>
+              <PricingCardFooter>
+                <div className="flex flex-col gap-2">
+                  <p className="text-sm font-bold text-white">{packages("overview.footer.title")}</p>
+                  <p className="text-xs text-white/60">{packages("overview.footer.body")}</p>
+                </div>
+              </PricingCardFooter>
+            </PricingCard>
+          </ShinyCardGroup>
       </div>
       <BelowEnterpriseSvg className="container inset-x-0 top-0 mx-auto -mt-64 -mb-32" />
 

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -311,57 +311,98 @@
       }
     },
     "Packages": {
+      "heading": "Other solutions",
       "common": {
         "included": "What's included:"
       },
-      "education": {
-        "title": "Education Package",
-        "description": "Focused on educating the workforce and making employees future-proof for AI adoption.",
-        "price": "$6,000",
-        "frequency": "one-time investment",
-        "cta": "Request education proposal",
+      "basicEducation": {
+        "title": "Basic education module",
+        "description": "In-person group modules that give every role AI confidence.",
+        "price": "€800",
+        "frequency": "per module (2h in-person)",
+        "cta": "Book education module",
         "bullets": {
-          "courseV1": "AI Education Course V1",
-          "courseV2": "AI Education Course V2",
-          "workshops": "Workshops for teams",
-          "trainingMaterials": "Practical training materials",
-          "certification": "Certification of completion"
+          "customLessons": "Tailored cohorts for every team and role",
+          "foundations": "From core principles to confident day-to-day use",
+          "handsOn": "Hands-on prompts plus image & video creation labs",
+          "catalog": "Pick from 20+ on-site modules",
+          "twoHours": "Two-hour, in-person sessions per module"
         },
         "footer": {
-          "title": "Need a tailored curriculum?",
-          "body": "We can adapt the education program to the unique roles across your organization."
+          "title": "Planning multiple learning paths?",
+          "body": "We’ll curate the right mix of modules for every department."
         }
       },
-      "introduction": {
-        "title": "Introduction Package",
-        "description": "Designed for companies starting their AI transition journey.",
-        "price": "$5,000",
-        "frequency": "one-time engagement",
-        "cta": "Plan your AI kickoff",
+      "advancedEducation": {
+        "title": "Advanced education module",
+        "description": "Build-first workshops for teams ready to ship new AI products.",
+        "price": "€1,100",
+        "frequency": "per advanced module (2h in-person)",
+        "cta": "Book advanced module",
         "bullets": {
-          "aiReadiness": "AI-readiness analysis of the company",
-          "automationSetup": "Initial workflow automation setup",
-          "pilotIntegration": "Pilot project integration",
-          "assessment": "Productivity & cost-efficiency assessment",
-          "guidance": "Strategic guidance session with our team"
+          "innovationTracks": "Co-engineer frontier AI systems with our experts",
+          "customBuilds": "Tracks tuned for makers who already know the basics",
+          "tooling": "Deep dives into orchestration, automation, and multimodal stacks",
+          "catalog": "10 advanced modules pushing applied AI forward",
+          "mentorship": "Mentorship that turns ideas into production-ready prototypes"
         },
         "footer": {
-          "title": "Preparing to scale further?",
-          "body": "We can expand these foundations into enterprise-wide automation and governance."
+          "title": "Already mastered the basics?",
+          "body": "We’ll co-design build tracks that match your teams’ ambitions."
         }
       },
-      "enterprise": {
-        "title": "Enterprise Solutions",
-        "description": "Custom AI transformation solutions built around your organization.",
-        "price": "Custom $",
-        "frequency": "Tailored proposal",
-        "cta": "Contact Us",
+      "platform": {
+        "title": "Custom Platform Enrollment",
+        "description": "One control center to operationalise AI across your company.",
+        "price": "Coming soon",
+        "frequency": "Private beta in development",
+        "cta": "Coming soon",
         "bullets": {
-          "tailoredIntegrations": "Tailored AI integrations",
-          "researchSupport": "Advanced research support",
-          "customModel": "Custom model development",
-          "consulting": "Dedicated consulting",
-          "continuousSupport": "Continuous support"
+          "operatingSystem": "Central OS for assistants, workflows, and guardrails",
+          "efficiency": "Maximize efficiency and value from every AI initiative",
+          "integrations": "Integrations with the tools your teams already use",
+          "guidance": "Guided onboarding and playbooks by industry",
+          "insights": "Realtime adoption and ROI insight dashboards"
+        },
+        "footer": {
+          "title": "Want early access?",
+          "body": "Join the waitlist to hear when enrollment opens."
+        }
+      },
+      "aiseo": {
+        "title": "AISEO package (AIEO)",
+        "description": "Put your brand at the top of AI-driven discovery.",
+        "price": "Beta access",
+        "frequency": "Apply for invitation",
+        "cta": "Apply for beta",
+        "bullets": {
+          "aiVisibility": "Shape how leading AI assistants understand your company",
+          "knowledgeGraphs": "Influence the knowledge graphs generative AI trusts",
+          "searchFuture": "Stay visible as AI-native search replaces SEO",
+          "experimentation": "Co-develop ranking experiments with our team",
+          "reporting": "Track visibility gains across AI channels"
+        },
+        "footer": {
+          "title": "Limited beta availability",
+          "body": "We review applications weekly and onboard focused cohorts."
+        }
+      },
+      "overview": {
+        "title": "AI situation overview",
+        "description": "A two-hour strategy sprint benchmarking your AI position.",
+        "price": "€799",
+        "frequency": "two-hour strategy session",
+        "cta": "Apply now",
+        "bullets": {
+          "topTierAdvice": "Receive senior-level advice tailored to your goals",
+          "situationOverview": "See where your company stands in today’s AI landscape",
+          "report": "Get a detailed report with next steps and priorities",
+          "benchmark": "Benchmark progress against peers in your industry",
+          "endToEnd": "Map front- and back-end opportunities in one workshop"
+        },
+        "footer": {
+          "title": "Ready for what’s next?",
+          "body": "We’ll outline roadmap options and connect you with the right experts."
         }
       }
     },

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -311,57 +311,98 @@
       }
     },
     "Packages": {
+      "heading": "Overige oplossingen",
       "common": {
         "included": "Dit zit erin:"
       },
-      "education": {
-        "title": "Educatiepakket",
-        "description": "Richt zich op het opleiden van medewerkers en maakt teams toekomstbestendig voor AI-adoptie.",
-        "price": "$6.000",
-        "frequency": "eenmalige investering",
-        "cta": "Vraag opleidingsvoorstel aan",
+      "basicEducation": {
+        "title": "Basismodule educatie",
+        "description": "Groepsmodules op locatie die elke rol AI-vaardig maken.",
+        "price": "€800",
+        "frequency": "per module (2u op locatie)",
+        "cta": "Boek educatiemodule",
         "bullets": {
-          "courseV1": "AI-opleidingsmodule V1",
-          "courseV2": "AI-opleidingsmodule V2",
-          "workshops": "Workshops voor teams",
-          "trainingMaterials": "Praktische trainingsmaterialen",
-          "certification": "Certificaat van afronding"
+          "customLessons": "Cohorten op maat voor elk team en elke rol",
+          "foundations": "Van kernprincipes tot dagelijkse toepassing",
+          "handsOn": "Hands-on prompts plus beeld- en videogeneratie",
+          "catalog": "Kies uit 20+ modules op locatie",
+          "twoHours": "Twee uur per module, altijd in persoon"
         },
         "footer": {
-          "title": "Maatwerk nodig?",
-          "body": "We stemmen het leerprogramma af op de specifieke rollen binnen jouw organisatie."
+          "title": "Meerdere leerpaden nodig?",
+          "body": "We helpen de ideale mix per afdeling samen te stellen."
         }
       },
-      "introduction": {
-        "title": "Introductiepakket",
-        "description": "Voor bedrijven die hun AI-transitie opstarten.",
-        "price": "$5.000",
-        "frequency": "eenmalig traject",
-        "cta": "Plan jullie AI-kick-off",
+      "advancedEducation": {
+        "title": "Geavanceerde educatiemodule",
+        "description": "Build-first sessies voor teams die nieuwe AI-producten willen bouwen.",
+        "price": "€1.100",
+        "frequency": "per geavanceerde module (2u op locatie)",
+        "cta": "Boek geavanceerde module",
         "bullets": {
-          "aiReadiness": "AI-ready analyse van het bedrijf",
-          "automationSetup": "Eerste workflow-automatisering",
-          "pilotIntegration": "Integratie van pilotproject",
-          "assessment": "Productiviteits- en kostenevaluatie",
-          "guidance": "Strategische sessie met ons team"
+          "innovationTracks": "Co-engineer grensverleggende AI-systemen met onze experts",
+          "customBuilds": "Trajecten op maat voor teams die de basis beheersen",
+          "tooling": "Diepduiken in orchestration, automatisering en multimodaal",
+          "catalog": "10 geavanceerde modules die applied AI versnellen",
+          "mentorship": "Begeleiding richting productieklare prototypes"
         },
         "footer": {
-          "title": "Groeien voorbij de pilot?",
-          "body": "We helpen om deze basis uit te breiden naar organisatiebrede automatisering en governance."
+          "title": "Basis al onder controle?",
+          "body": "We ontwerpen vervolgtrajecten die passen bij jullie ambitie."
         }
       },
-      "enterprise": {
-        "title": "Enterprise-oplossingen",
-        "description": "Maatwerk AI-transformatieoplossingen rond jouw organisatie.",
-        "price": "Custom $",
-        "frequency": "Op maat gemaakte offerte",
-        "cta": "Neem contact op",
+      "platform": {
+        "title": "Custom Platform Enrollment",
+        "description": "Eén controlecentrum om AI door de hele organisatie te operationaliseren.",
+        "price": "Binnenkort beschikbaar",
+        "frequency": "Private beta in ontwikkeling",
+        "cta": "Binnenkort beschikbaar",
         "bullets": {
-          "tailoredIntegrations": "Maatwerk AI-integraties",
-          "researchSupport": "Geavanceerde onderzoeksbegeleiding",
-          "customModel": "Ontwikkeling van maatwerkmodellen",
-          "consulting": "Toegewijde consulting",
-          "continuousSupport": "Doorlopende ondersteuning"
+          "operatingSystem": "Centraal OS voor assistants, workflows en guardrails",
+          "efficiency": "Maximaliseer efficiëntie en waarde uit elk AI-initiatief",
+          "integrations": "Integraties met de tools die jullie al gebruiken",
+          "guidance": "Begeleide onboarding en playbooks per sector",
+          "insights": "Realtime dashboards voor adoptie en ROI"
+        },
+        "footer": {
+          "title": "Interesse in vroege toegang?",
+          "body": "Schrijf je in voor de wachtlijst en hoor direct wanneer we openen."
+        }
+      },
+      "aiseo": {
+        "title": "AISEO-pakket (AIEO)",
+        "description": "Zorg dat AI-gedreven zoekresultaten jullie merk bovenaan plaatsen.",
+        "price": "Beta-toegang",
+        "frequency": "Vraag uitnodiging aan",
+        "cta": "Meld je aan voor beta",
+        "bullets": {
+          "aiVisibility": "Stuur hoe toonaangevende AI-assistenten jullie organisatie begrijpen",
+          "knowledgeGraphs": "Beïnvloed de kennisgrafen waar generatieve AI op vertrouwt",
+          "searchFuture": "Blijf zichtbaar nu AI-gestuurde search SEO vervangt",
+          "experimentation": "Ontwikkel ranking-experimenten samen met ons team",
+          "reporting": "Krijg duidelijke rapportages over zichtbaarheid in AI-kanalen"
+        },
+        "footer": {
+          "title": "Beperkte beta-capaciteit",
+          "body": "We beoordelen wekelijks en starten gefocuste cohorts."
+        }
+      },
+      "overview": {
+        "title": "AI-situatieoverzicht",
+        "description": "Een strategie sprint van twee uur die jullie AI-positie benchmarkt.",
+        "price": "€799",
+        "frequency": "twee uur strategieconsult",
+        "cta": "Meld je nu aan",
+        "bullets": {
+          "topTierAdvice": "Ontvang senior advies op maat van jullie doelen",
+          "situationOverview": "Zie waar jullie organisatie staat in het AI-landschap",
+          "report": "Krijg een helder rapport met concrete vervolgstappen",
+          "benchmark": "Benchmark tegen peers binnen jullie sector",
+          "endToEnd": "Breng front- en backend-kansen in één workshop in kaart"
+        },
+        "footer": {
+          "title": "Klaar voor de volgende stap?",
+          "body": "We schetsen roadmap-opties en koppelen je aan de juiste experts."
         }
       }
     },


### PR DESCRIPTION
## Summary
- add an "Other solutions" heading before the pricing package grid and tighten CTA layout spacing
- let pricing card content flex so CTA buttons align while allowing bullet text to wrap cleanly
- refresh English and Dutch package copy and log the update in WRITE_HERE/UPDATES

## Plan
- tighten translation strings for each package in English and Dutch
- adjust pricing card layout primitives to support wrapping text and consistent CTA placement
- add the section heading and updated bullet wrappers on the pricing page

## Testing
- `pnpm --filter www run lint` *(fails: missing `next-intl` dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6909b41ca4d4832aa6eac6633985c7ac