### PR TITLE
Refresh SEO metadata and localization flows

### DIFF
--- a/WRITE_HERE/UPDATES/2025-11-06T1432--seo-foundation-refresh.md
+++ b/WRITE_HERE/UPDATES/2025-11-06T1432--seo-foundation-refresh.md
@@ -1,0 +1,6 @@
+# SEO foundation refresh for localized pages
+
+- **What:** Updated localized metadata (title, description, Open Graph/Twitter) for English and Dutch, enforced canonical + hreflang structure with x-default to the language chooser, added organization JSON-LD, refreshed the language switcher to crawlable links, and aligned the sitemap/robots signals.
+- **Why:** Implemented the requested SEO fixes so search engines and social platforms understand the /en and /nl variants, consolidate signals on the correct URLs, and present richer snippets for TransformAI.
+- **Files:** `apps/www/app/[locale]/layout.tsx`, `apps/www/app/select-language/page.tsx`, `apps/www/app/sitemap.xml/route.ts`, `apps/www/components/language-switcher.tsx`, `apps/www/messages/en.json`, `apps/www/messages/nl.json`, `middleware.ts`.
+- **Follow-ups:** Validate the deployed robots.txt/sitemap endpoints in Search Console once live and localize any future metadata additions in both message catalogs.

--- a/apps/www/app/[locale]/layout.tsx
+++ b/apps/www/app/[locale]/layout.tsx
@@ -3,7 +3,7 @@ import { Navigation } from "@/components/navbar/navigation";
 import { CanonicalLink } from "@/components/seo/canonical-link";
 import { env } from "@/lib/env";
 import { loadMessages } from "@/i18n/messages";
-import { defaultLocale, isLocale, locales, type Locale } from "@/i18n/routing";
+import { isLocale, locales, type Locale } from "@/i18n/routing";
 import { ConsentManagerProvider } from "@c15t/nextjs";
 import { NextIntlClientProvider } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
