### PR TITLE
Enable assistant redirects with locale-aware responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Example environment variables for the mini chat
 TRANSFORMAI_ASSISTANT_KEY=
+OPENAI_API_KEY=
 CONTACT_DISCORD_WEBHOOK=https://discord.com/api/webhooks/1435203740100726881/sBJk5EK81sQ1DL6UkVZ4JMGqOf2uEnpFBo8DPrU0X5UbRtFTowJHqQAK_7rgPG4pwtR3

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Follow our [contributing guide](https://engineering.unkey.com/contributing)
 
 You can find the instructions for each project in their respective directories.
 
-Before running the marketing site with the new assistant, copy `.env.example` to `.env.local` and set `TRANSFORMAI_ASSISTANT_KEY`.
+Before running the marketing site with the new assistant, copy `.env.example` to `.env.local` and set `TRANSFORMAI_ASSISTANT_KEY` and `OPENAI_API_KEY`.

--- a/WRITE_HERE/FIXES/2025-12-03T1930--repair-assistant-openai-response.md
+++ b/WRITE_HERE/FIXES/2025-12-03T1930--repair-assistant-openai-response.md
@@ -1,0 +1,6 @@
+# Restore assistant replies through OpenAI responses API
+
+- **What:** Reworked the `/api/assistant` route to call OpenAI's `responses` endpoint with the unified system prompt, handle the new output schema, and align the fallback copy with Dutch/English locales.
+- **Why:** The previous integration attempted to use the deprecated chat completions path with `gpt-5-mini`, which returned HTTP 400 errors and left visitors with the fallback autoresponder.
+- **Files:** `apps/www/app/api/assistant/route.ts`.
+- **Follow-ups:** Consider wiring tool calls (e.g., direct meeting booking) once we confirm the live API contract and available automations.

--- a/WRITE_HERE/FIXES/2025-12-04T1015--stabilize-assistant-response-contract.md
+++ b/WRITE_HERE/FIXES/2025-12-04T1015--stabilize-assistant-response-contract.md
@@ -1,0 +1,6 @@
+# Stabilise assistant response contract
+
+- **What:** Removed unsupported sampling params from the `/api/assistant` OpenAI call, reformatted the payload to the documented responses schema, and moved the network trigger out of React state setters in both chat launchers to avoid duplicate sends.
+- **Why:** `gpt-5-mini` rejects `temperature`/`top_p`, and Strict Mode was invoking the state updater twice which caused the same prompt to be dispatched twice and show duplicate fallback replies.
+- **Files:** `apps/www/app/api/assistant/route.ts`, `apps/www/components/ask/PricingChat.tsx`, `apps/www/components/ask/StickyChat.tsx`.
+- **Follow-ups:** Watch production telemetry to confirm requests stay single-shot before reintroducing optional sampling controls.

--- a/WRITE_HERE/FIXES/2025-12-04T1535--fix-assistant-input-text-types.md
+++ b/WRITE_HERE/FIXES/2025-12-04T1535--fix-assistant-input-text-types.md
@@ -1,0 +1,6 @@
+# Fix assistant input text types
+
+- **What:** Updated the OpenAI Responses payload to label system and user messages as `input_text` and replay assistant history as `output_text`.
+- **Why:** OpenAI rejected the previous `text` message type, causing every assistant request to fall back to the autoresponder.
+- **Files:** `apps/www/app/api/assistant/route.ts`.
+- **Follow-ups:** Monitor production logs for any further schema mismatches from the Responses API updates.

--- a/WRITE_HERE/FIXES/2025-12-04T1805--assistant-redirect-and-language-routing.md
+++ b/WRITE_HERE/FIXES/2025-12-04T1805--assistant-redirect-and-language-routing.md
@@ -1,0 +1,6 @@
+# Assistant redirect and language routing
+
+- **What:** Bumped the OpenAI response budget to 4K tokens, expanded the TransformAI system brief with redirect instructions, parsed structured replies for optional redirect actions, and taught the chat widgets to surface one-click redirects while tracking the visitor's language preference.
+- **Why:** The assistant now needs to confirm and execute page redirections without duplicating submissions while replying consistently in Dutch or English based on the conversation.
+- **Files:** `apps/www/app/api/assistant/route.ts`, `apps/www/components/ask/ChatPanel.tsx`, `apps/www/components/ask/PricingChat.tsx`, `apps/www/components/ask/StickyChat.tsx`, `apps/www/components/ask/types.ts`.
+- **Follow-ups:** Monitor production logs for malformed JSON payloads or redirect URLs so we can tighten the schema if the model drifts.

--- a/WRITE_HERE/UPDATES/2025-11-04T1451--assistant-openai-integration.md
+++ b/WRITE_HERE/UPDATES/2025-11-04T1451--assistant-openai-integration.md
@@ -1,0 +1,6 @@
+# OpenAI-backed assistant with unified context
+
+- **What:** Swapped the assistant API to use OpenAI's `gpt-5-mini` with a shared TransformAI context, forwarded locale metadata from chat widgets, and exposed the required `OPENAI_API_KEY` env variable. Updated docs and fallback copy accordingly.
+- **Why:** Ensure the on-site chatbot answers with accurate company guidance, can recommend relevant pages, and supports meeting scheduling without relying on the old upstream placeholder.
+- **Files:** `.env.example`, `README.md`, `apps/www/app/api/assistant/route.ts`, `apps/www/components/ask/StickyChat.tsx`, `apps/www/components/ask/PricingChat.tsx`.
+- **Follow-ups:** Consider extending tool support so the assistant can surface live meeting availability or pre-fill scheduling requests automatically.

--- a/apps/www/app/api/assistant/route.ts
+++ b/apps/www/app/api/assistant/route.ts
@@ -8,9 +8,46 @@ const messageSchema = z.object({
 
 const requestSchema = z.object({
   messages: z.array(messageSchema).min(1),
+  locale: z.string().min(2).max(16).optional(),
+  language: z.enum(["en", "nl"]).optional(),
+});
+
+const assistantRedirectSchema = z.object({
+  url: z.string().min(1),
+  label: z.string().min(1),
+  confirm: z.string().min(1),
+});
+
+const assistantResponseSchema = z.object({
+  reply: z.string().min(1),
+  language: z.enum(["en", "nl"]).optional(),
+  redirect: assistantRedirectSchema.optional(),
 });
 
 type ConversationMessage = z.infer<typeof messageSchema>;
+type OpenAIResponse = {
+  id?: string;
+  output?: Array<
+    | null
+    | {
+        id?: string;
+        type?: string;
+        role?: string;
+        content?: Array<
+          | null
+          | {
+              type?: string;
+              text?: string;
+            }
+        >;
+      }
+  >;
+  error?: {
+    message?: string;
+    type?: string;
+    code?: string | number;
+  };
+};
 
 type Bucket = {
   tokens: number;
@@ -20,12 +57,19 @@ type Bucket = {
 const RATE_BUCKETS = new Map<string, Bucket>();
 const MAX_TOKENS = 6;
 const REFILL_INTERVAL_MS = 60_000;
+const OUTPUT_TOKEN_LIMIT = 4000;
 
 export async function POST(request: NextRequest) {
   const apiKey = process.env.TRANSFORMAI_ASSISTANT_KEY;
   if (!apiKey) {
     console.error("TRANSFORMAI_ASSISTANT_KEY is not configured");
     return NextResponse.json({ error: "Assistant unavailable" }, { status: 401 });
+  }
+
+  const openAiKey = process.env.OPENAI_API_KEY;
+  if (!openAiKey) {
+    console.error("OPENAI_API_KEY is not configured");
+    return NextResponse.json({ error: "Assistant unavailable" }, { status: 500 });
   }
 
   const clientId = getClientIdentifier(request);
@@ -46,36 +90,106 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
   }
 
-  const { messages } = parseResult.data;
+  const { messages, locale, language } = parseResult.data;
+  const localeHint = sanitizeLocale(locale);
+  const visitorLanguage = language ?? inferConversationLanguage(messages, localeHint);
+  const systemPrompt = buildSystemPrompt(localeHint, visitorLanguage);
+  const openAiMessages = [
+    {
+      role: "system" as const,
+      content: [{ type: "input_text" as const, text: systemPrompt }],
+    },
+    ...messages.map(({ role, content }) => ({
+      role,
+      content: [
+        {
+          type: (role === "assistant" ? "output_text" : "input_text") as const,
+          text: content,
+        },
+      ],
+    })),
+  ];
 
   try {
-    const response = await fetch("https://api.transformai.ai/assistant", {
+    const response = await fetch("https://api.openai.com/v1/responses", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
+        Authorization: `Bearer ${openAiKey}`,
       },
-      body: JSON.stringify({ messages }),
+      body: JSON.stringify({
+        model: "gpt-5-mini",
+        input: openAiMessages,
+        max_output_tokens: OUTPUT_TOKEN_LIMIT,
+        response_format: {
+          type: "json_schema",
+          json_schema: {
+            name: "transformai_chat_response",
+            schema: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                reply: { type: "string", description: "Primary reply shown to the visitor." },
+                language: {
+                  type: "string",
+                  enum: ["en", "nl"],
+                  description: "Language code (en or nl) matching the visitor's preference.",
+                },
+                redirect: {
+                  type: "object",
+                  additionalProperties: false,
+                  required: ["url", "label", "confirm"],
+                  properties: {
+                    url: {
+                      type: "string",
+                      description: "Absolute or locale-prefixed path to redirect the visitor to.",
+                    },
+                    label: {
+                      type: "string",
+                      description: "Label for the redirect confirmation button in the visitor's language.",
+                    },
+                    confirm: {
+                      type: "string",
+                      description: "Question asking if the visitor would like to be redirected now.",
+                    },
+                  },
+                },
+              },
+              required: ["reply"],
+            },
+          },
+        },
+      }),
       cache: "no-store",
     });
 
     if (response.ok) {
-      const data = (await response.json().catch(() => ({}))) as { message?: string; choices?: Array<{ message?: { content?: string } }>; };
-      const modelMessage = getMessageFromResponse(data);
+      const data = (await response.json().catch(() => ({}))) as OpenAIResponse;
+      const modelMessage = getAssistantPayload(data);
       if (modelMessage) {
-        return NextResponse.json({ message: modelMessage });
+        return NextResponse.json({
+          reply: modelMessage.reply,
+          language: modelMessage.language ?? visitorLanguage,
+          redirect: modelMessage.redirect ?? null,
+        });
       }
     } else {
-      const errorResponse = await response.json().catch(() => null);
-      const reason = typeof errorResponse?.error === "string" ? errorResponse.error : response.statusText;
-      console.error("Assistant upstream responded with error", reason);
+      const errorResponse = (await response.json().catch(() => null)) as OpenAIResponse | null;
+      const reason =
+        typeof errorResponse?.error?.message === "string"
+          ? errorResponse.error.message
+          : response.statusText;
+      console.error("OpenAI response API returned an error", reason, {
+        code: errorResponse?.error?.code,
+        type: errorResponse?.error?.type,
+      });
     }
   } catch (error) {
-    console.error("Assistant upstream request failed", error);
+    console.error("OpenAI response API request failed", error);
   }
 
-  const fallback = buildFallbackMessage(messages);
-  return NextResponse.json({ message: fallback });
+  const fallback = buildFallbackMessage(messages, localeHint, visitorLanguage);
+  return NextResponse.json({ reply: fallback.reply, language: fallback.language, redirect: null });
 }
 
 function consumeToken(identifier: string) {
@@ -115,24 +229,180 @@ function getClientIdentifier(request: NextRequest) {
   return "anonymous";
 }
 
-function getMessageFromResponse(data: {
-  message?: string;
-  choices?: Array<{ message?: { content?: string } }>;
-}) {
-  if (data?.message && typeof data.message === "string") {
-    return data.message.trim();
+function getAssistantPayload(data: OpenAIResponse) {
+  if (!data?.output?.length) {
+    return null;
   }
-  const choice = data?.choices?.[0]?.message?.content;
-  if (typeof choice === "string") {
-    return choice.trim();
+
+  for (const block of data.output) {
+    if (!block || block.type !== "message" || block.role !== "assistant" || !block.content?.length) {
+      continue;
+    }
+
+    const text = block.content
+      .map((entry) => (entry?.type === "output_text" && typeof entry.text === "string" ? entry.text : ""))
+      .filter(Boolean)
+      .join("")
+      .trim();
+
+    if (!text) {
+      continue;
+    }
+
+    const parsed = safeParseAssistantPayload(text);
+    if (parsed) {
+      return parsed;
+    }
   }
-  return "";
+
+  return null;
 }
 
-function buildFallbackMessage(messages: ConversationMessage[]) {
+function sanitizeLocale(locale?: string | null) {
+  if (!locale) {
+    return undefined;
+  }
+  const trimmed = locale.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const normalized = trimmed.toLowerCase().replace(/[^a-z0-9-]/g, "");
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized.slice(0, 16);
+}
+
+function buildSystemPrompt(locale: string | undefined, visitorLanguage: "en" | "nl") {
+  const normalizedLocale = locale ?? "en";
+  const localeInstruction = locale
+    ? `Use relative URLs with the ${normalizedLocale} locale segment (for example, /${normalizedLocale}/about).`
+    : "Use English URLs (starting with /en/...) unless the visitor requests Dutch; if you are unsure, ask which language they prefer.";
+  const languageInstruction = visitorLanguage === "nl"
+    ? "Respond in Dutch unless the visitor explicitly asks for English."
+    : "Respond in English unless the visitor explicitly switches to Dutch.";
+
+  return [
+    "You are the TransformAI Assistant, the friendly but direct concierge for TransformAI's marketing site.",
+    "You only answer questions about TransformAI's services, platform, team, and resources. If someone asks about anything else, politely explain that you can only discuss TransformAI.",
+    "",
+    `VisitorLanguage=${visitorLanguage}. Mirror this language unless the visitor clearly switches.`,
+    "Background:",
+    "- TransformAI is an AI transformation partner based in Amsterdam, Netherlands. The company was founded in 2025 and rebranded from StaccatoAI to reflect its move from building standalone products to guiding full-scale AI transformations.",
+    "- We work as a long-term partner rather than a short-term consultant. Every engagement is co-created with the client's teams so AI becomes embedded across the organisation, whether they are just starting or scaling advanced automation.",
+    "- The homepage highlights more than 100,000 hours saved for partners, showcases active projects and partner logos, and gives direct ways to chat, contact us, or schedule time.",
+    "- A TransformAI platform (a central operating system for assistants, workflows, and guardrails) is in private beta. Visitors can request access via the analytics section on the homepage.",
+    "",
+    "Offerings you can reference:",
+    "- Education modules on the pricing page: the Basic education module (€800 per 2-hour in-person session) builds AI confidence across roles, and the Advanced education module (€1,100 per 2-hour workshop) co-develops new AI products with experienced teams.",
+    "- AISEO package (AIEO) beta to improve visibility inside AI-powered discovery channels.",
+    "- AI Situation Overview (€799 for a two-hour strategy sprint) benchmarks a company's AI readiness and delivers next-step recommendations.",
+    "- Transformation programmes (Foundation, Integrated, Intrinsic) described on the pricing page cover everything from the first AI steps to fully integrated company-wide adoption.",
+    "- Case studies and research—including the education platform, HR researcher, email responder, and automation playbooks—are published in the blog and highlighted projects.",
+    "",
+    "Key resources to guide visitors:",
+    `- Home: /${normalizedLocale} for the overall story, hours-saved ticker, and partner highlights.`,
+    `- About: /${normalizedLocale}/about for the founder story, team bios (showing 10× productivity vs. AI-enabled peers and 52× vs. non-AI roles), values, and FAQs.`,
+    `- Blog: /${normalizedLocale}/blog for articles, research, and case studies about TransformAI's work.`,
+    `- Pricing & solutions: /${normalizedLocale}/pricing for solution overviews, package comparisons, and education modules.`,
+    `- Contact: /${normalizedLocale}/contact for the contact form (TransformAI replies within two business days) with request types for general questions, solution inquiries, AI help, or other topics, plus the direct email info@transformai.nl.`,
+    `- Meeting scheduler: /${normalizedLocale}/meeting to reserve time with the team—bookings go straight to leadership.`,
+    `- Platform beta request form: available from the analytics section on the homepage.`,
+    `- Partner account sign-up: /${normalizedLocale}/create-account (access is limited to TransformAI partners).`,
+    "",
+    "Meeting support:",
+    "- Offer to help schedule meetings proactively. Collect the person's name, company, email, focus areas, and timing preferences.",
+    `- When they are ready, share the meeting link (/${normalizedLocale}/meeting) and summarise what they should submit.`,
+    "",
+    "Redirect support:",
+    "- When recommending a page, include a redirect suggestion so the visitor can jump straight there.",
+    "- Ask for confirmation first (for example: 'Should I redirect you to the pricing page now?').",
+    `- Provide the locale-aware URL in the redirect object (for example, /${normalizedLocale}/pricing).`,
+    "",
+    "Communication rules:",
+    `- ${languageInstruction}`,
+    `- ${localeInstruction}`,
+    "- Be friendly, clear, and straightforward. Provide direct answers without unnecessary padding.",
+    "- Whenever helpful, point people to the exact page, blog post, or service so they know where to continue.",
+    "- If you do not have the information someone wants, explain the limitation and recommend the best next step (contact form, meeting, or email).",
+    "- Stay strictly within TransformAI's domain; acknowledge the question and decline if it falls outside TransformAI.",
+    "",
+    "Response contract:",
+    "- Return valid JSON that matches the transformai_chat_response schema (reply, optional language, optional redirect).",
+    "- Put the full conversational answer inside reply. Do not include Markdown backticks or extra commentary outside the JSON body.",
+    "- If offering a redirect, ensure the confirm string invites the visitor to opt-in explicitly.",
+  ].join("\n");
+}
+
+function buildFallbackMessage(
+  messages: ConversationMessage[],
+  locale: string | undefined,
+  visitorLanguage: "en" | "nl",
+) {
+  const lastUserMessage = [...messages].reverse().find((message) => message.role === "user");
+  const isDutch = visitorLanguage === "nl" || locale?.startsWith("nl");
+  if (isDutch) {
+    const followUp = "Ons team reageert binnen twee werkdagen.";
+    if (!lastUserMessage) {
+      return { reply: `Bedankt voor je bericht aan TransformAI. ${followUp}`, language: "nl" as const };
+    }
+    return {
+      reply: `Bedankt voor je vraag over "${lastUserMessage.content}". ${followUp}`,
+      language: "nl" as const,
+    };
+  }
+
+  const followUp = "Our team will follow up within two business days.";
+  if (!lastUserMessage) {
+    return { reply: `Thanks for reaching out to TransformAI. ${followUp}`, language: "en" as const };
+  }
+  return {
+    reply: `Thanks for your question about "${lastUserMessage.content}". ${followUp}`,
+    language: "en" as const,
+  };
+}
+
+function safeParseAssistantPayload(raw: string) {
+  try {
+    const parsed = JSON.parse(raw);
+    const result = assistantResponseSchema.safeParse(parsed);
+    if (result.success) {
+      return result.data;
+    }
+  } catch (error) {
+    console.error("Failed to parse assistant payload", error);
+  }
+  return null;
+}
+
+function inferConversationLanguage(messages: ConversationMessage[], locale?: string | null): "en" | "nl" {
+  if (locale?.startsWith("nl")) {
+    return "nl";
+  }
+
   const lastUserMessage = [...messages].reverse().find((message) => message.role === "user");
   if (!lastUserMessage) {
-    return "Thanks for reaching out to TransformAI. We'll reply with tailored guidance shortly.";
+    return "en";
   }
-  return `Thanks for your question about "${lastUserMessage.content}". A TransformAI strategist will follow up with tailored guidance shortly.`;
+
+  const text = lastUserMessage.content.toLowerCase();
+  const dutchPatterns = [
+    /\bde\b/,
+    /\bhet\b/,
+    /\ben\b/,
+    /\bhoe\b/,
+    /\bwaarom\b/,
+    /\bdank/,
+    /\bmet\b/,
+    /\bvoor\b/,
+    /\bkun\w*/,
+    /\bbedrijf\b/,
+    /\bafspraak\b/,
+    /\bspreek\b/,
+  ];
+  const matches = dutchPatterns.reduce((total, pattern) => total + (pattern.test(text) ? 1 : 0), 0);
+  if (matches >= 2 || /[äëïöüáéíóú]/.test(text) || text.includes("ij")) {
+    return "nl";
+  }
+  return "en";
 }

--- a/apps/www/components/ask/ChatPanel.tsx
+++ b/apps/www/components/ask/ChatPanel.tsx
@@ -3,6 +3,7 @@
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { AlertTriangle, Loader2, Send, Sparkles, X } from "lucide-react";
+import { useRouter } from "next/navigation";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
   type MutableRefObject,
@@ -13,7 +14,7 @@ import {
   useRef,
   useState,
 } from "react";
-import type { ChatLocale, ChatMessage } from "./types";
+import type { ChatAction, ChatLocale, ChatMessage } from "./types";
 
 export type ChatPanelProps = {
   messages: ChatMessage[];
@@ -342,6 +343,9 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({ message, locale }) => {
           <p className="text-xs font-medium uppercase tracking-[0.08em] text-white/60">{locale.assistantLabel}</p>
           <div className="mt-2 w-full rounded-2xl border border-white/10 bg-neutral-900/90 p-4 text-sm leading-relaxed text-white/90 shadow-[0_25px_60px_rgba(30,64,175,0.25)]">
             <p className="whitespace-pre-wrap text-left">{message.content}</p>
+            {message.action && message.action.type === "redirect" ? (
+              <RedirectAction action={message.action} />
+            ) : null}
           </div>
         </div>
       </div>
@@ -356,6 +360,62 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({ message, locale }) => {
           {message.content}
         </div>
       </div>
+    </div>
+  );
+};
+
+type RedirectActionProps = {
+  action: Extract<ChatAction, { type: "redirect" }>;
+};
+
+const RedirectAction: React.FC<RedirectActionProps> = ({ action }) => {
+  const router = useRouter();
+  const [isNavigating, setIsNavigating] = useState(false);
+
+  const handleRedirect = useCallback(() => {
+    if (isNavigating) {
+      return;
+    }
+    const target = action.url.trim();
+    if (!target) {
+      return;
+    }
+
+    const isSupported = target.startsWith("/") || /^https?:\/\//i.test(target);
+    if (!isSupported) {
+      console.error("Unsupported redirect URL", target);
+      return;
+    }
+
+    setIsNavigating(true);
+
+    try {
+      if (target.startsWith("http://") || target.startsWith("https://")) {
+        window.location.href = target;
+        return;
+      }
+      router.push(target);
+      window.setTimeout(() => {
+        setIsNavigating(false);
+      }, 1200);
+    } catch (error) {
+      console.error("Failed to redirect visitor", error);
+      setIsNavigating(false);
+    }
+  }, [action.url, isNavigating, router]);
+
+  return (
+    <div className="mt-4 space-y-3 rounded-2xl border border-white/10 bg-white/5 p-3">
+      <p className="text-sm leading-relaxed text-white/80">{action.confirm}</p>
+      <button
+        type="button"
+        onClick={handleRedirect}
+        disabled={isNavigating}
+        className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-white/10 bg-gradient-to-r from-teal-400 via-sky-500 to-purple-500 px-4 py-2 text-sm font-semibold text-white transition hover:shadow-[0_0_30px_rgba(56,189,248,0.35)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950 disabled:cursor-not-allowed disabled:opacity-70"
+      >
+        {isNavigating ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : null}
+        <span>{action.label}</span>
+      </button>
     </div>
   );
 };

--- a/apps/www/components/ask/PricingChat.tsx
+++ b/apps/www/components/ask/PricingChat.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
@@ -22,6 +22,7 @@ type PricingChatProps = {
 
 export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChange }) => {
   const t = useTranslations("Pricing.Chat");
+  const localeCode = useLocale();
   const locale = useMemo<ChatLocale>(
     () => ({
       ctaLabel: t("cta.label"),
@@ -57,6 +58,9 @@ export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChang
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
+  const [visitorLanguage, setVisitorLanguage] = useState<"en" | "nl">(
+    localeCode === "nl" ? "nl" : "en",
+  );
   const buttonRef = useRef<HTMLButtonElement>(null);
   const hasOpenedRef = useRef(false);
 
@@ -113,6 +117,8 @@ export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChang
           },
           body: JSON.stringify({
             messages: conversation.map(({ role, content }) => ({ role, content })),
+            locale: localeCode,
+            language: visitorLanguage,
           }),
         });
 
@@ -122,12 +128,36 @@ export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChang
           throw new Error(message);
         }
 
-        const data = (await response.json().catch(() => ({}))) as { message?: string };
-        const assistantText = typeof data.message === "string" ? data.message.trim() : "";
+        const data = (await response.json().catch(() => ({}))) as {
+          reply?: string;
+          language?: "en" | "nl";
+          redirect?: {
+            url?: string;
+            label?: string;
+            confirm?: string;
+          } | null;
+        };
+        const assistantText = typeof data.reply === "string" ? data.reply.trim() : "";
 
         if (!assistantText) {
           throw new Error("Empty assistant response");
         }
+
+        const assistantLanguage = data.language === "nl" ? "nl" : data.language === "en" ? "en" : undefined;
+        const nextLanguage = assistantLanguage ?? visitorLanguage;
+        setVisitorLanguage(nextLanguage);
+
+        const redirect = data.redirect && typeof data.redirect === "object"
+          ? {
+              type: "redirect" as const,
+              url: typeof data.redirect.url === "string" ? data.redirect.url.trim() : "",
+              label: typeof data.redirect.label === "string" ? data.redirect.label.trim() : "",
+              confirm: typeof data.redirect.confirm === "string" ? data.redirect.confirm.trim() : "",
+            }
+          : null;
+
+        const action =
+          redirect && redirect.url && redirect.label && redirect.confirm ? redirect : null;
 
         setMessages((prev) => [
           ...prev,
@@ -135,6 +165,8 @@ export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChang
             id: crypto.randomUUID(),
             role: "assistant",
             content: assistantText,
+            action,
+            language: nextLanguage,
           },
         ]);
         setPendingPrompt(null);
@@ -145,7 +177,7 @@ export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChang
         setIsLoading(false);
       }
     },
-    [locale.errorBody],
+    [locale.errorBody, localeCode, visitorLanguage],
   );
 
   const openChat = useCallback(() => {
@@ -176,13 +208,19 @@ export const PricingChat: React.FC<PricingChatProps> = ({ className, onOpenChang
         id: crypto.randomUUID(),
         role: "user",
         content: trimmed,
+        action: null,
+        language: visitorLanguage,
       };
 
+      let nextMessages: ChatMessage[] | null = null;
       setMessages((prev) => {
-        const next = [...prev, userMessage];
-        void sendToAssistant(next, trimmed);
-        return next;
+        nextMessages = [...prev, userMessage];
+        return nextMessages;
       });
+
+      if (nextMessages) {
+        void sendToAssistant(nextMessages, trimmed);
+      }
     },
     [sendToAssistant],
   );

--- a/apps/www/components/ask/StickyChat.tsx
+++ b/apps/www/components/ask/StickyChat.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import {
   type CSSProperties,
   useCallback,
@@ -34,6 +34,7 @@ type StickyChatProps = {
 
 export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, boundaryId }) => {
   const t = useTranslations("CodeExamples.chat");
+  const localeCode = useLocale();
   const locale = useMemo<ChatLocale>(
     () => ({
       ctaLabel: t("cta.label"),
@@ -70,6 +71,9 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
+  const [visitorLanguage, setVisitorLanguage] = useState<"en" | "nl">(
+    localeCode === "nl" ? "nl" : "en",
+  );
   const [isDesktop, setIsDesktop] = useState(false);
   const [hasReachedTrigger, setHasReachedTrigger] = useState(false);
   const [hasReachedBoundary, setHasReachedBoundary] = useState(false);
@@ -472,6 +476,8 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
           },
           body: JSON.stringify({
             messages: conversation.map(({ role, content }) => ({ role, content })),
+            locale: localeCode,
+            language: visitorLanguage,
           }),
         });
 
@@ -481,12 +487,36 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
           throw new Error(message);
         }
 
-        const data = (await response.json().catch(() => ({}))) as { message?: string };
-        const assistantText = typeof data.message === "string" ? data.message.trim() : "";
+        const data = (await response.json().catch(() => ({}))) as {
+          reply?: string;
+          language?: "en" | "nl";
+          redirect?: {
+            url?: string;
+            label?: string;
+            confirm?: string;
+          } | null;
+        };
+        const assistantText = typeof data.reply === "string" ? data.reply.trim() : "";
 
         if (!assistantText) {
           throw new Error("Empty assistant response");
         }
+
+        const assistantLanguage = data.language === "nl" ? "nl" : data.language === "en" ? "en" : undefined;
+        const nextLanguage = assistantLanguage ?? visitorLanguage;
+        setVisitorLanguage(nextLanguage);
+
+        const redirect = data.redirect && typeof data.redirect === "object"
+          ? {
+              type: "redirect" as const,
+              url: typeof data.redirect.url === "string" ? data.redirect.url.trim() : "",
+              label: typeof data.redirect.label === "string" ? data.redirect.label.trim() : "",
+              confirm: typeof data.redirect.confirm === "string" ? data.redirect.confirm.trim() : "",
+            }
+          : null;
+
+        const action =
+          redirect && redirect.url && redirect.label && redirect.confirm ? redirect : null;
 
         setMessages((prev) => [
           ...prev,
@@ -494,6 +524,8 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
             id: crypto.randomUUID(),
             role: "assistant",
             content: assistantText,
+            action,
+            language: nextLanguage,
           },
         ]);
         setPendingPrompt(null);
@@ -504,7 +536,7 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
         setIsLoading(false);
       }
     },
-    [locale.errorBody],
+    [locale.errorBody, localeCode, visitorLanguage],
   );
 
   const handleSend = useCallback(
@@ -518,13 +550,19 @@ export const StickyChat: React.FC<StickyChatProps> = ({ className, triggerId, bo
         id: crypto.randomUUID(),
         role: "user",
         content: trimmed,
+        action: null,
+        language: visitorLanguage,
       };
 
+      let nextMessages: ChatMessage[] | null = null;
       setMessages((prev) => {
-        const next = [...prev, userMessage];
-        void sendToAssistant(next, trimmed);
-        return next;
+        nextMessages = [...prev, userMessage];
+        return nextMessages;
       });
+
+      if (nextMessages) {
+        void sendToAssistant(nextMessages, trimmed);
+      }
     },
     [sendToAssistant],
   );

--- a/apps/www/components/ask/types.ts
+++ b/apps/www/components/ask/types.ts
@@ -1,9 +1,19 @@
 export type ChatRole = "user" | "assistant";
 
+export type ChatAction =
+  | {
+      type: "redirect";
+      url: string;
+      label: string;
+      confirm: string;
+    };
+
 export type ChatMessage = {
   id: string;
   role: ChatRole;
   content: string;
+  action?: ChatAction | null;
+  language?: "en" | "nl";
 };
 
 export type ChatLocale = {


### PR DESCRIPTION
## Summary
- expand the assistant system brief with visitor-language context, redirect guidance, and a 4K token ceiling while enforcing a JSON response contract
- surface locale-aware redirect actions and language hints from the API so chat widgets can render confirmation buttons and keep track of the active language
- log the fix for the new redirect workflow in WRITE_HERE/FIXES for continuity

## Plan
- teach the assistant API to accept a language hint, infer the visitor’s locale, and parse structured JSON responses with optional redirect metadata
- raise the max output tokens, enrich the system prompt with redirect instructions, and add schema validation for replies
- update chat components to track language state, display redirect CTAs, and record the change in WRITE_HERE/FIXES

## Testing
- `pnpm --filter www run typecheck` *(fails: repository lacks optional dependencies such as next-intl and drizzle-orm in this environment)*
- `pnpm --filter www run lint` *(fails: next lint cannot resolve next-intl in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690a10e976b4832a85ecdc45d00b5750