### PR TITLE
Fix Dutch oplossingen subtitle contact wording

### DIFF
--- a/WRITE_HERE/UPDATES/2025-12-03T1300--oplossingen-subtitle-copy-fix.md
+++ b/WRITE_HERE/UPDATES/2025-12-03T1300--oplossingen-subtitle-copy-fix.md
@@ -1,0 +1,6 @@
+# Oplossingen subtitle copy fix
+
+- **What:** Corrected the Dutch pricing header subtitle to use "contacteer ons" while keeping the call-to-action markup intact.
+- **Why:** Align the oplossingen page copy with the requested wording and fix a spelling mistake in the contact link.
+- **Files:** `apps/www/messages/nl.json`.
+- **Follow-ups:** None.

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -304,7 +304,7 @@
     "Header": {
       "eyebrow": "Maatwerk AI-oplossingen",
       "title": "Kies de AI-oplossing die bij u past",
-      "subtitle": "Elke oplossing wordt per bedrijf op maat gemaakt, zodat u uit elke oplossing maximale waarde haalt. Weet u niet welke oplossing bij u past? <contact>contacteren ons</contact> – dan zorgen wij voor de juiste match.",
+      "subtitle": "Elke oplossing wordt per bedrijf op maat gemaakt, zodat u uit elke oplossing maximale waarde haalt. Weet u niet welke oplossing bij u past? <contact>contacteer ons</contact> – dan zorgen wij voor de juiste match.",
       "highlights": {
         "speed": "AI-integraties van de hoogste kwaliteit",
         "support": "Begeleid door Nederlandstalige experts",


### PR DESCRIPTION
## Summary
- update the Dutch pricing header subtitle to use the corrected "contacteer ons" phrasing
- ensure the oplossingen subtitle keeps the requested contact CTA markup intact
- log the content tweak in the updates journal for traceability

## Plan
- adjust the Pricing.Header subtitle copy in `apps/www/messages/nl.json`
- review the oplossingen page rendering to confirm the CTA remains a button
- add an updates entry capturing the wording change and rationale
- verify no other locales require matching updates

## Testing
- not run (copy-only change)


------
https://chatgpt.com/codex/tasks/task_e_690b7a5c05c8832abb791b36059ee939