### PR TITLE
Handle missing contact messages table gracefully

### DIFF
--- a/WRITE_HERE/FIXES/2025-11-04T1006--contact-server-action-initial-state.md
+++ b/WRITE_HERE/FIXES/2025-11-04T1006--contact-server-action-initial-state.md
@@ -1,0 +1,6 @@
+# Restore contact form server action exports
+
+- **What:** Moved the contact form's initial state constant into the client component so the server action module only exports async functions.
+- **Why:** Next.js rejected the "use server" module because the exported object violated the server action export rules, causing submissions to fail.
+- **Files:** `apps/www/app/[locale]/(site)/contact/components/contact-form.tsx`, `apps/www/app/[locale]/(site)/contact/server/send-message.ts`.
+- **Follow-ups:** Audit other server action modules for similar exported constants if they trigger runtime errors.

--- a/WRITE_HERE/FIXES/2025-12-03T1100--contact-form-persists-without-table.md
+++ b/WRITE_HERE/FIXES/2025-12-03T1100--contact-form-persists-without-table.md
@@ -1,0 +1,6 @@
+# Keep contact submissions flowing when persistence fails
+
+- **What:** Let contact submissions continue to send email and Discord alerts even if the new `contact_messages` table has not been migrated yet, and prevent the staff inbox from crashing when the table is missing.
+- **Why:** The contact form returned an error in environments that had not applied the latest database migration, preventing any enquiry from being delivered.
+- **Files:** `apps/www/app/[locale]/(site)/contact/server/send-message.ts`, `apps/www/app/[locale]/(site)/dashboard/inbox/page.tsx`, `apps/www/lib/db/errors.ts`.
+- **Follow-ups:** Apply the `contact_messages` migration to enable in-app archiving once the database is ready.

