### PR TITLE
Gate auth flows with client code entry and refresh chatbot prompts

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-04T2209--client-code-gate.md
+++ b/WRITE_HERE/UPDATES/2025-11-04T2209--client-code-gate.md
@@ -1,0 +1,6 @@
+# Added client access gate for auth
+
+- **What:** Introduced a reusable client-code gate before the sign-up and sign-in forms, wired translations for the new flow, and refreshed the assistant prompt suggestions in EN/NL.
+- **Why:** Requested to require client code "Cake2025" ahead of account access and update chatbot starter copy.
+- **Files:** Auth pages/components, EN/NL message catalogs.
+- **Follow-ups:** None.

--- a/apps/www/app/[locale]/(site)/create-account/page.tsx
+++ b/apps/www/app/[locale]/(site)/create-account/page.tsx
@@ -1,4 +1,5 @@
 import { SignUpForm } from "@/components/auth/sign-up-form";
+import { ClientAccessGate } from "@/components/auth/client-access-gate";
 import { getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
 
@@ -25,7 +26,9 @@ export default function CreateAccountPage() {
         className="pointer-events-none absolute inset-x-0 top-[-320px] h-[640px] bg-gradient-to-b from-sky-400/20 via-transparent to-transparent blur-3xl"
       />
       <div className="container relative z-10 max-w-2xl">
-        <SignUpForm />
+        <ClientAccessGate variant="signUp">
+          <SignUpForm />
+        </ClientAccessGate>
       </div>
     </div>
   );

--- a/apps/www/app/[locale]/(site)/sign-in/page.tsx
+++ b/apps/www/app/[locale]/(site)/sign-in/page.tsx
@@ -1,4 +1,5 @@
 import { SignInForm } from "@/components/auth/sign-in-form";
+import { ClientAccessGate } from "@/components/auth/client-access-gate";
 import { getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
 
@@ -25,7 +26,9 @@ export default function SignInPage() {
         className="pointer-events-none absolute inset-x-0 top-[-320px] h-[640px] bg-gradient-to-b from-indigo-500/25 via-transparent to-transparent blur-3xl"
       />
       <div className="container relative z-10 max-w-2xl">
-        <SignInForm />
+        <ClientAccessGate variant="signIn">
+          <SignInForm />
+        </ClientAccessGate>
       </div>
     </div>
   );

--- a/apps/www/components/auth/client-access-gate.tsx
+++ b/apps/www/components/auth/client-access-gate.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import type { ReactNode, FormEvent } from "react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const CLIENT_CODE = "Cake2025";
+
+type Variant = "signUp" | "signIn";
+
+interface ClientAccessGateProps {
+  children: ReactNode;
+  variant: Variant;
+}
+
+export function ClientAccessGate({ children, variant }: ClientAccessGateProps) {
+  const t = useTranslations(variant === "signUp" ? "Auth.SignUp" : "Auth.SignIn");
+  const [codeInput, setCodeInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [hasAccess, setHasAccess] = useState(false);
+  const cardShadow =
+    variant === "signUp"
+      ? "shadow-[0_40px_120px_-60px_rgba(96,165,250,0.45)]"
+      : "shadow-[0_40px_120px_-60px_rgba(129,140,248,0.45)]";
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = codeInput.trim();
+
+    if (trimmed === CLIENT_CODE) {
+      setHasAccess(true);
+      setError(null);
+      return;
+    }
+
+    setError(t("clientGate.error"));
+  };
+
+  if (hasAccess) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2 text-center">
+        <p className="text-xs font-semibold uppercase tracking-[0.32em] text-white/60">
+          {t("clientGate.eyebrow")}
+        </p>
+        <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+          {t("clientGate.title")}
+        </h1>
+        <p className="text-sm text-white/60">{t("clientGate.description")}</p>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className={`space-y-5 rounded-2xl border border-white/10 bg-black/40 p-8 ${cardShadow} backdrop-blur-xl`}
+      >
+        <div className="space-y-2">
+          <Label htmlFor="client-code" className="text-white/80">
+            {t("clientGate.label")}
+          </Label>
+          <Input
+            id="client-code"
+            type="password"
+            value={codeInput}
+            onChange={(event) => {
+              setCodeInput(event.target.value);
+              if (error) {
+                setError(null);
+              }
+            }}
+            placeholder={t("clientGate.placeholder")}
+            autoComplete="one-time-code"
+            className="border-white/10 bg-white/5 text-white placeholder:text-white/40 focus-visible:ring-white/40"
+          />
+        </div>
+
+        {error ? <p className="text-sm text-red-400">{error}</p> : null}
+
+        <Button type="submit" className="w-full bg-white text-black hover:bg-white/90">
+          {t("clientGate.submit")}
+        </Button>
+        <p className="text-xs text-white/50">{t("clientGate.hint")}</p>
+      </form>
+    </div>
+  );
+}

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -912,12 +912,12 @@
         "send": "Send"
       },
       "empty": {
-        "title": "How we can help…",
+        "title": "Common questions",
         "prompts": [
-          "What AI transformation services does TransformAI offer for mid-sized companies?",
-          "How do I schedule a free introduction call?",
-          "Can you compare the Education and Introduction packages?",
-          "How does TransformAI ensure AI adoption stays compliant?"
+          "What is TransformAI?",
+          "Which solutions does TransformAI provide?",
+          "Where can I get in touch?",
+          "How can you type so fast?"
         ],
         "action": "Ask this question"
       },