@@ -41,7 +41,8 @@ export async function generateMetadata({
     locales.map((code) => [code, `/${code}`]),
   ) as Record<string, string>;
 
-  languageAlternates["x-default"] = `/${defaultLocale}`;
+  languageAlternates["x-default"] = "/";
+  const canonicalPath = `/${locale}`;
 
   return {
     metadataBase: baseUrl,
@@ -53,7 +54,7 @@ export async function generateMetadata({
     openGraph: {
       title: t("openGraph.title"),
       description: t("openGraph.description"),
-      url: `${baseUrl.origin}/${params.locale}`,
+      url: `${baseUrl.origin}${canonicalPath}`,
       siteName: t("openGraph.siteName"),
       images: [
         {
@@ -65,13 +66,14 @@ export async function generateMetadata({
     },
     twitter: {
       title: t("twitter.title"),
+      description: t("twitter.description"),
       card: "summary_large_image",
     },
     icons: {
       shortcut: "/images/logos/transformai/logosvg.svg",
     },
     alternates: {
-      canonical: locale === defaultLocale ? "/" : `/${locale}`,
+      canonical: canonicalPath,
       languages: languageAlternates,
     },
   };
@@ -94,10 +96,39 @@ export default async function LocaleLayout({
   setRequestLocale(locale);
 
   const messages = await loadMessages(locale);
+  const baseUrl = new URL(parsedEnv.NEXT_PUBLIC_BASE_URL);
+  const organizationStructuredData = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "TransformAI",
+    url: `${baseUrl.origin}/`,
+    logo: `${baseUrl.origin}/images/logos/transformai/logosvg.svg`,
+    sameAs: [
+      "https://www.linkedin.com/company/transformai",
+      "https://x.com/transformai",
+    ],
+    contactPoint: [
+      {
+        "@type": "ContactPoint",
+        contactType: "sales",
+        email: "info@transformai.nl",
+        availableLanguage: ["en", "nl"],
+      },
+    ],
+  } as const;
+  const organizationStructuredDataJson = JSON.stringify(
+    organizationStructuredData,
+  ).replace(/</g, "\\u003c");
 
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>
       <CanonicalLink />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: organizationStructuredDataJson,
+        }}
+      />
       <ConsentManagerProvider
         options={{
           ...(parsedEnv.NEXT_PUBLIC_C15T_MODE

--- a/apps/www/app/select-language/page.tsx
+++ b/apps/www/app/select-language/page.tsx
@@ -1,5 +1,5 @@
 import { TransformAILogo } from "@/components/footer/footer-svgs";
-import { type Locale, defaultLocale, isLocale } from "@/i18n/routing";
+import { type Locale, defaultLocale, isLocale, locales } from "@/i18n/routing";
 import { createTranslator } from "next-intl";
 import { cookies } from "next/headers";
 
@@ -26,6 +26,7 @@ export default async function SelectLanguagePage({
 
   const nextParam = searchParams?.next;
   const nextPath = Array.isArray(nextParam) ? nextParam[0] : nextParam ?? "";
+  const sanitizedNextPath = sanitizeNextPath(nextPath);
 
   const options: Array<LanguageOption> = [
     { locale: "en", label: t("english") },
@@ -61,14 +62,11 @@ export default async function SelectLanguagePage({
               <h1 className="text-balance text-3xl font-semibold tracking-tight text-white sm:text-4xl">
                 {t("selectTitle")}
               </h1>
-              <form action="/api/select-language" method="post" className="mt-4 grid w-full gap-4 text-left">
-                <input type="hidden" name="next" value={nextPath} />
+              <div className="mt-4 grid w-full gap-4 text-left">
                 {options.map(({ locale, label }) => (
-                  <button
+                  <a
                     key={locale}
-                    type="submit"
-                    name="locale"
-                    value={locale}
+                    href={buildLocaleHref(locale, sanitizedNextPath)}
                     className="group relative flex w-full items-center justify-between overflow-hidden rounded-2xl border border-white/15 bg-white/[0.04] px-6 py-4 text-base font-semibold text-white transition hover:border-white/25 hover:bg-white/[0.06] focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                   >
                     <span className="relative z-10">{label}</span>
@@ -81,13 +79,50 @@ export default async function SelectLanguagePage({
                     <span className="relative z-10 text-sm font-medium uppercase tracking-[0.2em] text-white/60">
                       {locale.toUpperCase()}
                     </span>
-                  </button>
+                  </a>
                 ))}
-              </form>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
   );
+}
+
+function sanitizeNextPath(path: string | null | undefined) {
+  if (!path) {
+    return null;
+  }
+
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+function buildLocaleHref(locale: Locale, nextPath: string | null) {
+  if (!nextPath || nextPath === "/") {
+    return `/${locale}`;
+  }
+
+  for (const candidate of locales) {
+    const prefix = `/${candidate}`;
+    if (nextPath === prefix) {
+      return `/${locale}`;
+    }
+
+    if (nextPath.startsWith(`${prefix}/`)) {
+      const remainder = nextPath.slice(prefix.length);
+      return remainder.length > 0 ? `/${locale}${remainder}` : `/${locale}`;
+    }
+  }
+
+  if (nextPath.startsWith("/")) {
+    return `/${locale}${nextPath}`;
+  }
+
+  return `/${locale}/${nextPath}`;
 }

--- a/apps/www/app/sitemap.xml/route.ts
+++ b/apps/www/app/sitemap.xml/route.ts
@@ -7,14 +7,12 @@ import path from "node:path";
 type SitemapRoute = {
   segments: string[];
   sourceFile: string;
-  xDefaultLocale?: Locale;
 };
 
 const localizedRoutes: SitemapRoute[] = [
   {
     segments: [],
     sourceFile: "apps/www/app/[locale]/(site)/page.tsx",
-    xDefaultLocale: "en",
   },
   {
     segments: ["about"],
@@ -71,10 +69,7 @@ export async function GET() {
         hreflang: altLocale,
         href: buildHref(origin, altLocale, route.segments),
       }));
-      const xDefaultLocale = route.xDefaultLocale ?? alternateLinks[0]?.hreflang;
-      const xDefaultHref = xDefaultLocale
-        ? buildHref(origin, xDefaultLocale, route.segments)
-        : currentHref;
+      const xDefaultHref = `${origin}/`;
 
       const hreflangLinks = [
         ...alternateLinks,

--- a/apps/www/components/language-switcher.tsx
+++ b/apps/www/components/language-switcher.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { usePathname, useRouter } from "@/i18n/navigation";
-import { locales } from "@/i18n/routing";
+import { Link, usePathname } from "@/i18n/navigation";
+import { locales, type Locale } from "@/i18n/routing";
 import { cn } from "@/lib/utils";
 import { useLocale, useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
@@ -11,7 +11,6 @@ type LanguageSwitcherProps = {
 };
 
 export function LanguageSwitcher({ className }: LanguageSwitcherProps) {
-  const router = useRouter();
   const pathname = usePathname();
   const locale = useLocale();
   const searchParams = useSearchParams();
@@ -26,33 +25,79 @@ export function LanguageSwitcher({ className }: LanguageSwitcherProps) {
     [languageT],
   );
 
-  const currentLabel = t("current", { language: languageNames[locale as keyof typeof languageNames] ?? locale });
+  const trimmedPathname = useMemo(() => {
+    if (!pathname) {
+      return "/";
+    }
+
+    if (pathname.length > 1 && pathname.endsWith("/")) {
+      return pathname.slice(0, -1);
+    }
+
+    return pathname;
+  }, [pathname]);
+
+  const localeStrippedPath = useMemo(() => {
+    return locales.reduce((currentPath, code) => {
+      const prefix = `/${code}`;
+      if (currentPath === prefix) {
+        return "/";
+      }
+
+      if (currentPath.startsWith(`${prefix}/`)) {
+        const sliced = currentPath.slice(prefix.length);
+        return sliced.length > 0 ? sliced : "/";
+      }
+
+      return currentPath;
+    }, trimmedPathname);
+  }, [trimmedPathname]);
+
+  const normalizedPathname = useMemo(() => {
+    if (localeStrippedPath.length > 1 && localeStrippedPath.endsWith("/")) {
+      return localeStrippedPath.slice(0, -1);
+    }
+
+    return localeStrippedPath || "/";
+  }, [localeStrippedPath]);
+
+  const search = searchParams.toString();
+
+  const buildHref = (code: Locale) => {
+    const basePath = normalizedPathname === "/" ? `/${code}` : `/${code}${normalizedPathname}`;
+
+    return search ? `${basePath}?${search}` : basePath;
+  };
 
   return (
-    <label className={cn("flex items-center gap-2 text-sm text-white/70", className)}>
+    <nav aria-label={t("label")} className={cn("flex items-center gap-2", className)}>
       <span className="sr-only">{t("label")}</span>
-      <select
-        aria-label={t("label")}
-        title={currentLabel}
-        value={locale}
-        onChange={(event) => {
-          const nextLocale = event.target.value;
-          if (nextLocale === locale) {
-            return;
-          }
+      <div className="flex overflow-hidden rounded-full border border-white/15 bg-white/[0.04] p-0.5">
+        {locales.map((code) => {
+          const isActive = code === locale;
+          const languageName = languageNames[code as keyof typeof languageNames] ?? code;
+          const href = buildHref(code);
+          const ariaLabel = isActive ? t("current", { language: languageName }) : languageName;
 
-          const search = searchParams.toString();
-          const destination = search ? `${pathname}?${search}` : pathname;
-          void router.replace(destination, { locale: nextLocale });
-        }}
-        className="h-8 rounded-md border border-white/20 bg-black/60 px-2 text-sm text-white/80 shadow-sm transition focus:border-white/40 focus:outline-none focus:ring-2 focus:ring-white/30"
-      >
-        {locales.map((code) => (
-          <option key={code} value={code} className="text-black">
-            {languageNames[code as keyof typeof languageNames] ?? code}
-          </option>
-        ))}
-      </select>
-    </label>
+          return (
+            <Link
+              key={code}
+              href={href}
+              aria-current={isActive ? "page" : undefined}
+              aria-label={ariaLabel}
+              className={cn(
+                "relative px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-white/70 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black",
+                isActive
+                  ? "bg-white text-black shadow-[0_0_22px_rgba(255,255,255,0.35)]"
+                  : "hover:bg-white/10 hover:text-white",
+              )}
+            >
+              <span aria-hidden>{code.toUpperCase()}</span>
+              <span className="sr-only">{languageName}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
   );
 }

--- a/apps/www/messages/en.json
+++ b/apps/www/messages/en.json
@@ -1,15 +1,16 @@
 {
   "Metadata": {
-    "title": "Unkey",
-    "titleTemplate": "%s | Unkey",
-    "description": "Your Transformation Partner for the Age of AI",
+    "title": "TransformAI — AI Integrations & Adoption for SMEs",
+    "titleTemplate": "%s — TransformAI",
+    "description": "We help companies integrate AI end-to-end—strategy, workflows, and governance—so teams get real productivity gains safely.",
     "openGraph": {
-      "title": "Unkey",
-      "description": "Your Transformation Partner for the Age of AI",
-      "siteName": "unkey.com"
+      "title": "TransformAI — AI Integrations & Adoption for SMEs",
+      "description": "We help companies integrate AI end-to-end—strategy, workflows, and governance—so teams get real productivity gains safely.",
+      "siteName": "TransformAI"
     },
     "twitter": {
-      "title": "Unkey"
+      "title": "TransformAI — AI Integrations & Adoption for SMEs",
+      "description": "We help companies integrate AI end-to-end—strategy, workflows, and governance—so teams get real productivity gains safely."
     }
   },
   "Navigation": {

--- a/apps/www/messages/nl.json
+++ b/apps/www/messages/nl.json
@@ -1,15 +1,16 @@
 {
   "Metadata": {
-    "title": "Unkey",
-    "titleTemplate": "%s | Unkey",
-    "description": "Jouw transformatiepartner voor het AI-tijdperk",
+    "title": "TransformAI — AI-integraties & adoptie voor het mkb",
+    "titleTemplate": "%s — TransformAI",
+    "description": "We helpen organisaties AI end-to-end te integreren—strategie, workflows en governance—zodat teams veilig echte productiviteitswinst boeken.",
     "openGraph": {
-      "title": "Unkey",
-      "description": "Jouw transformatiepartner voor het AI-tijdperk",
-      "siteName": "unkey.com"
+      "title": "TransformAI — AI-integraties & adoptie voor het mkb",
+      "description": "We helpen organisaties AI end-to-end te integreren—strategie, workflows en governance—zodat teams veilig echte productiviteitswinst boeken.",
+      "siteName": "TransformAI"
     },
     "twitter": {
-      "title": "Unkey"
+      "title": "TransformAI — AI-integraties & adoptie voor het mkb",
+      "description": "We helpen organisaties AI end-to-end te integreren—strategie, workflows en governance—zodat teams veilig echte productiviteitswinst boeken."
     }
   },
   "Navigation": {

--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,8 @@ const intlMiddleware = createMiddleware({
   localePrefix: "always",
 });
 
+const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
+
 export default function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const canonicalHost = "transformai.nl";
@@ -62,7 +64,22 @@ export default function middleware(request: NextRequest) {
     }
   }
 
-  return intlMiddleware(request);
+  const response = intlMiddleware(request);
+
+  const matchedLocale = locales.find((code) => {
+    return pathname === `/${code}` || pathname.startsWith(`/${code}/`);
+  });
+
+  if (matchedLocale) {
+    response.cookies.set("NEXT_LOCALE", matchedLocale, {
+      maxAge: ONE_YEAR_IN_SECONDS,
+      path: "/",
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+    });
+  }
+
+  return response;
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- replace the outdated Unkey metadata with TransformAI-specific titles, descriptions, and social previews for both English and Dutch locales
- adjust locale layouts to emit canonical URLs, hreflang maps with an x-default pointing to the language chooser, and embed basic organization JSON-LD
- update the language switcher, select-language landing page, and sitemap so crawlers can discover `/en` and `/nl` directly while preserving locale cookies

## Testing
- `pnpm --filter www run lint`
- `pnpm --filter www run typecheck` *(fails: existing ChatPanel dynamic import typings in components/ask)*

## Plan
- align locale metadata, canonical links, and social tags with the requested copy
- ensure language switching UX uses crawlable links and still records the visitor locale
- refresh sitemap/x-default handling and add organization structured data for clearer signals

------
https://chatgpt.com/codex/tasks/task_e_690caf5bae60832a9310143389018890