--- a/WRITE_HERE/UPDATES/2025-12-03T0900--contact-inbox-and-translation-refresh.md
+++ b/WRITE_HERE/UPDATES/2025-12-03T0900--contact-inbox-and-translation-refresh.md
@@ -1,0 +1,6 @@
+# Contact inbox and translation refresh
+
+- **What:** Updated contact request categories and email requirements in both locales, persisted submissions to the database with Discord notifications, and added a staff inbox view for reviewing contact messages.
+- **Why:** Align the form copy with the latest offerings, capture all inbound enquiries centrally, and alert the team via Discord for faster follow-up.
+- **Files:** `apps/www/app/[locale]/(site)/contact/*`, `apps/www/app/[locale]/(site)/dashboard/inbox/page.tsx`, `apps/www/components/navbar/navigation.tsx`, `apps/www/lib/db/schema.ts`, `apps/www/drizzle/0005_contact_messages.sql`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`.
+- **Follow-ups:** Run the new migration in the target environment and configure `CONTACT_DISCORD_WEBHOOK` (or equivalent) with the production webhook URL if it differs from the provided default.

--- a/apps/www/app/[locale]/(site)/contact/components/contact-form.tsx
+++ b/apps/www/app/[locale]/(site)/contact/components/contact-form.tsx
@@ -12,7 +12,8 @@ import {
   CONTACT_REQUEST_TYPES,
   type ContactRequestType,
 } from "../constants";
-import { initialState, sendContactMessage } from "../server/send-message";
+import type { ContactFormState } from "../server/send-message";
+import { sendContactMessage } from "../server/send-message";
 import { RequestTypeSelector } from "./request-type-selector";
 
 type FieldName = "name" | "company" | "email";
@@ -29,9 +30,20 @@ type FieldConfig = {
 const fieldClassName =
   "w-full rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:border-white/40 transition disabled:cursor-not-allowed disabled:opacity-60";
 
-export function ContactForm() {
+interface ContactFormProps {
+  locale: string;
+}
+
+const CONTACT_FORM_INITIAL_STATE: ContactFormState = {
+  status: "idle",
+};
+
+export function ContactForm({ locale }: ContactFormProps) {
   const t = useTranslations("Contact.Form");
-  const [state, formAction] = useFormState(sendContactMessage, initialState);
+  const [state, formAction] = useFormState(
+    sendContactMessage,
+    CONTACT_FORM_INITIAL_STATE,
+  );
   const formRef = useRef<HTMLFormElement>(null);
   const [requestType, setRequestType] = useState<ContactRequestType>(
     CONTACT_REQUEST_TYPES[0].value,
@@ -74,6 +86,7 @@ export function ContactForm() {
       label: t("fields.email.label"),
       placeholder: t("fields.email.placeholder"),
       autoComplete: "email",
+      required: true,
     },
   ];
 
@@ -138,9 +151,14 @@ export function ContactForm() {
           error={state.fieldErrors?.requestType}
         />
 
+        <input type="hidden" name="locale" value={locale} />
+
         <div className="grid gap-4 sm:grid-cols-2">
           {fields.map(({ name, label, placeholder, type = "text", autoComplete, required }) => (
-            <div key={name} className="space-y-2">
+            <div
+              key={name}
+              className={cn("space-y-2", name === "email" ? "sm:col-span-2" : undefined)}
+            >
               <label className="text-xs font-medium uppercase tracking-[0.2em] text-white/60" htmlFor={name}>
                 {label}
                 {required ? <span className="ml-1 text-white/40">*</span> : null}

--- a/apps/www/app/[locale]/(site)/contact/constants.ts
+++ b/apps/www/app/[locale]/(site)/contact/constants.ts
@@ -1,23 +1,23 @@
 export const CONTACT_REQUEST_TYPES = [
   {
-    value: "strategy",
-    translationKey: "strategy",
-    emailLabel: "AI strategy sprint",
+    value: "general",
+    translationKey: "general",
+    emailLabel: "General questions",
   },
   {
-    value: "automation",
-    translationKey: "automation",
-    emailLabel: "Automation & efficiency audit",
+    value: "solutions",
+    translationKey: "solutions",
+    emailLabel: "Solution inquiries",
   },
   {
-    value: "integration",
-    translationKey: "integration",
-    emailLabel: "Custom AI integration",
+    value: "aiHelp",
+    translationKey: "aiHelp",
+    emailLabel: "Help with AI",
   },
   {
-    value: "training",
-    translationKey: "training",
-    emailLabel: "Executive enablement & training",
+    value: "other",
+    translationKey: "other",
+    emailLabel: "Other",
   },
 ] as const;
 

--- a/apps/www/app/[locale]/(site)/contact/page.tsx
+++ b/apps/www/app/[locale]/(site)/contact/page.tsx
@@ -119,7 +119,7 @@ export default async function ContactPage({ params }: PageProps) {
             </FadeIn>
           </FadeInStagger>
           <FadeIn className="lg:translate-y-0">
-            <ContactForm />
+            <ContactForm locale={locale} />
           </FadeIn>
         </div>
       </Container>

--- a/apps/www/app/[locale]/(site)/contact/server/send-message.ts
+++ b/apps/www/app/[locale]/(site)/contact/server/send-message.ts
@@ -7,6 +7,10 @@ import {
   CONTACT_REQUEST_TYPES,
   type ContactRequestType,
 } from "../constants";
+import { db } from "@/lib/db/client";
+import { isUndefinedTableError } from "@/lib/db/errors";
+import { contactMessages } from "@/lib/db/schema";
+import { locales } from "@/i18n/routing";
 
 const REQUEST_TYPE_VALUES = CONTACT_REQUEST_TYPES.map((option) => option.value) as [
   ContactRequestType,
@@ -25,10 +29,9 @@ const contactSchema = z.object({
     .max(120, { message: "Company name must be under 120 characters" })
     .optional(),
   email: z
-    .string()
+    .string({ required_error: "Email is required" })
     .trim()
-    .email({ message: "Email must be valid" })
-    .optional(),
+    .email({ message: "Email must be valid" }),
   requestType: z.enum(REQUEST_TYPE_VALUES, {
     errorMap: () => ({ message: "Select a request type" }),
   }),
@@ -37,16 +40,15 @@ const contactSchema = z.object({
     .trim()
     .min(20, { message: "Description must be at least 20 characters" })
     .max(2000, { message: "Description must be under 2000 characters" }),
+  locale: z.enum(locales, {
+    errorMap: () => ({ message: "Locale is required" }),
+  }),
 });
 
 export type ContactFormState = {
   status: "idle" | "success" | "error";
   message?: string;
   fieldErrors?: Partial<Record<keyof z.infer<typeof contactSchema>, string>>;
-};
-
-export const initialState: ContactFormState = {
-  status: "idle",
 };
 
 export async function sendContactMessage(
@@ -58,6 +60,7 @@ export async function sendContactMessage(
   const rawEmail = formData.get("email");
   const rawRequestType = formData.get("requestType");
   const rawDescription = formData.get("description");
+  const rawLocale = formData.get("locale");
 
   const parsed = contactSchema.safeParse({
     name: typeof rawName === "string" ? rawName : "",
@@ -65,15 +68,13 @@ export async function sendContactMessage(
       typeof rawCompany === "string" && rawCompany.trim().length > 0
         ? rawCompany
         : undefined,
-    email:
-      typeof rawEmail === "string" && rawEmail.trim().length > 0
-        ? rawEmail
-        : undefined,
+    email: typeof rawEmail === "string" ? rawEmail : "",
     requestType:
       typeof rawRequestType === "string"
         ? (rawRequestType as ContactRequestType)
         : undefined,
     description: typeof rawDescription === "string" ? rawDescription : "",
+    locale: typeof rawLocale === "string" ? rawLocale : undefined,
   });
 
   if (!parsed.success) {
@@ -93,6 +94,31 @@ export async function sendContactMessage(
   }
 
   const data = parsed.data;
+
+  try {
+    await db.insert(contactMessages).values({
+      name: data.name,
+      company: data.company ?? null,
+      email: data.email,
+      requestType: data.requestType,
+      description: data.description,
+      locale: data.locale,
+    });
+  } catch (error) {
+    if (isUndefinedTableError(error)) {
+      console.warn(
+        "Contact form submission could not persist message because the contact_messages table is missing. Continuing with notifications.",
+      );
+    } else {
+      console.error("Contact form submission failed while recording message:", error);
+      return {
+        status: "error",
+        message:
+          "We couldn't record your message right now. Please try again or email info@transformai.nl directly.",
+      } satisfies ContactFormState;
+    }
+  }
+
   const resendApiKey = process.env.RESEND_API_KEY;
   const fromEmail = process.env.CONTACT_FROM_EMAIL ?? "TransformAI <info@transformai.nl>";
   const forwardTo = process.env.CONTACT_FORWARD_TO;
@@ -119,7 +145,8 @@ const emailBody = [
     `Name: ${data.name}`,
     data.company ? `Company: ${data.company}` : null,
     `Request type: ${requestLabel}`,
-    data.email ? `Contact email: ${data.email}` : "Contact email: not provided",
+    `Contact email: ${data.email}`,
+    `Locale: ${data.locale}`,
     "",
     "Request description:",
     data.description,
@@ -142,7 +169,7 @@ const emailBody = [
             )}</p>`,
         )
         .join(""),