@@ -1387,6 +1387,16 @@
       "eyebrow": "Members",
       "title": "Create your TransformAI account",
       "subtitle": "Unlock tailored AI news and staff dashboards.",
+      "clientGate": {
+        "eyebrow": "Members",
+        "title": "Enter your client access code",
+        "description": "Only TransformAI clients can create an account. Enter the shared code to continue.",
+        "label": "Client access code",
+        "placeholder": "Enter the code from TransformAI",
+        "submit": "Continue to create account",
+        "hint": "Need access? Contact your TransformAI consultant to request the latest client code.",
+        "error": "That client code doesn't match. Try again."
+      },
       "staffButton": "Client",
       "staffModeOn": "Staff mode",
       "staffDialog": {
@@ -1429,6 +1439,16 @@
       "eyebrow": "Members",
       "title": "Welcome back",
       "subtitle": "Pick up where you left off with tailored updates.",
+      "clientGate": {
+        "eyebrow": "Members",
+        "title": "Confirm your client access",
+        "description": "Enter the TransformAI client code to continue to the sign-in page.",
+        "label": "Client access code",
+        "placeholder": "Enter the code from TransformAI",
+        "submit": "Continue to sign in",
+        "hint": "Need the code? Reach out to your TransformAI point of contact.",
+        "error": "That client code doesn't match. Try again."
+      },
       "googleCta": "Sign in with Google",
       "or": "or continue with email",
       "emailLabel": "Email address",

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -869,12 +869,12 @@
         "send": "Versturen"
       },
       "empty": {
-        "title": "Waarmee kunnen we helpen…",
+        "title": "basis vragen",
         "prompts": [
-          "Welke AI-transformatiediensten biedt TransformAI voor middelgrote bedrijven?",
-          "Hoe plan ik een gratis kennismakingsgesprek?",
-          "Kun je het verschil uitleggen tussen het Education- en het Introduction-pakket?",
-          "Hoe zorgt TransformAI ervoor dat AI-adoptie compliant blijft?"
+          "Wat is TransformAI?",
+          "Welke oplossingen biedt TransformAI aan?",
+          "Waar kan ik contact opnemen?",
+          "Hoe kan jij zo snel typen?"
         ],
         "action": "Stel deze vraag"
       },
@@ -1344,6 +1344,16 @@
       "eyebrow": "Leden",
       "title": "Maak je TransformAI-account",
       "subtitle": "Ontvang exclusieve AI-updates en toegang tot het teamdashboard.",
+      "clientGate": {
+        "eyebrow": "Leden",
+        "title": "Voer je klantcode in",
+        "description": "Alleen TransformAI-klanten kunnen een account aanmaken. Vul de gedeelde klantcode in om door te gaan.",
+        "label": "Klantcode",
+        "placeholder": "Voer de code van TransformAI in",
+        "submit": "Ga verder naar account aanmaken",
+        "hint": "Hulp nodig? Neem contact op met je TransformAI-consultant voor de actuele klantcode.",
+        "error": "Die klantcode klopt niet. Probeer het opnieuw."
+      },
       "staffButton": "Client",
       "staffModeOn": "Staff-modus",
       "staffDialog": {
@@ -1386,6 +1396,16 @@
       "eyebrow": "Leden",
       "title": "Welkom terug",
       "subtitle": "Ga verder met je persoonlijke AI-updates.",
+      "clientGate": {
+        "eyebrow": "Leden",
+        "title": "Bevestig je klanttoegang",
+        "description": "Vul de TransformAI-klantcode in om door te gaan naar de inlogpagina.",
+        "label": "Klantcode",
+        "placeholder": "Voer de code van TransformAI in",
+        "submit": "Ga verder naar inloggen",
+        "hint": "Code kwijt? Neem contact op met je TransformAI-contactpersoon.",
+        "error": "Die klantcode klopt niet. Probeer het opnieuw."
+      },
       "googleCta": "Log in met Google",
       "or": "of ga verder met e-mail",
       "emailLabel": "E-mailadres",


### PR DESCRIPTION
## Summary
- add a reusable client access gate that requires the Cake2025 code before rendering the sign-up and sign-in forms
- localize the new gate copy for English and Dutch and document the change in the updates log
- refresh the assistant starter prompts in both locales to the requested common questions

## Plan
- introduce a client access gate component and wrap both auth pages with it
- extend the English and Dutch auth message catalogs with gate copy for sign-up and sign-in
- update chatbot prompt seeds in both locales and log the change in WRITE_HERE/UPDATES

## Testing
- ⚠️ `pnpm --filter www run lint` *(fails: next-intl package not found during lint configuration load in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690a78df4cc4832a92fae2a8a6f8d4f1