### PR TITLE
Fix assistant OpenAI responses integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Example environment variables for the mini chat
 TRANSFORMAI_ASSISTANT_KEY=
+OPENAI_API_KEY=
 CONTACT_DISCORD_WEBHOOK=https://discord.com/api/webhooks/1435203740100726881/sBJk5EK81sQ1DL6UkVZ4JMGqOf2uEnpFBo8DPrU0X5UbRtFTowJHqQAK_7rgPG4pwtR3

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Follow our [contributing guide](https://engineering.unkey.com/contributing)
 
 You can find the instructions for each project in their respective directories.
 
-Before running the marketing site with the new assistant, copy `.env.example` to `.env.local` and set `TRANSFORMAI_ASSISTANT_KEY`.
+Before running the marketing site with the new assistant, copy `.env.example` to `.env.local` and set `TRANSFORMAI_ASSISTANT_KEY` and `OPENAI_API_KEY`.

--- a/WRITE_HERE/FIXES/2025-12-03T1930--repair-assistant-openai-response.md
+++ b/WRITE_HERE/FIXES/2025-12-03T1930--repair-assistant-openai-response.md
@@ -1,0 +1,6 @@
+# Restore assistant replies through OpenAI responses API
+
+- **What:** Reworked the `/api/assistant` route to call OpenAI's `responses` endpoint with the unified system prompt, handle the new output schema, and align the fallback copy with Dutch/English locales.
+- **Why:** The previous integration attempted to use the deprecated chat completions path with `gpt-5-mini`, which returned HTTP 400 errors and left visitors with the fallback autoresponder.
+- **Files:** `apps/www/app/api/assistant/route.ts`.
+- **Follow-ups:** Consider wiring tool calls (e.g., direct meeting booking) once we confirm the live API contract and available automations.

--- a/WRITE_HERE/UPDATES/2025-11-04T1451--assistant-openai-integration.md
+++ b/WRITE_HERE/UPDATES/2025-11-04T1451--assistant-openai-integration.md
@@ -1,0 +1,6 @@
+# OpenAI-backed assistant with unified context
+
+- **What:** Swapped the assistant API to use OpenAI's `gpt-5-mini` with a shared TransformAI context, forwarded locale metadata from chat widgets, and exposed the required `OPENAI_API_KEY` env variable. Updated docs and fallback copy accordingly.
+- **Why:** Ensure the on-site chatbot answers with accurate company guidance, can recommend relevant pages, and supports meeting scheduling without relying on the old upstream placeholder.
+- **Files:** `.env.example`, `README.md`, `apps/www/app/api/assistant/route.ts`, `apps/www/components/ask/StickyChat.tsx`, `apps/www/components/ask/PricingChat.tsx`.
+- **Follow-ups:** Consider extending tool support so the assistant can surface live meeting availability or pre-fill scheduling requests automatically.

--- a/apps/www/app/api/assistant/route.ts
+++ b/apps/www/app/api/assistant/route.ts
@@ -8,9 +8,33 @@ const messageSchema = z.object({
 
 const requestSchema = z.object({
   messages: z.array(messageSchema).min(1),
+  locale: z.string().min(2).max(16).optional(),
 });
 
 type ConversationMessage = z.infer<typeof messageSchema>;
+type OpenAIResponse = {
+  id?: string;
+  output?: Array<
+    | null
+    | {
+        id?: string;
+        type?: string;
+        role?: string;
+        content?: Array<
+          | null
+          | {
+              type?: string;
+              text?: string;
+            }
+        >;
+      }
+  >;
+  error?: {
+    message?: string;
+    type?: string;
+    code?: string | number;
+  };
+};
 
 type Bucket = {
   tokens: number;
@@ -26,6 +50,12 @@ export async function POST(request: NextRequest) {
   if (!apiKey) {
     console.error("TRANSFORMAI_ASSISTANT_KEY is not configured");
     return NextResponse.json({ error: "Assistant unavailable" }, { status: 401 });
+  }
+
+  const openAiKey = process.env.OPENAI_API_KEY;
+  if (!openAiKey) {
+    console.error("OPENAI_API_KEY is not configured");
+    return NextResponse.json({ error: "Assistant unavailable" }, { status: 500 });
   }
 
   const clientId = getClientIdentifier(request);
@@ -46,35 +76,53 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
   }
 
-  const { messages } = parseResult.data;
+  const { messages, locale } = parseResult.data;
+  const localeHint = sanitizeLocale(locale);
+  const systemPrompt = buildSystemPrompt(localeHint);
+  const openAiMessages = [
+    { role: "system" as const, content: systemPrompt },
+    ...messages.map(({ role, content }) => ({ role, content })),
+  ];
 
   try {
-    const response = await fetch("https://api.transformai.ai/assistant", {
+    const response = await fetch("https://api.openai.com/v1/responses", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
+        Authorization: `Bearer ${openAiKey}`,
       },
-      body: JSON.stringify({ messages }),
+      body: JSON.stringify({
+        model: "gpt-5-mini",
+        input: openAiMessages,
+        temperature: 0.3,
+        top_p: 0.9,
+        max_output_tokens: 600,
+      }),
       cache: "no-store",
     });
 
     if (response.ok) {
-      const data = (await response.json().catch(() => ({}))) as { message?: string; choices?: Array<{ message?: { content?: string } }>; };
+      const data = (await response.json().catch(() => ({}))) as OpenAIResponse;
       const modelMessage = getMessageFromResponse(data);
       if (modelMessage) {
         return NextResponse.json({ message: modelMessage });
       }
     } else {
-      const errorResponse = await response.json().catch(() => null);
-      const reason = typeof errorResponse?.error === "string" ? errorResponse.error : response.statusText;
-      console.error("Assistant upstream responded with error", reason);
+      const errorResponse = (await response.json().catch(() => null)) as OpenAIResponse | null;
+      const reason =
+        typeof errorResponse?.error?.message === "string"
+          ? errorResponse.error.message
+          : response.statusText;
+      console.error("OpenAI response API returned an error", reason, {
+        code: errorResponse?.error?.code,
+        type: errorResponse?.error?.type,
+      });
     }
   } catch (error) {
-    console.error("Assistant upstream request failed", error);
+    console.error("OpenAI response API request failed", error);
   }
 
-  const fallback = buildFallbackMessage(messages);
+  const fallback = buildFallbackMessage(messages, localeHint);
   return NextResponse.json({ message: fallback });
 }
 
@@ -115,24 +163,111 @@ function getClientIdentifier(request: NextRequest) {
   return "anonymous";
 }
 
-function getMessageFromResponse(data: {
-  message?: string;
-  choices?: Array<{ message?: { content?: string } }>;
-}) {
-  if (data?.message && typeof data.message === "string") {
-    return data.message.trim();
+function getMessageFromResponse(data: OpenAIResponse) {
+  if (!data?.output?.length) {
+    return "";
   }
-  const choice = data?.choices?.[0]?.message?.content;
-  if (typeof choice === "string") {
-    return choice.trim();
+
+  for (const block of data.output) {
+    if (!block || block.type !== "message" || block.role !== "assistant" || !block.content?.length) {
+      continue;
+    }
+
+    const text = block.content
+      .map((entry) => (entry?.type === "output_text" && typeof entry.text === "string" ? entry.text : ""))
+      .filter(Boolean)
+      .join("\n")
+      .trim();
+
+    if (text) {
+      return text;
+    }
   }
+
   return "";
 }
 
-function buildFallbackMessage(messages: ConversationMessage[]) {
-  const lastUserMessage = [...messages].reverse().find((message) => message.role === "user");
-  if (!lastUserMessage) {
-    return "Thanks for reaching out to TransformAI. We'll reply with tailored guidance shortly.";
+function sanitizeLocale(locale?: string | null) {
+  if (!locale) {
+    return undefined;
   }
-  return `Thanks for your question about "${lastUserMessage.content}". A TransformAI strategist will follow up with tailored guidance shortly.`;
+  const trimmed = locale.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const normalized = trimmed.toLowerCase().replace(/[^a-z0-9-]/g, "");
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized.slice(0, 16);
+}
+
+function buildSystemPrompt(locale?: string) {
+  const normalizedLocale = locale ?? "en";
+  const localeInstruction = locale
+    ? `Use relative URLs with the ${normalizedLocale} locale segment (for example, /${normalizedLocale}/about).`
+    : "Use English URLs (starting with /en/...) unless the visitor requests Dutch; if you are unsure, ask which language they prefer.";
+  const languageInstruction = !locale
+    ? "Default to English unless the visitor clearly prefers Dutch; mirror their language once you know it."
+    : normalizedLocale === "nl"
+      ? "Respond in Dutch by default unless the visitor explicitly asks for English."
+      : "Respond in English by default but feel free to switch to Dutch if the visitor uses it.";
+
+  return [
+    "You are the TransformAI Assistant, the friendly but direct concierge for TransformAI's marketing site.",
+    "You only answer questions about TransformAI's services, platform, team, and resources. If someone asks about anything else, politely explain that you can only discuss TransformAI.",
+    "",
+    "Background:",
+    "- TransformAI is an AI transformation partner based in Amsterdam, Netherlands. The company was founded in 2025 and rebranded from StaccatoAI to reflect its move from building standalone products to guiding full-scale AI transformations.",
+    "- We work as a long-term partner rather than a short-term consultant. Every engagement is co-created with the client's teams so AI becomes embedded across the organisation, whether they are just starting or scaling advanced automation.",
+    "- The homepage highlights more than 100,000 hours saved for partners, showcases active projects and partner logos, and gives direct ways to chat, contact us, or schedule time.",
+    "- A TransformAI platform (a central operating system for assistants, workflows, and guardrails) is in private beta. Visitors can request access via the analytics section on the homepage.",
+    "",
+    "Offerings you can reference:",
+    "- Education modules on the pricing page: the Basic education module (€800 per 2-hour in-person session) builds AI confidence across roles, and the Advanced education module (€1,100 per 2-hour workshop) co-develops new AI products with experienced teams.",
+    "- AISEO package (AIEO) beta to improve visibility inside AI-powered discovery channels.",
+    "- AI Situation Overview (€799 for a two-hour strategy sprint) benchmarks a company's AI readiness and delivers next-step recommendations.",
+    "- Transformation programmes (Foundation, Integrated, Intrinsic) described on the pricing page cover everything from the first AI steps to fully integrated company-wide adoption.",
+    "- Case studies and research—including the education platform, HR researcher, email responder, and automation playbooks—are published in the blog and highlighted projects.",
+    "",
+    "Key resources to guide visitors:",
+    `- Home: /${normalizedLocale} for the overall story, hours-saved ticker, and partner highlights.`,
+    `- About: /${normalizedLocale}/about for the founder story, team bios (showing 10× productivity vs. AI-enabled peers and 52× vs. non-AI roles), values, and FAQs.`,
+    `- Blog: /${normalizedLocale}/blog for articles, research, and case studies about TransformAI's work.`,
+    `- Pricing & solutions: /${normalizedLocale}/pricing for solution overviews, package comparisons, and education modules.`,
+    `- Contact: /${normalizedLocale}/contact for the contact form (TransformAI replies within two business days) with request types for general questions, solution inquiries, AI help, or other topics, plus the direct email info@transformai.nl.`,
+    `- Meeting scheduler: /${normalizedLocale}/meeting to reserve time with the team—bookings go straight to leadership.`,
+    `- Platform beta request form: available from the analytics section on the homepage.`,
+    `- Partner account sign-up: /${normalizedLocale}/create-account (access is limited to TransformAI partners).`,
+    "",
+    "Meeting support:",
+    "- Offer to help schedule meetings proactively. Collect the person's name, company, email, focus area, and timing preferences.",
+    `- When they are ready, share the meeting link (/${normalizedLocale}/meeting) and summarise what they should submit.`,
+    "",
+    "Communication rules:",
+    `- ${languageInstruction}`,
+    `- ${localeInstruction}`,
+    "- Be friendly, clear, and straightforward. Provide direct answers without unnecessary padding.",
+    "- Whenever helpful, point people to the exact page, blog post, or service so they know where to continue.",
+    "- If you do not have the information someone wants, explain the limitation and recommend the best next step (contact form, meeting, or email).",
+    "- Stay strictly within TransformAI's domain; acknowledge the question and decline if it falls outside TransformAI.",
+  ].join("\n");
+}
+
+function buildFallbackMessage(messages: ConversationMessage[], locale?: string) {
+  const lastUserMessage = [...messages].reverse().find((message) => message.role === "user");
+  const isDutch = locale?.startsWith("nl");
+  if (isDutch) {
+    const followUp = "Ons team reageert binnen twee werkdagen.";
+    if (!lastUserMessage) {
+      return `Bedankt voor je bericht aan TransformAI. ${followUp}`;
+    }
+    return `Bedankt voor je vraag over "${lastUserMessage.content}". ${followUp}`;
+  }
+
+  const followUp = "Our team will follow up within two business days.";
+  if (!lastUserMessage) {
+    return `Thanks for reaching out to TransformAI. ${followUp}`;
+  }
+  return `Thanks for your question about "${lastUserMessage.content}". ${followUp}`;
 }

--- a/apps/www/components/ask/PricingChat.tsx
+++ b/apps/www/components/ask/PricingChat.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
@@ -22,6 +22,7 @@ type PricingChatProps = {
 
 export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChange }) => {
   const t = useTranslations("Pricing.Chat");
+  const localeCode = useLocale();
   const locale = useMemo<ChatLocale>(
     () => ({
       ctaLabel: t("cta.label"),
@@ -113,6 +114,7 @@ export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChang
           },
           body: JSON.stringify({
             messages: conversation.map(({ role, content }) => ({ role, content })),
+            locale: localeCode,
           }),
         });
 
@@ -145,7 +147,7 @@ export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChang
         setIsLoading(false);
       }
     },
-    [locale.errorBody],
+    [locale.errorBody, localeCode],
   );
 
   const openChat = useCallback(() => {

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import {
   type CSSProperties,
   useCallback,
@@ -34,6 +34,7 @@ type StickyChatProps = {
 
 export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, boundaryId }) => {
   const t = useTranslations("CodeExamples.chat");
+  const localeCode = useLocale();
   const locale = useMemo<ChatLocale>(
     () => ({
       ctaLabel: t("cta.label"),
@@ -472,6 +473,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
           },
           body: JSON.stringify({
             messages: conversation.map(({ role, content }) => ({ role, content })),
+            locale: localeCode,
           }),
         });
 
@@ -504,7 +506,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
         setIsLoading(false);
       }
     },
-    [locale.errorBody],
+    [locale.errorBody, localeCode],
   );
 
   const handleSend = useCallback(


### PR DESCRIPTION
## Summary
- switch `/api/assistant` to OpenAI's `responses` endpoint, parse the new output schema, and add locale-aware fallbacks
- refine the TransformAI system prompt so Dutch/English handling matches the visitor's locale and increase the output budget
- log the fix in `WRITE_HERE/FIXES` for the assistant outage repair

## Plan
- update the assistant API route to build `responses` payloads and extract assistant output text
- adjust system prompt and fallback helpers to respect the request locale
- capture the change in the FIXES log for visibility

## Testing
- `pnpm --filter www run typecheck` *(fails: repository lacks optional deps like `next-intl`/`drizzle-orm` in this environment)*
- `pnpm --filter www run lint` *(fails: Next lint cannot resolve `next-intl` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690a10e976b4832a85ecdc45d00b5750