-      reply_to: data.email ?? undefined,
+      reply_to: data.email,
       headers: {
         "X-TransformAI-Request-Type": data.requestType,
       },
@@ -154,6 +181,62 @@ const emailBody = [
       message:
         "Something went wrong while sending your message. Please try again or email info@transformai.nl directly.",
     } satisfies ContactFormState;
+  }
+
+  const discordWebhook = process.env.CONTACT_DISCORD_WEBHOOK;
+  if (discordWebhook) {
+    const truncate = (value: string, max: number) =>
+      value.length > max ? `${value.slice(0, max - 1)}…` : value;
+
+    const discordPayload = {
+      username: "TransformAI Contact",
+      embeds: [
+        {
+          title: `New contact message – ${requestLabel}`,
+          color: 0x2563eb,
+          fields: [
+            { name: "Name", value: data.name, inline: true },
+            { name: "Email", value: data.email, inline: true },
+            {
+              name: "Company",
+              value: data.company?.trim() ? data.company : "–",
+              inline: true,
+            },
+            {
+              name: "Request type",
+              value: requestLabel,
+              inline: true,
+            },
+            { name: "Locale", value: data.locale, inline: true },
+            {
+              name: "Message",
+              value: truncate(data.description, 1024) || "(empty)",
+            },
+          ],
+          timestamp: new Date().toISOString(),
+        },
+      ],
+      allowed_mentions: { parse: [] as string[] },
+    };
+
+    try {
+      const response = await fetch(discordWebhook, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(discordPayload),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error(
+          "Contact form submission sent email but Discord webhook responded with status",
+          response.status,
+          errorText,
+        );
+      }
+    } catch (error) {
+      console.error("Contact form submission failed while notifying Discord:", error);
+    }
   }
 
   return {

--- a/apps/www/app/[locale]/(site)/dashboard/inbox/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/inbox/page.tsx
@@ -1,0 +1,165 @@
+import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { desc } from "drizzle-orm";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CONTACT_REQUEST_TYPES } from "@/app/[locale]/(site)/contact/constants";
+import { getAuthSession } from "@/lib/auth";
+import { db } from "@/lib/db/client";
+import { isUndefinedTableError } from "@/lib/db/errors";
+import { contactMessages } from "@/lib/db/schema";
+import { formatDateWithZone } from "@/lib/date";
+import { MEETING_TIME_ZONE } from "@/lib/meetings/constants";
+
+type ContactMessageRow = typeof contactMessages.$inferSelect;
+
+interface PageProps {
+  params: {
+    locale: string;
+  };
+}
+
+export default async function DashboardInboxPage({ params }: PageProps) {
+  const { locale } = params;
+  const session = await getAuthSession();
+
+  if (session?.user?.role !== "staff") {
+    redirect(`/${locale}/newsupdates`);
+  }
+
+  const t = await getTranslations({ locale, namespace: "DashboardInbox" });
+  const contactT = await getTranslations({ locale, namespace: "Contact" });
+  let messages: ContactMessageRow[] = [];
+
+  try {
+    messages = await db
+      .select({
+        id: contactMessages.id,
+        name: contactMessages.name,
+        company: contactMessages.company,
+        email: contactMessages.email,
+        requestType: contactMessages.requestType,
+        description: contactMessages.description,
+        locale: contactMessages.locale,
+        createdAt: contactMessages.createdAt,
+      })
+      .from(contactMessages)
+      .orderBy(desc(contactMessages.createdAt))
+      .limit(100);
+  } catch (error) {
+    if (isUndefinedTableError(error)) {
+      console.warn(
+        "Dashboard inbox attempted to load contact_messages before the table existed. Returning an empty inbox.",
+      );
+    } else {
+      throw error;
+    }
+  }
+
+  const requestTypeLabels = Object.fromEntries(
+    CONTACT_REQUEST_TYPES.map((type) => [
+      type.value,
+      contactT(`Form.requestTypes.${type.translationKey}.title`),
+    ]),
+  ) as Record<string, string>;
+
+  return (
+    <div className="bg-black py-12 sm:py-16">
+      <div className="container max-w-5xl space-y-8">
+        <header className="space-y-3">
+          <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+            {t("title")}
+          </h1>
+          <p className="text-sm text-white/60 sm:text-base">{t("subtitle")}</p>
+          <p className="text-xs font-medium uppercase tracking-[0.3em] text-white/50">
+            {t("currentUser", { email: session.user.email ?? "" })}
+          </p>
+        </header>
+
+        {messages.length === 0 ? (
+          <p className="rounded-2xl border border-white/10 bg-white/[0.04] p-6 text-sm text-white/60">
+            {t("empty")}
+          </p>
+        ) : (
+          <div className="space-y-4">
+            {messages.map((message) => {
+              const requestTypeLabel =
+                requestTypeLabels[message.requestType] ?? message.requestType;
+              const receivedLabel = formatDateWithZone(
+                message.createdAt,
+                {
+                  dateStyle: "medium",
+                  timeStyle: "short",
+                },
+                locale,
+                MEETING_TIME_ZONE,
+              );
+
+              return (
+                <Card
+                  key={message.id}
+                  className="border-white/10 bg-white/[0.04] text-white shadow-[0_24px_80px_rgba(15,23,42,0.45)] backdrop-blur"
+                >
+                  <CardHeader className="space-y-2 border-b border-white/10 bg-white/[0.02]">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-baseline sm:justify-between">
+                      <CardTitle className="text-2xl font-semibold text-white">
+                        {message.name}
+                      </CardTitle>
+                      <span className="text-xs font-medium uppercase tracking-[0.28em] text-white/50">
+                        {receivedLabel}
+                      </span>
+                    </div>
+                    <p className="text-sm text-white/70">{requestTypeLabel}</p>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <dl className="grid gap-3 text-sm text-white/70 sm:grid-cols-2">
+                      <div className="space-y-1">
+                        <dt className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+                          {t("table.email")}
+                        </dt>
+                        <dd>
+                          <a
+                            href={`mailto:${message.email}`}
+                            className="text-white underline-offset-2 transition hover:text-white/80 hover:underline"
+                          >
+                            {message.email}
+                          </a>
+                        </dd>
+                      </div>
+                      <div className="space-y-1">
+                        <dt className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+                          {t("table.company")}
+                        </dt>
+                        <dd>{message.company?.trim() || "–"}</dd>
+                      </div>
+                      <div className="space-y-1">
+                        <dt className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+                          {t("table.requestType")}
+                        </dt>
+                        <dd>{requestTypeLabel}</dd>
+                      </div>
+                      <div className="space-y-1">
+                        <dt className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+                          {t("table.locale")}
+                        </dt>
+                        <dd className="uppercase">{message.locale}</dd>
+                      </div>
+                      <div className="space-y-1 sm:col-span-2">
+                        <dt className="text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+                          {t("table.message")}
+                        </dt>
+                        <dd className="whitespace-pre-wrap break-words text-sm text-white/80">
+                          {message.description}
+                        </dd>
+                      </div>
+                    </dl>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/www/app/[locale]/(site)/dashboard/page.tsx
+++ b/apps/www/app/[locale]/(site)/dashboard/page.tsx
@@ -97,6 +97,13 @@ export default async function DashboardPage({ params }: PageProps) {
       description: t("sections.hoursSaved.description"),
     },
     {
+      key: "inbox" as const,
+      href: `/${locale}/dashboard/inbox`,
+      eyebrow: t("sections.inbox.eyebrow"),
+      title: t("sections.inbox.title"),
+      description: t("sections.inbox.description"),
+    },
+    {
       key: "planning" as const,
       href: `/${locale}/dashboard/planning`,
       eyebrow: t("sections.planning.eyebrow"),

--- a/apps/www/components/navbar/navigation.tsx
+++ b/apps/www/components/navbar/navigation.tsx
@@ -84,8 +84,13 @@ export function Navigation() {
   const isStaffOverviewView = normalizedPathname === "/dashboard";
   const isStaffPlanningView = normalizedPathname.startsWith("/dashboard/planning");
   const isStaffHoursSavedView = normalizedPathname.startsWith("/dashboard/hours-saved");
+  const isStaffInboxView = normalizedPathname.startsWith("/dashboard/inbox");
   const isStaffView =
-    isStaffOverviewView || isStaffPlanningView || isStaffHoursSavedView || normalizedPathname.startsWith("/dashboard/");
+    isStaffOverviewView ||
+    isStaffPlanningView ||
+    isStaffHoursSavedView ||
+    isStaffInboxView ||
+    normalizedPathname.startsWith("/dashboard/");
   const isLoggedInView = isClientView || isStaffView;
   const settledLogoScale = 0.68;
   const initialLogoScale = isHome ? 1 : 0.74;
@@ -108,6 +113,12 @@ export function Navigation() {
             href: "/dashboard",
             label: t("loggedIn.overview"),
             current: isStaffOverviewView,
+          },
+          {
+            key: "inbox",
+            href: "/dashboard/inbox",
+            label: t("loggedIn.inbox"),
+            current: isStaffInboxView,
           },
           {
             key: "hoursSaved",

--- a/apps/www/drizzle/0005_contact_messages.sql
+++ b/apps/www/drizzle/0005_contact_messages.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "contact_messages" (
+  "id" text PRIMARY KEY NOT NULL,
+  "name" text NOT NULL,
+  "company" text,
+  "email" text NOT NULL,
+  "request_type" text NOT NULL,
+  "description" text NOT NULL,
+  "locale" text NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "contact_messages_created_at_idx" ON "contact_messages" ("created_at");
+CREATE INDEX IF NOT EXISTS "contact_messages_request_type_idx" ON "contact_messages" ("request_type");

--- a/apps/www/lib/db/errors.ts
+++ b/apps/www/lib/db/errors.ts
@@ -1,0 +1,14 @@
+export const POSTGRES_UNDEFINED_TABLE_CODE = "42P01";
+
+type PgLikeError = {
+  code?: unknown;
+};
+
+export function isUndefinedTableError(error: unknown): error is PgLikeError {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const code = (error as PgLikeError).code;
+  return typeof code === "string" && code === POSTGRES_UNDEFINED_TABLE_CODE;
+}

--- a/apps/www/lib/db/schema.ts
+++ b/apps/www/lib/db/schema.ts
@@ -146,6 +146,30 @@ export const meetingBookings = pgTable(
   }),
 );
 
+export const contactMessages = pgTable(
+  "contact_messages",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    name: text("name").notNull(),
+    company: text("company"),
+    email: text("email").notNull(),
+    requestType: text("request_type").notNull(),
+    description: text("description").notNull(),
+    locale: text("locale").notNull(),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => ({
+    createdAtIdx: index("contact_messages_created_at_idx").on(table.createdAt),
+    requestTypeIdx: index("contact_messages_request_type_idx").on(
+      table.requestType,
+    ),
+  }),
+);
+
 export const visitorSessions = pgTable(
   "visitor_sessions",
   {

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -27,6 +27,7 @@
       "exit": "Exit",
       "messages": "Messages",
       "overview": "Overview",
+      "inbox": "Inbox",
       "planning": "Planning",
       "hoursSaved": "Hours saved",
       "dashboard": "Dashboard",
@@ -219,7 +220,7 @@
       "eyebrow": "Let’s talk",
       "title": "Contact TransformAI",
       "body": "Share your challenge and we’ll respond with a tailored AI roadmap within two business days.",
-      "emailNotice": "Prefer email? Reach out at info@transformai.nl — this is our only official inbox."
+      "emailNotice": "Prefer email? Email info@transformai.nl directly."
     },
     "Highlights": {
       "label": "Why leaders reach out",
@@ -253,21 +254,21 @@
         "helper": "Choose the option that best matches your focus."
       },
       "requestTypes": {
-        "strategy": {
-          "title": "AI strategy sprint",
-          "description": "Align leadership around outcomes, KPIs, and the first 90-day roadmap."
+        "general": {
+          "title": "General questions",
+          "description": "Questions about the company."
         },
-        "automation": {
-          "title": "Automation opportunity audit",
-          "description": "Spot high-impact automations across teams and model the efficiency gains."
+        "solutions": {
+          "title": "Solution inquiries",
+          "description": "Any questions about the solutions we provide."
         },
-        "integration": {
-          "title": "Custom AI integration",
-          "description": "Design bespoke copilots, agents, or data products that plug into your stack."
+        "aiHelp": {
+          "title": "Help with AI",
+          "description": "Questions about AI in your organisation (complimentary)."
         },
-        "training": {
-          "title": "Executive enablement & training",
-          "description": "Upskill leaders and teams so AI adoption sticks across the organisation."
+        "other": {
+          "title": "Other",
+          "description": "Anything that doesn’t fit the other categories."
         }
       },
       "fields": {
@@ -280,7 +281,7 @@
           "placeholder": "Company or team name"
         },
         "email": {
-          "label": "Contact email (optional)",
+          "label": "Contact email (we'll reply here)",
           "placeholder": "you@company.com"
         },
         "description": {
@@ -1715,6 +1716,11 @@
         "title": "Coordinate the meeting agenda",
         "description": "Review availability, assign colleagues, and publish upcoming TransformAI strategy sessions."
       },
+      "inbox": {
+        "eyebrow": "Inbox",
+        "title": "Review incoming contact messages",
+        "description": "Monitor every enquiry from the contact page in one place."
+      },
       "outreach": {
         "eyebrow": "Outreach",
         "title": "Launch personalised landing pages",
@@ -1799,6 +1805,20 @@
         "outreach": "Coordinate with delivery leads to share the new AI maturity playbook with their accounts.",
         "briefings": "Prepare January leadership briefings showcasing ROI metrics from automation pilots."
       }
+    }
+  },
+  "DashboardInbox": {
+    "title": "Contact inbox",
+    "subtitle": "Review every message submitted through the TransformAI contact form.",
+    "currentUser": "Signed in as {email}",
+    "empty": "No contact messages yet. New enquiries will appear here instantly.",
+    "table": {
+      "received": "Received",
+      "requestType": "Request type",
+      "email": "Email",
+      "company": "Company",
+      "locale": "Locale",
+      "message": "Message"
     }
   },
   "OutreachPage": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -27,6 +27,7 @@
       "exit": "Afsluiten",
       "messages": "Berichten",
       "overview": "Overzicht",
+      "inbox": "Inbox",
       "planning": "Planning",
       "hoursSaved": "Uren bespaard",
       "dashboard": "Dashboard",
@@ -219,7 +220,7 @@
       "eyebrow": "Laten we praten",
       "title": "Neem contact op met TransformAI",
       "body": "Deel je uitdaging en wij leveren binnen twee werkdagen een op maat gemaakt AI-plan.",
-      "emailNotice": "Liever mailen? Gebruik info@transformai.nl — dit is ons enige officiële adres."
+      "emailNotice": "Liever mailen? Mail direct naar info@transformai.nl."
     },
     "Highlights": {
       "label": "Waarom leiders ons benaderen",
@@ -253,21 +254,21 @@
         "helper": "Kies de optie die het beste bij je vraag past."
       },
       "requestTypes": {
-        "strategy": {
-          "title": "AI-strategiesprint",
-          "description": "Breng leiders op één lijn over resultaten, KPI's en de eerste 90-dagen-roadmap."
+        "general": {
+          "title": "Algemene vragen",
+          "description": "Vragen met betrekking tot het bedrijf."
         },
-        "automation": {
-          "title": "Automatiseringsscan",
-          "description": "Ontdek automatiseringskansen in teams en kwantificeer de efficiëntiewinst."
+        "solutions": {
+          "title": "Vragen over oplossingen",
+          "description": "Alle vragen met betrekking tot de oplossingen die wij aanbieden."
         },
-        "integration": {
-          "title": "Maatwerk AI-integratie",
-          "description": "Ontwerp copilots, agents of dataproducten die aansluiten op jullie stack."
+        "aiHelp": {
+          "title": "Hulp met AI",
+          "description": "Voor vragen met betrekking tot AI in uw bedrijf (kostenloos)."
         },
-        "training": {
-          "title": "Executive enablement & training",
-          "description": "Maak leiders en teams vaardig zodat AI-adoptie organisatiebreed blijft plakken."
+        "other": {
+          "title": "Overige",
+          "description": "Voor alle vragen die niet in de andere categorieën vallen."
         }
       },
       "fields": {
@@ -280,7 +281,7 @@
           "placeholder": "Bedrijfs- of teamnaam"
         },
         "email": {
-          "label": "Contact e-mail (optioneel)",
+          "label": "Contact e-mail (Hier zullen wij u terug op berichten)",
           "placeholder": "jij@bedrijf.nl"
         },
         "description": {
@@ -1672,6 +1673,11 @@
         "title": "Stem de agenda af",
         "description": "Bekijk de beschikbaarheid, wijs collega’s toe en publiceer aankomende TransformAI-strategiesessies."
       },
+      "inbox": {
+        "eyebrow": "Inbox",
+        "title": "Bekijk inkomende contactberichten",
+        "description": "Houd alle aanvragen van de contactpagina centraal bij."
+      },
       "outreach": {
         "eyebrow": "Outreach",
         "title": "Activeer gepersonaliseerde landingspagina’s",
@@ -1756,6 +1762,20 @@
         "outreach": "Stem met delivery leads af om het nieuwe AI-maturiteitsplaybook bij hun accounts te delen.",
         "briefings": "Bereid leiderschapsbriefings voor januari voor met ROI-cijfers uit de automatiseringspilots."
       }
+    }
+  },
+  "DashboardInbox": {
+    "title": "Contact-inbox",
+    "subtitle": "Bekijk elk bericht dat via het TransformAI-contactformulier is verzonden.",
+    "currentUser": "Ingelogd als {email}",
+    "empty": "Er zijn nog geen contactberichten. Nieuwe aanvragen verschijnen hier direct.",
+    "table": {
+      "received": "Ontvangen",
+      "requestType": "Aanvraagtype",
+      "email": "E-mail",
+      "company": "Bedrijf",
+      "locale": "Taal",
+      "message": "Bericht"
     }
   },
   "OutreachPage": {


### PR DESCRIPTION
## Plan
- Add a Postgres error helper so we can detect when the new contact messages table is unavailable.
- Allow the contact form server action to continue sending notifications even if persistence fails because the table is missing.
- Guard the staff inbox query so it treats a missing table as an empty inbox and document the fix.

## Summary
- Introduced a small database error helper that recognises the Postgres undefined-table error code.
- Updated the contact form server action to log and continue when the contact_messages table is missing while still failing for other database errors.
- Wrapped the staff inbox query in a safe guard so the page still loads even when the table has not been migrated yet, and logged the behaviour in WRITE_HERE/FIXES.

## Testing
- `pnpm --filter www run lint` *(fails: missing `next-intl` dependency in this environment)*
- `pnpm --filter www run typecheck` *(cancelled after hanging while building content collections)*

------
https://chatgpt.com/codex/tasks/task_e_6909cbd0e130832ab85a91f95730c0e0